### PR TITLE
feat/keyvalue nats bucket policy

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -1278,8 +1278,20 @@ impl HostBuilder {
     /// registered plugin reports `supports_named_instances() == false` and a
     /// workload needing named multiplexing fails to bind.
     #[cfg(feature = "wasm_component_model_implements")]
-    pub fn with_multiplexed_plugins(mut self) -> anyhow::Result<Self> {
-        for plugin in crate::plugin::multiplexed_plugins() {
+    pub fn with_multiplexed_plugins(self) -> anyhow::Result<Self> {
+        self.with_multiplexed_plugins_with(&crate::plugin::MultiplexedDefaults::default())
+    }
+
+    /// [`Self::with_multiplexed_plugins`], with the settings a named interface
+    /// inherits unless its own `config` overrides them. Pass the embedder's
+    /// configuration here so it reaches `(implements ..)` imports and not only
+    /// the standard plugins.
+    #[cfg(feature = "wasm_component_model_implements")]
+    pub fn with_multiplexed_plugins_with(
+        mut self,
+        defaults: &crate::plugin::MultiplexedDefaults,
+    ) -> anyhow::Result<Self> {
+        for plugin in crate::plugin::multiplexed_plugins_with(defaults) {
             self = self.with_plugin(plugin)?;
         }
         Ok(self)

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -514,6 +514,41 @@ pub(crate) fn lock_root(root: impl AsRef<Path>, untrusted: &str) -> Result<PathB
 /// as `multiplex_only`, depends on the host's own configuration.
 #[cfg(feature = "wasm_component_model_implements")]
 pub fn multiplexed_plugins() -> Vec<std::sync::Arc<dyn HostPlugin>> {
+    multiplexed_plugins_with(&MultiplexedDefaults::default())
+}
+
+/// Settings an embedder chose that the multiplexed plugin set is built with.
+///
+/// A named interface's own `config` still wins key by key; these fill in the
+/// rest, which is how a host's flags reach an `(implements ..)` import instead
+/// of stopping at the standard plugins.
+#[cfg(feature = "wasm_component_model_implements")]
+#[derive(Clone, Debug, Default)]
+pub struct MultiplexedDefaults {
+    /// Bucket naming and creation policy for NATS-backed keyvalue interfaces.
+    /// Applies to `wasi:keyvalue` and `wasmcloud:keyvalue` alike — both
+    /// register the same backend providers.
+    #[cfg(feature = "wasi-keyvalue")]
+    pub keyvalue_nats_bucket: wasi_keyvalue::BucketPolicy,
+}
+
+#[cfg(feature = "wasm_component_model_implements")]
+impl MultiplexedDefaults {
+    /// Set the NATS keyvalue bucket policy. A setter rather than a struct
+    /// literal so an embedder keeps compiling as fields are added here, and so
+    /// one that builds without `wasi-keyvalue` is unaffected.
+    #[cfg(feature = "wasi-keyvalue")]
+    pub fn with_keyvalue_nats_bucket(mut self, policy: wasi_keyvalue::BucketPolicy) -> Self {
+        self.keyvalue_nats_bucket = policy;
+        self
+    }
+}
+
+/// [`multiplexed_plugins`], built with the embedder's `defaults`.
+#[cfg(feature = "wasm_component_model_implements")]
+pub fn multiplexed_plugins_with(
+    #[allow(unused_variables)] defaults: &MultiplexedDefaults,
+) -> Vec<std::sync::Arc<dyn HostPlugin>> {
     #[allow(unused_mut)]
     let mut plugins: Vec<std::sync::Arc<dyn HostPlugin>> = Vec::new();
     #[allow(unused_imports)]
@@ -521,18 +556,26 @@ pub fn multiplexed_plugins() -> Vec<std::sync::Arc<dyn HostPlugin>> {
 
     #[cfg(feature = "wasi-keyvalue")]
     {
+        // One provider instance per plugin, both carrying the same bucket
+        // policy, so `wasi:keyvalue` and `wasmcloud:keyvalue` resolve NATS
+        // buckets identically.
+        let nats = || {
+            Arc::new(wasi_keyvalue::NatsProvider::with_defaults(
+                defaults.keyvalue_nats_bucket.clone(),
+            ))
+        };
         plugins.push(Arc::new(
             wasi_keyvalue::MultiplexedKeyValue::new()
                 .with_provider(Arc::new(wasi_keyvalue::InMemoryProvider))
                 .with_provider(Arc::new(wasi_keyvalue::RedisProvider))
-                .with_provider(Arc::new(wasi_keyvalue::NatsProvider))
+                .with_provider(nats())
                 .with_provider(Arc::new(wasi_keyvalue::FilesystemProvider)),
         ));
         plugins.push(Arc::new(
             wasi_keyvalue::MultiplexedAsyncKeyValue::new()
                 .with_provider(Arc::new(wasi_keyvalue::InMemoryProvider))
                 .with_provider(Arc::new(wasi_keyvalue::RedisProvider))
-                .with_provider(Arc::new(wasi_keyvalue::NatsProvider))
+                .with_provider(nats())
                 .with_provider(Arc::new(wasi_keyvalue::FilesystemProvider)),
         ));
     }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/filesystem.rs
@@ -5,6 +5,10 @@
 //! storage lives in the shared [`FsKvStore`](super::fs_store::FsKvStore) — this
 //! module is the host-binding adapter (the unnamed/default `wasi:keyvalue`
 //! instance); the multiplexed `FilesystemBackend` is the other adapter.
+//!
+//! An identifier is a subdirectory of the store root, shared by every workload
+//! on the host: two workloads that open the same identifier share the store.
+//! Give a deployment its own root to separate them.
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/in_memory.rs
@@ -2,6 +2,18 @@
 //!
 //! This module implements an in-memory keyvalue plugin for the wasmCloud runtime,
 //! providing the `wasi:keyvalue@0.2.0-draft` interfaces for development and testing scenarios.
+//!
+//! Buckets here are keyed by workload id, so two workloads that open the same
+//! identifier get separate stores. That isolation is a property of this
+//! development backend, not of `wasi:keyvalue`: the external backends
+//! ([`nats`](super::nats), [`redis`](super::redis),
+//! [`filesystem`](super::filesystem)) key buckets host-globally, so the same
+//! guest code that is isolated here shares a store there. Those backends
+//! separate one host or deployment from another — the NATS backend's
+//! [`BucketPolicy::prefix`](super::BucketPolicy), a per-deployment redis
+//! database, a per-deployment filesystem root — but two workloads on one host
+//! still share a bucket they both name. Give them distinct identifiers, or
+//! distinct `(implements ..)` interfaces, to keep them apart.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/mod.rs
@@ -6,6 +6,7 @@ mod multiplexed;
 #[cfg(feature = "wasm_component_model_implements")]
 mod multiplexed_async;
 mod nats;
+mod nats_bucket;
 mod redis;
 
 pub use filesystem::FilesystemKeyValue;
@@ -19,4 +20,5 @@ pub use multiplexed::{
 #[cfg(feature = "wasm_component_model_implements")]
 pub use multiplexed_async::MultiplexedAsyncKeyValue;
 pub use nats::NatsKeyValue;
+pub use nats_bucket::{BucketPolicy, CreatePolicy, OpenError, OpenOutcome};
 pub use redis::RedisKeyValue;

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed.rs
@@ -71,6 +71,14 @@ impl KvBucket {
 /// (NATS revision, a per-bucket counter, ...). Never a hash of the value, or a
 /// value that returns to identical bytes (A → B → A) would reuse a version and
 /// defeat the ABA check.
+///
+/// The guarantee is per bucket lifetime, not eternal: deleting a bucket and
+/// recreating it under the same name restarts NATS revisions at 1, so a token
+/// taken before the recreate is not comparable to one taken after. A guard
+/// carried across that boundary can in principle match a different
+/// generation's entry at the same revision. Deleting a bucket already destroys
+/// the data such a guard protects, so this is a documented edge rather than
+/// something the backends defend against.
 #[derive(Clone, Debug)]
 pub struct Versioned {
     pub value: Vec<u8>,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
@@ -8,15 +8,19 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::RwLock;
 
 use crate::plugin::multiplex::BackendProvider;
+use crate::plugin::wasi_keyvalue::nats_bucket::{BucketPolicy, OpenError};
 
 use super::{
     CasGuard, CasOutcome, KeyResponse, KvBackend, KvId, LIST_KEYS_BATCH_SIZE, StoreError, Versioned,
 };
 
-/// A NATS JetStream KV-backed [`KvBackend`]. Each bucket maps to a JetStream KV
-/// store (which must already exist); store handles are cached by name.
+/// A NATS JetStream KV-backed [`KvBackend`]. A [`BucketPolicy`] maps the
+/// identifier a guest opens onto the physical JetStream bucket and decides
+/// whether a missing one may be created; store handles are cached by physical
+/// name.
 pub struct NatsBackend {
     context: Arc<async_nats::jetstream::Context>,
+    policy: BucketPolicy,
     stores: RwLock<HashMap<String, async_nats::jetstream::kv::Store>>,
 }
 
@@ -25,50 +29,49 @@ impl NatsBackend {
         StoreError::Other(format!("JetStream error: {e}"))
     }
 
+    fn open_err(e: OpenError) -> StoreError {
+        match e {
+            OpenError::NoSuchStore => StoreError::NoSuchStore,
+            OpenError::Other(e) => StoreError::Other(e),
+        }
+    }
+
+    /// Resolve a bucket for an operation. Look-up only: a bucket is created
+    /// (when the policy allows) by `open` alone, so a stray `get` on an
+    /// identifier that was never opened cannot mint a stream.
     async fn store(&self, bucket: &str) -> Result<async_nats::jetstream::kv::Store, StoreError> {
-        if let Some(s) = self.stores.read().await.get(bucket) {
+        let physical = self.policy.physical_name(bucket);
+        if let Some(s) = self.stores.read().await.get(&physical) {
             return Ok(s.clone());
         }
-        use async_nats::jetstream::context::{
-            GetStreamError, GetStreamErrorKind, KeyValueErrorKind,
-        };
-        use std::error::Error as _;
         let kv = self
-            .context
-            .get_key_value(bucket)
+            .policy
+            .get(&self.context, &physical)
             .await
-            .map_err(|e| match e.kind() {
-                // An invalid name is never a real store.
-                KeyValueErrorKind::InvalidStoreName => StoreError::NoSuchStore,
-                // `GetBucket` wraps a `get_stream` failure: a missing/invalid
-                // stream is `no-such-store`, but a `Request` (transport/timeout)
-                // failure is a real error that must propagate so a guest can retry
-                // instead of seeing "not found".
-                KeyValueErrorKind::GetBucket => {
-                    if matches!(
-                        e.source().and_then(|s| s.downcast_ref::<GetStreamError>()),
-                        Some(g) if g.kind() == GetStreamErrorKind::Request
-                    ) {
-                        Self::err(e)
-                    } else {
-                        StoreError::NoSuchStore
-                    }
-                }
-                // A JetStream/transport failure is a real error, not "not found".
-                KeyValueErrorKind::JetStream => Self::err(e),
-            })?;
-        self.stores
-            .write()
-            .await
-            .insert(bucket.to_string(), kv.clone());
+            .map_err(Self::open_err)?;
+        self.cache(physical, kv.clone()).await;
         Ok(kv)
+    }
+
+    async fn cache(&self, physical: String, kv: async_nats::jetstream::kv::Store) {
+        self.stores.write().await.insert(physical, kv);
     }
 }
 
 #[async_trait::async_trait]
 impl KvBackend for NatsBackend {
     async fn open(&self, identifier: &str) -> Result<(), StoreError> {
-        self.store(identifier).await.map(|_| ())
+        let physical = self.policy.physical_name(identifier);
+        if self.stores.read().await.contains_key(&physical) {
+            return Ok(());
+        }
+        let (kv, _outcome) = self
+            .policy
+            .open(&self.context, identifier)
+            .await
+            .map_err(Self::open_err)?;
+        self.cache(physical, kv).await;
+        Ok(())
     }
 
     async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
@@ -318,13 +321,45 @@ async fn present_entry(
 
 /// Provider for [`NatsBackend`], selected by `config.backend = "nats"`. Requires
 /// `config.url` (e.g. `nats://127.0.0.1:4222`).
+///
+/// The remaining config is the interface's [`BucketPolicy`]: `bucket`,
+/// `bucket_prefix`, `create` (`never` — the default here — or `missing`), and
+/// the settings a created bucket is given (`replicas`, `storage`, `max_age`,
+/// `history`, `max_bytes`). Any key an interface leaves unset comes from the
+/// embedder's [`NatsProvider::with_defaults`] policy, whose own default is
+/// `create = never`: a guest's identifier cannot create JetStream streams, so
+/// an operator declares the buckets and anything else is `no-such-store`.
 #[derive(Default)]
-pub struct NatsProvider;
+pub struct NatsProvider {
+    defaults: BucketPolicy,
+}
+
+impl NatsProvider {
+    /// The bucket policy interfaces inherit from unless they configure their
+    /// own. This is how a host's `--keyvalue-nats-*` flags reach a named
+    /// import, and it is shared by the `wasi:keyvalue` and `wasmcloud:keyvalue`
+    /// plugins, which register the same providers.
+    pub fn with_defaults(defaults: BucketPolicy) -> Self {
+        Self { defaults }
+    }
+}
 
 #[async_trait::async_trait]
 impl BackendProvider<KvId> for NatsProvider {
+    /// Pooled per URL *and* resolved bucket policy: the backend carries its
+    /// policy, so two interfaces on one NATS server may only share a backend
+    /// when they resolve buckets the same way. The policy is fingerprinted
+    /// after merging with the embedder's defaults, so what an interface
+    /// inherits counts the same as what it spells out — including an empty
+    /// `bucket_prefix` opting out of an inherited one.
+    ///
+    /// A config this provider cannot parse yields no pool key at all: it is
+    /// about to fail in `instantiate`, and a placeholder key could collide
+    /// with a valid one.
     fn pool_key(&self, config: &HashMap<String, String>) -> Option<String> {
-        config.get("url").cloned()
+        let url = config.get("url")?;
+        let policy = BucketPolicy::from_config(config, &self.defaults).ok()?;
+        Some(format!("{url}\u{1}{}", policy.fingerprint()))
     }
     fn backend_type(&self) -> &'static str {
         "nats"
@@ -334,10 +369,12 @@ impl BackendProvider<KvId> for NatsProvider {
         let url = config
             .get("url")
             .ok_or_else(|| anyhow::anyhow!("nats keyvalue backend requires a 'url' config"))?;
+        let policy = BucketPolicy::from_config(config, &self.defaults)?;
         let client = async_nats::connect(url).await?;
         let context = async_nats::jetstream::new(client);
         Ok(Arc::new(NatsBackend {
             context: Arc::new(context),
+            policy,
             stores: RwLock::new(HashMap::new()),
         }))
     }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
@@ -185,24 +185,27 @@ impl NatsBackend {
 
 #[async_trait::async_trait]
 impl KvBackend for NatsBackend {
+    /// Resolve the bucket, creating it if the policy allows.
+    ///
+    /// Always asks the policy rather than trusting a cached handle: `open` is
+    /// where a guest learns whether its store exists, so answering from a
+    /// handle cached before the bucket was deleted would report a bucket that
+    /// is gone as present, and leave the guest to discover it on the next
+    /// operation instead.
     async fn open(&self, identifier: &str) -> Result<(), StoreError> {
         let physical = self.policy.physical_name(identifier);
-        if self
-            .stores
-            .read()
-            .await
-            .get(&physical, Instant::now())
-            .is_some()
-        {
-            return Ok(());
+        let opened = self.policy.open(&self.context, identifier).await;
+        match opened {
+            Ok((kv, _outcome)) => {
+                self.cache(physical, kv).await;
+                Ok(())
+            }
+            Err(e) => {
+                // Whatever was cached for this name is no longer trustworthy.
+                self.stores.write().await.remove(&physical);
+                Err(Self::open_err(e))
+            }
         }
-        let (kv, _outcome) = self
-            .policy
-            .open(&self.context, identifier)
-            .await
-            .map_err(Self::open_err)?;
-        self.cache(physical, kv).await;
-        Ok(())
     }
 
     async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
@@ -311,19 +314,19 @@ impl KvBackend for NatsBackend {
         keys: Vec<String>,
     ) -> Result<Vec<Option<(String, Vec<u8>)>>, StoreError> {
         let s = self.store(bucket).await?;
-        FuturesUnordered::from_iter(keys.into_iter().map(|key| {
-            let s = s.clone();
-            async move {
-                Ok(s.get(&key)
-                    .await
-                    .map_err(Self::err)?
-                    .map(|b| (key, b.to_vec())))
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
+        let results: Vec<Result<Option<(String, Vec<u8>)>, _>> =
+            FuturesUnordered::from_iter(keys.into_iter().map(|key| {
+                let s = s.clone();
+                async move {
+                    s.get(&key)
+                        .await
+                        .map(|value| value.map(|b| (key, b.to_vec())))
+                }
+            }))
+            .collect()
+            .await;
+        self.check(bucket, results.into_iter().collect::<Result<Vec<_>, _>>())
+            .await
     }
 
     async fn set_many(
@@ -332,31 +335,30 @@ impl KvBackend for NatsBackend {
         key_values: Vec<(String, Vec<u8>)>,
     ) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        FuturesUnordered::from_iter(key_values.into_iter().map(|(key, value)| {
-            let s = s.clone();
-            async move {
-                s.put(key, value.into())
-                    .await
-                    .map(|_| ())
-                    .map_err(Self::err)
-            }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
+        let results: Vec<Result<(), _>> =
+            FuturesUnordered::from_iter(key_values.into_iter().map(|(key, value)| {
+                let s = s.clone();
+                async move { s.put(key, value.into()).await.map(|_| ()) }
+            }))
+            .collect()
+            .await;
+        self.check(bucket, results.into_iter().collect::<Result<Vec<_>, _>>())
+            .await?;
+        Ok(())
     }
 
     async fn delete_many(&self, bucket: &str, keys: Vec<String>) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        FuturesUnordered::from_iter(keys.into_iter().map(|key| {
-            let s = s.clone();
-            async move { s.delete(&key).await.map(|_| ()).map_err(Self::err) }
-        }))
-        .collect::<Vec<_>>()
-        .await
-        .into_iter()
-        .collect()
+        let results: Vec<Result<(), _>> =
+            FuturesUnordered::from_iter(keys.into_iter().map(|key| {
+                let s = s.clone();
+                async move { s.delete(&key).await.map(|_| ()) }
+            }))
+            .collect()
+            .await;
+        self.check(bucket, results.into_iter().collect::<Result<Vec<_>, _>>())
+            .await?;
+        Ok(())
     }
 
     async fn put_if_absent(
@@ -371,13 +373,14 @@ impl KvBackend for NatsBackend {
         match s.create(key, Bytes::from(value)).await {
             Ok(_) => Ok(true),
             Err(e) if e.kind() == CreateErrorKind::AlreadyExists => Ok(false),
-            Err(e) => Err(Self::err(e)),
+            Err(e) => Err(self.classify(bucket, e).await),
         }
     }
 
     async fn current(&self, bucket: &str, key: &str) -> Result<Option<Versioned>, StoreError> {
         let s = self.store(bucket).await?;
-        Ok(present_entry(&s, key).await?)
+        let entry = self.check(bucket, s.entry(key).await).await?;
+        Ok(present(entry))
     }
 
     async fn swap(
@@ -391,7 +394,7 @@ impl KvBackend for NatsBackend {
         let s = self.store(bucket).await?;
 
         // Read the current entry (with its revision) to evaluate preconditions.
-        let entry = s.entry(key).await.map_err(Self::err)?;
+        let entry = self.check(bucket, s.entry(key).await).await?;
         let revision = entry.as_ref().map(|e| e.revision);
         let current = entry
             .filter(|e| matches!(e.operation, Operation::Put))
@@ -426,29 +429,25 @@ impl KvBackend for NatsBackend {
         match s.update(key, Bytes::from(value), rev).await {
             Ok(_) => Ok(CasOutcome::Swapped),
             Err(e) if e.kind() == UpdateErrorKind::WrongLastRevision => {
-                Ok(CasOutcome::Stale(present_entry(&s, key).await?))
+                let entry = self.check(bucket, s.entry(key).await).await?;
+                Ok(CasOutcome::Stale(present(entry)))
             }
-            Err(e) => Err(Self::err(e)),
+            Err(e) => Err(self.classify(bucket, e).await),
         }
     }
 }
 
-/// Read a key's current value + revision, treating a delete/purge tombstone as
-/// absent.
-async fn present_entry(
-    store: &async_nats::jetstream::kv::Store,
-    key: &str,
-) -> Result<Option<Versioned>, StoreError> {
+/// A read entry as a [`Versioned`] value, treating a delete/purge tombstone as
+/// absent. Takes the entry rather than reading it so the caller classifies the
+/// read's failure against the bucket.
+fn present(entry: Option<async_nats::jetstream::kv::Entry>) -> Option<Versioned> {
     use async_nats::jetstream::kv::Operation;
-    Ok(store
-        .entry(key)
-        .await
-        .map_err(NatsBackend::err)?
+    entry
         .filter(|e| matches!(e.operation, Operation::Put))
         .map(|e| Versioned {
             value: e.value.to_vec(),
             version: e.revision.to_string(),
-        }))
+        })
 }
 
 #[cfg(test)]

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/multiplexed/nats.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use bytes::{Buf, Bytes};
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -14,14 +15,104 @@ use super::{
     CasGuard, CasOutcome, KeyResponse, KvBackend, KvId, LIST_KEYS_BATCH_SIZE, StoreError, Versioned,
 };
 
+/// How long a resolved bucket handle is reused before being looked up again.
+///
+/// A handle is a snapshot, not a session: `async_nats`'s `Store` carries the
+/// stream's config from resolve time and reads `allow_direct` off it, so one
+/// kept forever can route reads by a config the bucket no longer has.
+/// Re-resolving also means a bucket deleted out of band stops looking present.
+const STORE_TTL: Duration = Duration::from_secs(300);
+
+/// Ceiling on cached handles. Bucket names come from guest identifiers, so the
+/// map must not grow with them; past this the least recently resolved entries
+/// are dropped and simply re-resolve on next use.
+const STORE_CACHE_CAP: usize = 512;
+
+/// A resolved handle and when it was resolved.
+struct CachedStore<V> {
+    store: V,
+    resolved: Instant,
+}
+
+/// Bucket handles by physical name, with a TTL and a ceiling.
+///
+/// Generic over the handle so the expiry and ceiling can be tested without a
+/// NATS connection; the backend instantiates it with `kv::Store`.
+struct StoreCache<V = async_nats::jetstream::kv::Store> {
+    entries: HashMap<String, CachedStore<V>>,
+    ttl: Duration,
+    cap: usize,
+}
+
+impl<V> Default for StoreCache<V> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            ttl: STORE_TTL,
+            cap: STORE_CACHE_CAP,
+        }
+    }
+}
+
+impl<V: Clone> StoreCache<V> {
+    /// The handle for `physical`, if one was resolved recently enough.
+    fn get(&self, physical: &str, now: Instant) -> Option<V> {
+        self.entries
+            .get(physical)
+            .filter(|entry| now.duration_since(entry.resolved) < self.ttl)
+            .map(|entry| entry.store.clone())
+    }
+
+    fn insert(&mut self, physical: String, store: V, now: Instant) {
+        if self.entries.len() >= self.cap {
+            let ttl = self.ttl;
+            self.entries
+                .retain(|_, entry| now.duration_since(entry.resolved) < ttl);
+        }
+        // Nothing expired, so make room by dropping the oldest resolves.
+        while self.entries.len() >= self.cap {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.resolved)
+                .map(|(name, _)| name.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        self.entries.insert(
+            physical,
+            CachedStore {
+                store,
+                resolved: now,
+            },
+        );
+    }
+
+    fn remove(&mut self, physical: &str) {
+        self.entries.remove(physical);
+    }
+}
+
 /// A NATS JetStream KV-backed [`KvBackend`]. A [`BucketPolicy`] maps the
 /// identifier a guest opens onto the physical JetStream bucket and decides
-/// whether a missing one may be created; store handles are cached by physical
-/// name.
+/// whether a missing one may be created; resolved handles are cached by
+/// physical name for [`STORE_TTL`].
+///
+/// A bucket deleted out of band is reported to the guest as `no-such-store`,
+/// not as a transport error: an operation failure is checked against the
+/// bucket before being classified. A bucket deleted and *recreated* under the
+/// same name is simply an empty bucket — neither `wasi:keyvalue` nor
+/// `wasmcloud:keyvalue` has a store generation to signal, and the other
+/// backends (a redis prefix, a filesystem directory) behave the same way. The
+/// one sharp edge is that JetStream revisions restart at 1, so a CAS version
+/// token taken before a recreate is not comparable to one taken after; see
+/// [`Versioned`].
 pub struct NatsBackend {
     context: Arc<async_nats::jetstream::Context>,
     policy: BucketPolicy,
-    stores: RwLock<HashMap<String, async_nats::jetstream::kv::Store>>,
+    stores: RwLock<StoreCache>,
 }
 
 impl NatsBackend {
@@ -41,8 +132,8 @@ impl NatsBackend {
     /// identifier that was never opened cannot mint a stream.
     async fn store(&self, bucket: &str) -> Result<async_nats::jetstream::kv::Store, StoreError> {
         let physical = self.policy.physical_name(bucket);
-        if let Some(s) = self.stores.read().await.get(&physical) {
-            return Ok(s.clone());
+        if let Some(s) = self.stores.read().await.get(&physical, Instant::now()) {
+            return Ok(s);
         }
         let kv = self
             .policy
@@ -54,7 +145,41 @@ impl NatsBackend {
     }
 
     async fn cache(&self, physical: String, kv: async_nats::jetstream::kv::Store) {
-        self.stores.write().await.insert(physical, kv);
+        self.stores
+            .write()
+            .await
+            .insert(physical, kv, Instant::now());
+    }
+
+    /// Classify an operation failure.
+    ///
+    /// A JetStream operation against a deleted stream fails in a
+    /// transport-shaped way rather than saying "no such store", so ask the
+    /// bucket before deciding: if it is gone, drop the cached handle and
+    /// answer `no-such-store` — the case a guest can actually act on — and
+    /// otherwise keep the original error. The extra round trip is on the error
+    /// path only.
+    async fn classify(&self, bucket: &str, e: impl std::fmt::Display) -> StoreError {
+        let physical = self.policy.physical_name(bucket);
+        match self.policy.get(&self.context, &physical).await {
+            Err(OpenError::NoSuchStore) => {
+                self.stores.write().await.remove(&physical);
+                StoreError::NoSuchStore
+            }
+            _ => Self::err(e),
+        }
+    }
+
+    /// [`NatsBackend::classify`] applied to one operation's result.
+    async fn check<T, E: std::fmt::Display>(
+        &self,
+        bucket: &str,
+        result: Result<T, E>,
+    ) -> Result<T, StoreError> {
+        match result {
+            Ok(value) => Ok(value),
+            Err(e) => Err(self.classify(bucket, e).await),
+        }
     }
 }
 
@@ -62,7 +187,13 @@ impl NatsBackend {
 impl KvBackend for NatsBackend {
     async fn open(&self, identifier: &str) -> Result<(), StoreError> {
         let physical = self.policy.physical_name(identifier);
-        if self.stores.read().await.contains_key(&physical) {
+        if self
+            .stores
+            .read()
+            .await
+            .get(&physical, Instant::now())
+            .is_some()
+        {
             return Ok(());
         }
         let (kv, _outcome) = self
@@ -76,26 +207,28 @@ impl KvBackend for NatsBackend {
 
     async fn get(&self, bucket: &str, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
         let s = self.store(bucket).await?;
-        Ok(s.get(key).await.map_err(Self::err)?.map(|b| b.to_vec()))
+        Ok(self
+            .check(bucket, s.get(key).await)
+            .await?
+            .map(|b| b.to_vec()))
     }
 
     async fn set(&self, bucket: &str, key: &str, value: Vec<u8>) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        s.put(key.to_string(), value.into())
-            .await
-            .map_err(Self::err)?;
+        self.check(bucket, s.put(key.to_string(), value.into()).await)
+            .await?;
         Ok(())
     }
 
     async fn delete(&self, bucket: &str, key: &str) -> Result<(), StoreError> {
         let s = self.store(bucket).await?;
-        s.delete(key).await.map_err(Self::err)?;
+        self.check(bucket, s.delete(key).await).await?;
         Ok(())
     }
 
     async fn exists(&self, bucket: &str, key: &str) -> Result<bool, StoreError> {
         let s = self.store(bucket).await?;
-        Ok(s.get(key).await.map_err(Self::err)?.is_some())
+        Ok(self.check(bucket, s.get(key).await).await?.is_some())
     }
 
     async fn list_keys(
@@ -105,10 +238,9 @@ impl KvBackend for NatsBackend {
     ) -> Result<KeyResponse, StoreError> {
         let s = self.store(bucket).await?;
         let skip = cursor.unwrap_or(0) as usize;
-        let mut stream = s
-            .keys()
-            .await
-            .map_err(Self::err)?
+        let mut stream = self
+            .check(bucket, s.keys().await)
+            .await?
             .skip(skip)
             .take(LIST_KEYS_BATCH_SIZE + 1)
             .boxed();
@@ -135,7 +267,7 @@ impl KvBackend for NatsBackend {
         // erroring. `atomics.increment` is defined to be atomic, so contention
         // must serialize, not fail.
         loop {
-            let (revision, current) = match s.entry(key).await.map_err(Self::err)? {
+            let (revision, current) = match self.check(bucket, s.entry(key).await).await? {
                 // Read the counter as a big-endian i64, tolerating a malformed
                 // (non-8-byte) value as 0 rather than panicking: `Buf::get_i64`
                 // traps if the value has fewer than 8 bytes.
@@ -160,14 +292,14 @@ impl KvBackend for NatsBackend {
                 Some(rev) => match s.update(key, bytes, rev).await {
                     Ok(_) => return Ok(next),
                     Err(e) if e.kind() == UpdateErrorKind::WrongLastRevision => continue,
-                    Err(e) => return Err(Self::err(e)),
+                    Err(e) => return Err(self.classify(bucket, e).await),
                 },
                 // `create` (not `put`) so a concurrent create is detected and
                 // retried instead of clobbered.
                 None => match s.create(key, bytes).await {
                     Ok(_) => return Ok(next),
                     Err(e) if e.kind() == CreateErrorKind::AlreadyExists => continue,
-                    Err(e) => return Err(Self::err(e)),
+                    Err(e) => return Err(self.classify(bucket, e).await),
                 },
             }
         }
@@ -319,6 +451,86 @@ async fn present_entry(
         }))
 }
 
+#[cfg(test)]
+mod tests {
+    //! The cache's expiry and ceiling, which need no NATS connection. How a
+    //! deleted bucket is reported to a guest is covered against a real server
+    //! in `tests/integration_keyvalue_multiplexed.rs`.
+
+    use super::*;
+
+    fn cache(ttl: Duration, cap: usize) -> StoreCache<String> {
+        StoreCache {
+            entries: HashMap::new(),
+            ttl,
+            cap,
+        }
+    }
+
+    /// A handle is reused inside its TTL and re-resolved after it, so it
+    /// cannot carry a stream config — or a deleted bucket's existence —
+    /// indefinitely.
+    #[test]
+    fn a_handle_expires() {
+        let start = Instant::now();
+        let mut cache = cache(Duration::from_secs(300), 8);
+        cache.insert("counters".to_string(), "handle".to_string(), start);
+
+        assert_eq!(
+            cache.get("counters", start + Duration::from_secs(299)),
+            Some("handle".to_string())
+        );
+        assert_eq!(
+            cache.get("counters", start + Duration::from_secs(300)),
+            None
+        );
+    }
+
+    /// An evicted handle is gone immediately — this is what a failed operation
+    /// does once it learns the bucket is missing.
+    #[test]
+    fn remove_drops_a_handle() {
+        let now = Instant::now();
+        let mut cache = cache(Duration::from_secs(300), 8);
+        cache.insert("counters".to_string(), "handle".to_string(), now);
+        cache.remove("counters");
+        assert_eq!(cache.get("counters", now), None);
+    }
+
+    /// Guest identifiers name the buckets, so the map is capped however many
+    /// distinct ones arrive.
+    #[test]
+    fn the_cache_is_bounded() {
+        let now = Instant::now();
+        let mut cache = cache(Duration::from_secs(300), 4);
+        for i in 0..100 {
+            cache.insert(format!("bucket-{i}"), i.to_string(), now);
+        }
+        assert!(
+            cache.entries.len() <= 4,
+            "held {} entries, cap is 4",
+            cache.entries.len()
+        );
+    }
+
+    /// Expired entries are what a full cache drops first; a live handle
+    /// survives.
+    #[test]
+    fn expiry_makes_room_before_live_handles_are_dropped() {
+        let start = Instant::now();
+        let mut cache = cache(Duration::from_secs(60), 2);
+        cache.insert("old".to_string(), "old".to_string(), start);
+
+        let later = start + Duration::from_secs(61);
+        cache.insert("fresh".to_string(), "fresh".to_string(), later);
+        cache.insert("newest".to_string(), "newest".to_string(), later);
+
+        assert_eq!(cache.get("old", later), None, "the expired entry made room");
+        assert_eq!(cache.get("fresh", later), Some("fresh".to_string()));
+        assert_eq!(cache.get("newest", later), Some("newest".to_string()));
+    }
+}
+
 /// Provider for [`NatsBackend`], selected by `config.backend = "nats"`. Requires
 /// `config.url` (e.g. `nats://127.0.0.1:4222`).
 ///
@@ -375,7 +587,7 @@ impl BackendProvider<KvId> for NatsProvider {
         Ok(Arc::new(NatsBackend {
             context: Arc::new(context),
             policy,
-            stores: RwLock::new(HashMap::new()),
+            stores: RwLock::default(),
         }))
     }
 }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -97,7 +97,9 @@ struct WasiKeyvalueMetrics {
     /// Opens by what the bucket policy did: `existing`, `created`, or
     /// `refused` (the policy declined to create a missing bucket). Separate
     /// from `operations_total` so the policy is measurable without changing
-    /// the attributes of the existing series.
+    /// the attributes of the existing series. `created` counts opens that took
+    /// the create path, which two racing opens can both do — see
+    /// [`OpenOutcome::Created`].
     bucket_opens_total: opentelemetry::metrics::Counter<u64>,
 }
 
@@ -109,7 +111,10 @@ impl WasiKeyvalueMetrics {
             .build();
         let bucket_opens_total = meter
             .u64_counter("wasi_keyvalue_bucket_opens_total")
-            .with_description("Bucket opens by outcome: existing, created, or refused")
+            .with_description(
+                "Bucket opens by outcome: existing, created (this open took the create path), \
+                 or refused (the policy declined to create a missing bucket)",
+            )
             .build();
         Self {
             operations_total,

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats.rs
@@ -1,8 +1,16 @@
-//! # WASI KeyValue Memory Plugin
+//! # WASI KeyValue NATS Plugin
 //!
 //! This module implements `wasi:keyvalue@0.2.0-draft` interfaces using
 //! NATS JetStream as the backend storage.
 //! Atomics are stored in Network Byte Order (big-endian) format.
+//!
+//! A [`BucketPolicy`] maps the identifier a guest opens onto a physical
+//! JetStream bucket and decides whether a missing bucket may be created. The
+//! buckets themselves are host-global rather than per workload: two workloads
+//! that open the same identifier share one store, which is how they share
+//! state deliberately. Set [`BucketPolicy::prefix`] to namespace them apart.
+//! The in-memory plugin, by contrast, keys buckets by workload id, so the same
+//! guest code is isolated under a bare `wash dev` and shared on NATS.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -12,6 +20,7 @@ use bytes::{Buf, Bytes};
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
 use crate::engine::workload::WorkloadItem;
+use crate::plugin::wasi_keyvalue::nats_bucket::{BucketPolicy, OpenError, OpenOutcome};
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
@@ -75,15 +84,21 @@ pub struct BucketHandle {
     kv: async_nats::jetstream::kv::Store,
 }
 
-/// Memory-based keyvalue plugin
+/// NATS JetStream-backed keyvalue plugin
 #[derive(Clone)]
 pub struct NatsKeyValue {
     client: Arc<async_nats::jetstream::Context>,
     metrics: Arc<WasiKeyvalueMetrics>,
+    policy: Arc<BucketPolicy>,
 }
 
 struct WasiKeyvalueMetrics {
     operations_total: opentelemetry::metrics::Counter<u64>,
+    /// Opens by what the bucket policy did: `existing`, `created`, or
+    /// `refused` (the policy declined to create a missing bucket). Separate
+    /// from `operations_total` so the policy is measurable without changing
+    /// the attributes of the existing series.
+    bucket_opens_total: opentelemetry::metrics::Counter<u64>,
 }
 
 impl WasiKeyvalueMetrics {
@@ -92,17 +107,34 @@ impl WasiKeyvalueMetrics {
             .u64_counter("wasi_keyvalue_operations_total")
             .with_description("Total number of operations performed on the keyvalue store")
             .build();
-        Self { operations_total }
+        let bucket_opens_total = meter
+            .u64_counter("wasi_keyvalue_bucket_opens_total")
+            .with_description("Bucket opens by outcome: existing, created, or refused")
+            .build();
+        Self {
+            operations_total,
+            bucket_opens_total,
+        }
     }
 }
 
 impl NatsKeyValue {
+    /// A plugin that creates missing buckets on first open. The development
+    /// default: a guest's `open` works against a bare JetStream server with no
+    /// configuration. Use [`NatsKeyValue::with_bucket_policy`] to name, prefix,
+    /// or lock down the buckets a deployment exposes.
     pub fn new(client: &async_nats::Client) -> Self {
+        Self::with_bucket_policy(client, BucketPolicy::create_missing())
+    }
+
+    /// A plugin whose opens resolve through `policy`.
+    pub fn with_bucket_policy(client: &async_nats::Client, policy: BucketPolicy) -> Self {
         let meter = opentelemetry::global::meter("wasi-keyvalue");
         let metrics = WasiKeyvalueMetrics::new(&meter);
         Self {
             client: async_nats::jetstream::new(client.clone()).into(),
             metrics: Arc::new(metrics),
+            policy: Arc::new(policy),
         }
     }
 
@@ -114,43 +146,21 @@ impl NatsKeyValue {
         self.metrics.operations_total.add(1, &attributes);
     }
 
-    /// Open the JetStream KV bucket for `identifier`, creating it if it doesn't
-    /// exist.
+    fn record_bucket_open(&self, outcome: &'static str) {
+        let attributes = [opentelemetry::KeyValue::new("outcome", outcome)];
+        self.metrics.bucket_opens_total.add(1, &attributes);
+    }
+
+    /// Open the JetStream KV bucket `identifier` resolves to under this
+    /// plugin's [`BucketPolicy`], creating it only if the policy allows.
     ///
-    /// We unconditionally call `create_key_value`: it is idempotent for an
-    /// identical config, so creating a bucket that already exists returns the
-    /// existing store (entries intact) rather than erroring, and concurrent
-    /// opens racing here all succeed. Verified by
-    /// `tests::test_reopening_bucket_preserves_entries`.
-    ///
-    /// Any error is therefore a genuine failure (permission, connection,
-    /// JetStream disabled, or a pre-existing bucket created with a *different*
-    /// config) and is surfaced rather than masked.
-    ///
-    /// Note this means `open` requires stream-create permission even for an
-    /// already-existing bucket. That is fine today because the NATS connection —
-    /// and therefore its permissions — is owned by the Host and shared across
-    /// all workloads, not scoped per workload. If per-workload NATS credentials
-    /// are ever introduced, a workload allowed to open but not create buckets
-    /// would break here, and this should fall back to a get-then-create path.
-    async fn get_or_create_bucket(
+    /// Re-opening an existing, populated bucket returns it with its entries
+    /// intact — verified by `tests::test_reopening_bucket_preserves_entries`.
+    async fn open_bucket(
         &self,
         identifier: &str,
-    ) -> Result<async_nats::jetstream::kv::Store, String> {
-        self.client
-            .create_key_value(async_nats::jetstream::kv::Config {
-                bucket: identifier.to_string(),
-                ..Default::default()
-            })
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    bucket = %identifier,
-                    "Failed to open keyvalue bucket in JetStream"
-                );
-                format!("failed to open keyvalue bucket in JetStream({identifier}): {e}")
-            })
+    ) -> Result<(async_nats::jetstream::kv::Store, OpenOutcome), OpenError> {
+        self.policy.open(&self.client, identifier).await
     }
 }
 
@@ -165,9 +175,16 @@ impl<'a> bindings::wasi::keyvalue::store::Host for ActiveCtx<'a> {
 
         plugin.record_operation("open");
 
-        let kv = match plugin.get_or_create_bucket(&identifier).await {
-            Ok(kv) => kv,
-            Err(e) => return Ok(Err(StoreError::Other(e))),
+        let kv = match plugin.open_bucket(&identifier).await {
+            Ok((kv, outcome)) => {
+                plugin.record_bucket_open(outcome.as_str());
+                kv
+            }
+            Err(OpenError::NoSuchStore) => {
+                plugin.record_bucket_open("refused");
+                return Ok(Err(StoreError::NoSuchStore));
+            }
+            Err(OpenError::Other(e)) => return Ok(Err(StoreError::Other(e))),
         };
 
         let bucket = BucketHandle { kv };
@@ -556,9 +573,9 @@ impl HostPlugin for NatsKeyValue {
 
 #[cfg(test)]
 mod tests {
-    //! Tests for the private `get_or_create_bucket` path that `open` relies
-    //! on, and for the `collect_key_page` pagination helper `list_keys`
-    //! delegates to.
+    //! Tests for the private `open_bucket` path — the bucket policy's naming
+    //! and creation rules — and for the `collect_key_page` pagination helper
+    //! `list_keys` delegates to.
     //!
     //! These live here (rather than under `tests/`) because they exercise
     //! private items directly; the repo's `tests/integration_nats_*` files can
@@ -672,6 +689,13 @@ mod tests {
         runners::AsyncRunner,
     };
 
+    fn init_tracing() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init()
+            .ok();
+    }
+
     async fn start_nats_jetstream()
     -> anyhow::Result<(ContainerAsync<GenericImage>, async_nats::Client)> {
         let container = GenericImage::new("nats", "2.12.8-alpine")
@@ -694,35 +718,37 @@ mod tests {
         Ok((container, client))
     }
 
-    /// `get_or_create_bucket` is implemented as an idempotent `create_key_value`.
-    /// This verifies the property that makes that safe: re-opening an existing,
-    /// populated bucket returns the same store with its entries intact — the
-    /// duplicate create does not reset or wipe the bucket.
+    /// Re-opening an existing, populated bucket returns the same store with its
+    /// entries intact: the create-if-missing path must not reset or wipe a
+    /// bucket that is already there.
     #[tokio::test]
     #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
     async fn test_reopening_bucket_preserves_entries() -> anyhow::Result<()> {
-        tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .try_init()
-            .ok();
+        init_tracing();
 
         let (_container, client) = start_nats_jetstream().await?;
         let kv = NatsKeyValue::new(&client);
         let bucket = format!("kv-{}", uuid::Uuid::new_v4());
 
-        let created = kv
-            .get_or_create_bucket(&bucket)
+        let (created, outcome) = kv
+            .open_bucket(&bucket)
             .await
             .map_err(|e| anyhow::anyhow!("first open failed: {e}"))?;
+        assert_eq!(outcome, OpenOutcome::Created);
         created
             .put("greeting", bytes::Bytes::from_static(b"hello"))
             .await
             .map_err(|e| anyhow::anyhow!("put failed: {e}"))?;
 
-        let reopened = kv
-            .get_or_create_bucket(&bucket)
+        let (reopened, outcome) = kv
+            .open_bucket(&bucket)
             .await
             .map_err(|e| anyhow::anyhow!("re-open failed: {e}"))?;
+        assert_eq!(
+            outcome,
+            OpenOutcome::Existing,
+            "the second open must find the bucket, not recreate it"
+        );
         let value = reopened
             .get("greeting")
             .await
@@ -733,6 +759,116 @@ mod tests {
             Some(b"hello".as_slice()),
             "entry was lost when re-opening the bucket"
         );
+
+        Ok(())
+    }
+
+    /// Under `create = never` a guest cannot bring a bucket into existence: an
+    /// unknown identifier is `no-such-store`, and only a bucket the operator
+    /// created is reachable.
+    #[tokio::test]
+    #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+    async fn test_create_never_rejects_unknown_bucket() -> anyhow::Result<()> {
+        init_tracing();
+
+        let (_container, client) = start_nats_jetstream().await?;
+        let kv = NatsKeyValue::with_bucket_policy(&client, BucketPolicy::default());
+        let bucket = format!("kv-{}", uuid::Uuid::new_v4());
+
+        let err = kv
+            .open_bucket(&bucket)
+            .await
+            .expect_err("opening an absent bucket must fail under create = never");
+        assert!(
+            matches!(err, OpenError::NoSuchStore),
+            "expected no-such-store, got {err}"
+        );
+
+        // The same identifier opens once the bucket exists.
+        async_nats::jetstream::new(client.clone())
+            .create_key_value(async_nats::jetstream::kv::Config {
+                bucket: bucket.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("operator create failed: {e}"))?;
+        kv.open_bucket(&bucket)
+            .await
+            .map_err(|e| anyhow::anyhow!("open of an existing bucket failed: {e}"))?;
+
+        Ok(())
+    }
+
+    /// The prefix is applied to the physical bucket, so the same guest
+    /// identifier lands in different stores for differently-prefixed policies.
+    #[tokio::test]
+    #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+    async fn test_prefix_separates_buckets() -> anyhow::Result<()> {
+        init_tracing();
+
+        let (_container, client) = start_nats_jetstream().await?;
+        let identifier = format!("kv-{}", uuid::Uuid::new_v4());
+
+        let mut policy = BucketPolicy::create_missing();
+        policy.prefix = "a-".to_string();
+        let a = NatsKeyValue::with_bucket_policy(&client, policy.clone());
+        policy.prefix = "b-".to_string();
+        let b = NatsKeyValue::with_bucket_policy(&client, policy);
+
+        let (a_bucket, _) = a
+            .open_bucket(&identifier)
+            .await
+            .map_err(|e| anyhow::anyhow!("open a failed: {e}"))?;
+        a_bucket
+            .put("greeting", bytes::Bytes::from_static(b"hello"))
+            .await
+            .map_err(|e| anyhow::anyhow!("put failed: {e}"))?;
+
+        let (b_bucket, _) = b
+            .open_bucket(&identifier)
+            .await
+            .map_err(|e| anyhow::anyhow!("open b failed: {e}"))?;
+        let value = b_bucket
+            .get("greeting")
+            .await
+            .map_err(|e| anyhow::anyhow!("get failed: {e}"))?;
+
+        assert!(
+            value.is_none(),
+            "the prefixed policies must not share a bucket"
+        );
+
+        Ok(())
+    }
+
+    /// Creation settings reach the bucket JetStream creates.
+    #[tokio::test]
+    #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+    async fn test_creation_settings_apply_to_new_bucket() -> anyhow::Result<()> {
+        init_tracing();
+
+        let (_container, client) = start_nats_jetstream().await?;
+        let identifier = format!("kv-{}", uuid::Uuid::new_v4());
+
+        let mut policy = BucketPolicy::create_missing();
+        policy.history = Some(5);
+        policy.max_age = Some(std::time::Duration::from_secs(3600));
+        let kv = NatsKeyValue::with_bucket_policy(&client, policy);
+
+        kv.open_bucket(&identifier)
+            .await
+            .map_err(|e| anyhow::anyhow!("open failed: {e}"))?;
+
+        let status = async_nats::jetstream::new(client.clone())
+            .get_key_value(&identifier)
+            .await
+            .map_err(|e| anyhow::anyhow!("get_key_value failed: {e}"))?
+            .status()
+            .await
+            .map_err(|e| anyhow::anyhow!("status failed: {e}"))?;
+
+        assert_eq!(status.history(), 5);
+        assert_eq!(status.max_age(), std::time::Duration::from_secs(3600));
 
         Ok(())
     }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
@@ -104,6 +104,10 @@ pub struct BucketPolicy {
     /// Prefix prepended to every physical bucket name. The namespacing knob:
     /// two hosts (or tenants) pointed at one NATS cluster can use distinct
     /// prefixes so identical guest identifiers do not collide.
+    ///
+    /// An embedder's prefix bounds what the interfaces under it can name —
+    /// [`BucketPolicy::from_config`] nests an interface's prefix inside it
+    /// rather than letting it be replaced.
     pub prefix: String,
     /// Pins this policy to one physical bucket: when set, every identifier a
     /// guest opens resolves to this bucket and the identifier is ignored. Use
@@ -130,21 +134,34 @@ pub struct BucketPolicy {
 /// bookkeeping. Capped because the names are guest-supplied — past the cap the
 /// set is cleared, which starts a fresh window rather than growing without
 /// bound or going permanently quiet.
-static REFUSED_BUCKETS: std::sync::LazyLock<Mutex<HashSet<String>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashSet::new()));
+static REFUSED_BUCKETS: std::sync::LazyLock<Mutex<RefusedBuckets>> =
+    std::sync::LazyLock::new(|| Mutex::new(RefusedBuckets::default()));
 
 /// How many distinct refused buckets are remembered before the set resets.
 const REFUSED_BUCKETS_CAP: usize = 256;
 
 /// Whether this is the first refusal for `physical`, and so the one that warns.
 fn first_refusal(physical: &str) -> bool {
-    let mut refused = REFUSED_BUCKETS
+    REFUSED_BUCKETS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if refused.len() >= REFUSED_BUCKETS_CAP {
-        refused.clear();
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .first_refusal(physical, REFUSED_BUCKETS_CAP)
+}
+
+/// The set behind [`first_refusal`], as a type so tests can drive their own
+/// rather than race each other through the process-global one.
+#[derive(Default)]
+struct RefusedBuckets {
+    seen: HashSet<String>,
+}
+
+impl RefusedBuckets {
+    fn first_refusal(&mut self, physical: &str, cap: usize) -> bool {
+        if self.seen.len() >= cap {
+            self.seen.clear();
+        }
+        self.seen.insert(physical.to_string())
     }
-    refused.insert(physical.to_string())
 }
 
 /// What an [`BucketPolicy::open`] did, for the caller to record. The physical
@@ -218,6 +235,13 @@ impl BucketPolicy {
     ///   inheriting it would silently collapse every named interface — a
     ///   `sessions` and a `cache` import alike — onto the embedder's single
     ///   bucket. An interface that wants a pin states it.
+    /// - `bucket_prefix` nests rather than replaces: an interface's prefix is
+    ///   appended to the embedder's. The embedder's prefix is what keeps one
+    ///   host's (or tenant's) buckets separate from another's, so an interface
+    ///   able to replace it could name a bucket outside its namespace — and
+    ///   `create = never` would not stop that, since the interesting buckets
+    ///   already exist. An interface can subdivide its namespace; it cannot
+    ///   leave it.
     pub fn from_config(config: &HashMap<String, String>, defaults: &Self) -> anyhow::Result<Self> {
         let create = match config.get(CREATE_KEY) {
             Some(v) => CreatePolicy::parse(v)?.clamped_to(defaults.create),
@@ -236,10 +260,17 @@ impl BucketPolicy {
         };
 
         Self {
-            prefix: config
-                .get(BUCKET_PREFIX_KEY)
-                .cloned()
-                .unwrap_or_else(|| defaults.prefix.clone()),
+            // Nested, not overridden: the embedder's prefix is the boundary an
+            // interface names within. An interface that replaced it could
+            // reach outside the namespace the host put it in.
+            prefix: format!(
+                "{}{}",
+                defaults.prefix,
+                config
+                    .get(BUCKET_PREFIX_KEY)
+                    .map(String::as_str)
+                    .unwrap_or("")
+            ),
             bucket: config.get(BUCKET_KEY).cloned(),
             create,
             replicas: parse_number(config, REPLICAS_KEY)?.or(defaults.replicas),
@@ -646,7 +677,8 @@ mod tests {
             &defaults,
         )
         .expect("must parse");
-        assert_eq!(overridden.prefix, "iface_");
+        // The prefix is the one key that nests instead of replacing.
+        assert_eq!(overridden.prefix, "host_iface_");
         assert_eq!(overridden.replicas, Some(1));
         // Untouched keys still come from the defaults.
         assert_eq!(overridden.create, CreatePolicy::Missing);
@@ -683,21 +715,30 @@ mod tests {
         );
 
         // Inheriting a value and spelling it out are the same policy, so they
-        // share a backend...
+        // share a backend. (The prefix is the exception — it nests, so
+        // restating it is a *different* namespace; see below.)
         let inherited = BucketPolicy {
             prefix: "host_".to_string(),
+            replicas: Some(3),
             ..BucketPolicy::default()
         };
         assert_eq!(
             fingerprint(&[], &inherited),
-            fingerprint(&[("bucket_prefix", "host_")], &inherited)
+            fingerprint(&[("replicas", "3")], &inherited)
         );
 
-        // ...while opting out of an inherited prefix with an empty value is a
-        // different policy, and must not be pooled with one that inherits it.
-        assert_ne!(
+        // An empty interface prefix nests to the same place as none at all,
+        // so those two *are* the same policy.
+        assert_eq!(
             fingerprint(&[], &inherited),
             fingerprint(&[("bucket_prefix", "")], &inherited)
+        );
+
+        // Subdividing the embedder's namespace is a different policy, and must
+        // not share a backend with one that does not.
+        assert_ne!(
+            fingerprint(&[], &inherited),
+            fingerprint(&[("bucket_prefix", "cache_")], &inherited)
         );
     }
 
@@ -716,6 +757,41 @@ mod tests {
             BucketPolicy::from_config(&config(&[("create", "missing")]), &host_withholds)
                 .expect("must parse");
         assert_eq!(attempted_escalation.create, CreatePolicy::Never);
+    }
+
+    /// An interface may subdivide the embedder's namespace but never leave it:
+    /// its prefix nests inside, and an empty one changes nothing.
+    #[test]
+    fn an_interface_prefix_nests_inside_the_embedder_s() {
+        let host = BucketPolicy {
+            prefix: "tenant-a_".to_string(),
+            ..BucketPolicy::default()
+        };
+
+        let nested = BucketPolicy::from_config(&config(&[("bucket_prefix", "cache_")]), &host)
+            .expect("must parse");
+        assert_eq!(nested.physical_name("counters"), "tenant-a_cache_counters");
+
+        // The escape attempts: an empty prefix, and another tenant's.
+        let emptied = BucketPolicy::from_config(&config(&[("bucket_prefix", "")]), &host)
+            .expect("must parse");
+        assert_eq!(emptied.physical_name("secrets"), "tenant-a_secrets");
+
+        let other = BucketPolicy::from_config(&config(&[("bucket_prefix", "tenant-b_")]), &host)
+            .expect("must parse");
+        assert_eq!(
+            other.physical_name("secrets"),
+            "tenant-a_tenant-b_secrets",
+            "an interface must not be able to name a bucket outside the embedder's prefix"
+        );
+
+        // A pin is bounded the same way: it names a bucket inside the prefix.
+        let pinned = BucketPolicy::from_config(&config(&[("bucket", "tenant-b_secrets")]), &host)
+            .expect("must parse");
+        assert_eq!(
+            pinned.physical_name("anything"),
+            "tenant-a_tenant-b_secrets"
+        );
     }
 
     /// A pin names one store, so it is never inherited: only the interface
@@ -748,30 +824,33 @@ mod tests {
     /// A refusal warns once per bucket, however many times a guest opens it.
     #[test]
     fn refusals_warn_once_per_bucket() {
-        // Unique names: the bookkeeping is process-wide, so a fixed name would
-        // couple this to whatever else has run.
-        let a = format!("bucket-a-{}", uuid::Uuid::new_v4());
-        let b = format!("bucket-b-{}", uuid::Uuid::new_v4());
-
-        assert!(first_refusal(&a), "the first refusal warns");
-        assert!(!first_refusal(&a), "a repeat does not");
-        assert!(first_refusal(&b), "a different bucket warns");
+        let mut refused = RefusedBuckets::default();
+        assert!(
+            refused.first_refusal("counters", REFUSED_BUCKETS_CAP),
+            "the first refusal warns"
+        );
+        assert!(
+            !refused.first_refusal("counters", REFUSED_BUCKETS_CAP),
+            "a repeat does not"
+        );
+        assert!(
+            refused.first_refusal("sessions", REFUSED_BUCKETS_CAP),
+            "a different bucket warns"
+        );
     }
 
     /// The set of remembered buckets is bounded: guests choose those names, so
     /// it must not grow forever.
     #[test]
     fn refusal_bookkeeping_is_bounded() {
-        for _ in 0..(REFUSED_BUCKETS_CAP + 10) {
-            first_refusal(&format!("bucket-{}", uuid::Uuid::new_v4()));
+        let mut refused = RefusedBuckets::default();
+        for i in 0..1_000 {
+            refused.first_refusal(&format!("bucket-{i}"), 8);
         }
-        let remembered = REFUSED_BUCKETS
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len();
         assert!(
-            remembered <= REFUSED_BUCKETS_CAP,
-            "remembered {remembered} buckets, cap is {REFUSED_BUCKETS_CAP}"
+            refused.seen.len() <= 8,
+            "remembered {} buckets, cap is 8",
+            refused.seen.len()
         );
     }
 

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
@@ -10,7 +10,8 @@
 //! store, and the policy — owned by whoever configured the host — decides which
 //! physical bucket that is and what its limits are.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use async_nats::jetstream::Context;
@@ -121,13 +122,43 @@ pub struct BucketPolicy {
     pub max_bytes: Option<i64>,
 }
 
+/// Buckets a refusal has already been logged for, so an operator gets one
+/// warning per missing bucket instead of one per guest call.
+///
+/// Deliberately not a field on [`BucketPolicy`]: the policy is a plain
+/// configuration value an embedder builds with a struct literal, and this is
+/// bookkeeping. Capped because the names are guest-supplied — past the cap the
+/// set is cleared, which starts a fresh window rather than growing without
+/// bound or going permanently quiet.
+static REFUSED_BUCKETS: std::sync::LazyLock<Mutex<HashSet<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// How many distinct refused buckets are remembered before the set resets.
+const REFUSED_BUCKETS_CAP: usize = 256;
+
+/// Whether this is the first refusal for `physical`, and so the one that warns.
+fn first_refusal(physical: &str) -> bool {
+    let mut refused = REFUSED_BUCKETS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if refused.len() >= REFUSED_BUCKETS_CAP {
+        refused.clear();
+    }
+    refused.insert(physical.to_string())
+}
+
 /// What an [`BucketPolicy::open`] did, for the caller to record. The physical
 /// bucket is on the span; this is what a metric needs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpenOutcome {
     /// The bucket was already there.
     Existing,
-    /// The bucket was missing and the policy created it.
+    /// The bucket was missing and this open took the create path.
+    ///
+    /// `create_key_value` is idempotent, which is what makes two opens racing
+    /// to create the same bucket both succeed — so in that race both report
+    /// `Created`. Read the metric as "opens that had to create", not as a
+    /// count of streams brought into existence.
     Created,
 }
 
@@ -228,6 +259,16 @@ impl BucketPolicy {
         // outside that can never name a real bucket, so every open would come
         // back as `no-such-store` — the least informative way possible to
         // learn about a typo in a host flag.
+        // An empty pin is not "no pin": it resolves every identifier to the
+        // prefix alone, which JetStream rejects, so every open would come back
+        // as `no-such-store` and the warning would name a bucket that cannot
+        // exist. Leave `bucket` unset to opt out.
+        if self.bucket.as_deref() == Some("") {
+            anyhow::bail!(
+                "keyvalue bucket name is empty; omit `{BUCKET_KEY}` to resolve each identifier \
+                 to its own bucket"
+            );
+        }
         for (key, value) in [
             (BUCKET_PREFIX_KEY, Some(self.prefix.as_str())),
             (BUCKET_KEY, self.bucket.as_deref()),
@@ -382,6 +423,7 @@ impl BucketPolicy {
     /// existed or was created here.
     #[instrument(
         name = "wasi.keyvalue.bucket.open",
+        level = "debug",
         skip(self, context),
         fields(
             %identifier,
@@ -406,13 +448,21 @@ impl BucketPolicy {
             }
             Err(OpenError::NoSuchStore) if self.create == CreatePolicy::Never => {
                 span.record("outcome", "refused");
-                tracing::warn!(
-                    bucket = %physical,
-                    %identifier,
-                    "keyvalue bucket does not exist and this host does not create buckets; \
-                     create it in JetStream, or start the host with \
-                     `--keyvalue-nats-create missing`"
-                );
+                // A guest may open per request, so warn once per bucket rather
+                // than once per call: the operator needs the name and the fix,
+                // not a line per request. `wasi_keyvalue_bucket_opens_total`
+                // with `outcome = refused` counts the rest.
+                if first_refusal(&physical) {
+                    tracing::warn!(
+                        bucket = %physical,
+                        %identifier,
+                        "keyvalue bucket does not exist and this host does not create buckets; \
+                         create it in JetStream, or start the host with \
+                         `--keyvalue-nats-create missing`"
+                    );
+                } else {
+                    tracing::debug!(bucket = %physical, %identifier, "keyvalue bucket refused");
+                }
                 Err(OpenError::NoSuchStore)
             }
             Err(OpenError::NoSuchStore) => {
@@ -679,6 +729,50 @@ mod tests {
         let policy = BucketPolicy::from_config(&config(&[]), &pinned_host).expect("must parse");
         assert_eq!(policy.bucket, None);
         assert_eq!(policy.physical_name("sessions"), "sessions");
+    }
+
+    /// An empty pin is refused rather than resolving every identifier to a
+    /// name JetStream cannot accept.
+    #[test]
+    fn an_empty_pin_is_refused() {
+        BucketPolicy::from_config(&config(&[("bucket", "")]), &BucketPolicy::default())
+            .expect_err("an empty bucket must be rejected");
+
+        // Omitting it is how you opt out, and an empty *prefix* stays valid.
+        let policy =
+            BucketPolicy::from_config(&config(&[("bucket_prefix", "")]), &BucketPolicy::default())
+                .expect("an empty prefix means no prefix");
+        assert_eq!(policy.physical_name("counters"), "counters");
+    }
+
+    /// A refusal warns once per bucket, however many times a guest opens it.
+    #[test]
+    fn refusals_warn_once_per_bucket() {
+        // Unique names: the bookkeeping is process-wide, so a fixed name would
+        // couple this to whatever else has run.
+        let a = format!("bucket-a-{}", uuid::Uuid::new_v4());
+        let b = format!("bucket-b-{}", uuid::Uuid::new_v4());
+
+        assert!(first_refusal(&a), "the first refusal warns");
+        assert!(!first_refusal(&a), "a repeat does not");
+        assert!(first_refusal(&b), "a different bucket warns");
+    }
+
+    /// The set of remembered buckets is bounded: guests choose those names, so
+    /// it must not grow forever.
+    #[test]
+    fn refusal_bookkeeping_is_bounded() {
+        for _ in 0..(REFUSED_BUCKETS_CAP + 10) {
+            first_refusal(&format!("bucket-{}", uuid::Uuid::new_v4()));
+        }
+        let remembered = REFUSED_BUCKETS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len();
+        assert!(
+            remembered <= REFUSED_BUCKETS_CAP,
+            "remembered {remembered} buckets, cap is {REFUSED_BUCKETS_CAP}"
+        );
     }
 
     /// A bucket name JetStream would never accept is refused where it was

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/nats_bucket.rs
@@ -1,0 +1,721 @@
+//! Bucket naming and creation policy for the NATS JetStream keyvalue backends.
+//!
+//! A guest passes a *logical* name to `wasi:keyvalue/store.open`. This module
+//! turns that name into the *physical* JetStream KV bucket the host reads and
+//! writes, and decides whether the host may create that bucket at all. Both the
+//! standard NATS plugin and the multiplexed NATS backend resolve their opens
+//! through it, so the two agree on naming and on who may create streams.
+//!
+//! The guest never supplies connection details or creation settings: it names a
+//! store, and the policy — owned by whoever configured the host — decides which
+//! physical bucket that is and what its limits are.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_nats::jetstream::Context;
+use async_nats::jetstream::kv::{Config, Store};
+use async_nats::jetstream::stream::StorageType;
+use tracing::instrument;
+
+/// `config` key holding an explicit physical bucket name.
+pub const BUCKET_KEY: &str = "bucket";
+/// `config` key holding a prefix applied to every physical bucket name.
+pub const BUCKET_PREFIX_KEY: &str = "bucket_prefix";
+/// `config` key holding the [`CreatePolicy`].
+pub const CREATE_KEY: &str = "create";
+/// `config` keys for the settings a created bucket is given.
+pub const REPLICAS_KEY: &str = "replicas";
+pub const STORAGE_KEY: &str = "storage";
+pub const MAX_AGE_KEY: &str = "max_age";
+pub const HISTORY_KEY: &str = "history";
+pub const MAX_BYTES_KEY: &str = "max_bytes";
+
+/// JetStream's ceiling on a KV bucket's per-key history.
+const MAX_HISTORY: i64 = 64;
+
+/// Whether the host may create a JetStream KV bucket that a guest opens.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CreatePolicy {
+    /// Open pre-existing buckets only. An identifier with no bucket behind it
+    /// is `no-such-store`, which makes the set of configured buckets an
+    /// allowlist: a guest cannot bring new JetStream streams into existence,
+    /// and the host's NATS credentials need no stream-create permission.
+    #[default]
+    Never,
+    /// Create the bucket on first open when it is missing, with the settings
+    /// on the [`BucketPolicy`].
+    Missing,
+}
+
+impl CreatePolicy {
+    /// Parse the `create` config value.
+    pub fn parse(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "never" => Ok(Self::Never),
+            "missing" => Ok(Self::Missing),
+            other => Err(anyhow::anyhow!(
+                "invalid keyvalue bucket create policy '{other}', expected 'never' or 'missing'"
+            )),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::Missing => "missing",
+        }
+    }
+
+    /// The policy in force when an interface asks for `self` under an
+    /// embedder's `ceiling`.
+    ///
+    /// An interface may tighten (ask for `never` on a host that allows
+    /// creation) but never loosen: a workload manifest cannot hand itself
+    /// stream-creation on a host whose operator withheld it.
+    pub fn clamped_to(self, ceiling: Self) -> Self {
+        match (self, ceiling) {
+            (Self::Missing, Self::Missing) => Self::Missing,
+            _ => Self::Never,
+        }
+    }
+}
+
+/// Parse the `storage` config value into a JetStream storage type.
+pub fn parse_storage(value: &str) -> anyhow::Result<StorageType> {
+    match value {
+        "file" => Ok(StorageType::File),
+        "memory" => Ok(StorageType::Memory),
+        other => Err(anyhow::anyhow!(
+            "invalid keyvalue bucket storage '{other}', expected 'file' or 'memory'"
+        )),
+    }
+}
+
+/// How a logical bucket identifier maps onto a JetStream KV bucket, and what
+/// that bucket looks like if the host is allowed to create it.
+///
+/// The defaults are the conservative ones: no name rewriting and
+/// [`CreatePolicy::Never`], so an unconfigured policy can only reach buckets
+/// that already exist.
+#[derive(Clone, Debug, Default)]
+pub struct BucketPolicy {
+    /// Prefix prepended to every physical bucket name. The namespacing knob:
+    /// two hosts (or tenants) pointed at one NATS cluster can use distinct
+    /// prefixes so identical guest identifiers do not collide.
+    pub prefix: String,
+    /// Pins this policy to one physical bucket: when set, every identifier a
+    /// guest opens resolves to this bucket and the identifier is ignored. Use
+    /// it to bind an import to an operator-chosen store; leave it unset to let
+    /// each identifier name its own bucket.
+    pub bucket: Option<String>,
+    /// Whether a missing bucket may be created.
+    pub create: CreatePolicy,
+    /// Settings applied to a bucket this policy creates. Unset fields keep
+    /// JetStream's own defaults, and none of them affect a bucket that already
+    /// exists.
+    pub replicas: Option<usize>,
+    pub storage: Option<StorageType>,
+    pub max_age: Option<Duration>,
+    pub history: Option<i64>,
+    pub max_bytes: Option<i64>,
+}
+
+/// What an [`BucketPolicy::open`] did, for the caller to record. The physical
+/// bucket is on the span; this is what a metric needs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenOutcome {
+    /// The bucket was already there.
+    Existing,
+    /// The bucket was missing and the policy created it.
+    Created,
+}
+
+impl OpenOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Existing => "existing",
+            Self::Created => "created",
+        }
+    }
+}
+
+/// Why an open failed. Kept separate from the WIT `store.error` so both the
+/// standard and multiplexed backends can map it into their own bindings.
+#[derive(Clone, Debug)]
+pub enum OpenError {
+    /// No bucket behind this identifier (and the policy does not allow
+    /// creating one).
+    NoSuchStore,
+    /// A real failure: transport, permissions, JetStream disabled, ...
+    Other(String),
+}
+
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSuchStore => write!(f, "no such store"),
+            Self::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl BucketPolicy {
+    /// A policy that creates missing buckets, with JetStream's default
+    /// settings. The development default: a guest's first `open` works with no
+    /// configuration at all.
+    pub fn create_missing() -> Self {
+        Self {
+            create: CreatePolicy::Missing,
+            ..Self::default()
+        }
+    }
+
+    /// Read a policy from a named host interface's `config`, falling back to
+    /// `defaults` key by key.
+    ///
+    /// `defaults` is what the embedder configured (a `wash dev` project's
+    /// `dev.wasi_keyvalue_nats`, a `wash host`'s `--keyvalue-nats-*` flags);
+    /// an interface that sets a key overrides it for itself alone. Two keys
+    /// are deliberately not plain overrides:
+    ///
+    /// - `create` is a ceiling, not a default: an interface may tighten it to
+    ///   `never`, but asking for `missing` on a host that withheld creation
+    ///   does not grant it. Otherwise a workload manifest could hand itself
+    ///   stream-creation the operator declined to give.
+    /// - `bucket` (the pin) is never inherited. A pin names one store, so
+    ///   inheriting it would silently collapse every named interface — a
+    ///   `sessions` and a `cache` import alike — onto the embedder's single
+    ///   bucket. An interface that wants a pin states it.
+    pub fn from_config(config: &HashMap<String, String>, defaults: &Self) -> anyhow::Result<Self> {
+        let create = match config.get(CREATE_KEY) {
+            Some(v) => CreatePolicy::parse(v)?.clamped_to(defaults.create),
+            None => defaults.create,
+        };
+        let storage = match config.get(STORAGE_KEY) {
+            Some(v) => Some(parse_storage(v)?),
+            None => defaults.storage,
+        };
+        let max_age = match config.get(MAX_AGE_KEY) {
+            Some(v) => Some(
+                humantime::parse_duration(v)
+                    .map_err(|e| anyhow::anyhow!("invalid keyvalue bucket max_age '{v}': {e}"))?,
+            ),
+            None => defaults.max_age,
+        };
+
+        Self {
+            prefix: config
+                .get(BUCKET_PREFIX_KEY)
+                .cloned()
+                .unwrap_or_else(|| defaults.prefix.clone()),
+            bucket: config.get(BUCKET_KEY).cloned(),
+            create,
+            replicas: parse_number(config, REPLICAS_KEY)?.or(defaults.replicas),
+            storage,
+            max_age,
+            history: parse_number(config, HISTORY_KEY)?.or(defaults.history),
+            max_bytes: parse_number(config, MAX_BYTES_KEY)?.or(defaults.max_bytes),
+        }
+        .validated()
+    }
+
+    /// Reject creation settings JetStream would refuse, so a bad value fails
+    /// where it was written — host startup, or a workload's bind — instead of
+    /// at some guest's first `open`.
+    pub fn validated(self) -> anyhow::Result<Self> {
+        // JetStream accepts `A-Za-z0-9_-` in a bucket name. A prefix or pin
+        // outside that can never name a real bucket, so every open would come
+        // back as `no-such-store` — the least informative way possible to
+        // learn about a typo in a host flag.
+        for (key, value) in [
+            (BUCKET_PREFIX_KEY, Some(self.prefix.as_str())),
+            (BUCKET_KEY, self.bucket.as_deref()),
+        ] {
+            if let Some(value) = value
+                && let Some(bad) = value
+                    .chars()
+                    .find(|c| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+            {
+                anyhow::bail!(
+                    "keyvalue bucket {key} '{value}' contains '{bad}'; JetStream bucket names \
+                     allow only letters, digits, '_' and '-'"
+                );
+            }
+        }
+        if let Some(replicas) = self.replicas
+            && replicas == 0
+        {
+            anyhow::bail!("keyvalue bucket replicas must be at least 1");
+        }
+        if let Some(history) = self.history
+            && !(1..=MAX_HISTORY).contains(&history)
+        {
+            anyhow::bail!("keyvalue bucket history must be between 1 and {MAX_HISTORY}");
+        }
+        if let Some(max_bytes) = self.max_bytes
+            && max_bytes < -1
+        {
+            anyhow::bail!("keyvalue bucket max_bytes must be -1 (unlimited) or greater");
+        }
+        Ok(self)
+    }
+
+    /// A fingerprint of the *resolved* policy, for pool keys.
+    ///
+    /// Taken after merging with the embedder's defaults, so two interfaces
+    /// share a pooled backend only when they truly resolve buckets the same
+    /// way — an interface that spells out what it inherits, or one that opts
+    /// out of an inherited prefix with an empty string, is not confused with a
+    /// neighbour that says nothing.
+    pub fn fingerprint(&self) -> String {
+        format!(
+            "{}\u{1}{}\u{1}{}\u{1}{:?}\u{1}{:?}\u{1}{:?}\u{1}{:?}\u{1}{:?}",
+            self.prefix,
+            self.bucket.as_deref().unwrap_or("\u{2}"),
+            self.create.as_str(),
+            self.replicas,
+            self.storage.map(|s| format!("{s:?}")),
+            self.max_age,
+            self.history,
+            self.max_bytes,
+        )
+    }
+
+    /// The physical JetStream bucket an identifier resolves to.
+    pub fn physical_name(&self, identifier: &str) -> String {
+        match &self.bucket {
+            Some(bucket) => format!("{}{bucket}", self.prefix),
+            None => format!("{}{identifier}", self.prefix),
+        }
+    }
+
+    /// The JetStream config a created bucket is given.
+    fn kv_config(&self, bucket: String) -> Config {
+        let mut config = Config {
+            bucket,
+            ..Default::default()
+        };
+        if let Some(replicas) = self.replicas {
+            config.num_replicas = replicas;
+        }
+        if let Some(storage) = self.storage {
+            config.storage = storage;
+        }
+        if let Some(max_age) = self.max_age {
+            config.max_age = max_age;
+        }
+        if let Some(history) = self.history {
+            config.history = history;
+        }
+        if let Some(max_bytes) = self.max_bytes {
+            config.max_bytes = max_bytes;
+        }
+        config
+    }
+
+    /// Look up an existing bucket by its physical name, without creating
+    /// anything. Every operation after `open` resolves through here, so a
+    /// bucket is only ever created by [`BucketPolicy::open`].
+    #[instrument(
+        name = "wasi.keyvalue.bucket.get",
+        level = "debug",
+        skip(self, context),
+        fields(bucket = %physical)
+    )]
+    pub async fn get(&self, context: &Context, physical: &str) -> Result<Store, OpenError> {
+        use async_nats::jetstream::ErrorCode;
+        use async_nats::jetstream::context::{
+            GetStreamError, GetStreamErrorKind, KeyValueErrorKind,
+        };
+        use std::error::Error as _;
+
+        context.get_key_value(physical).await.map_err(|e| {
+            let other = || OpenError::Other(format!("JetStream error: {e}"));
+            match e.kind() {
+                // An invalid name is never a real store.
+                KeyValueErrorKind::InvalidStoreName => OpenError::NoSuchStore,
+                // `GetBucket` wraps a `get_stream` failure. Only a stream the
+                // server reports as missing (or a name it would never accept)
+                // is absence. Every other outcome — a transport/timeout
+                // `Request` failure, JetStream disabled for the account, an
+                // account without `$JS.API.STREAM.INFO` permission — is a real
+                // error and must propagate: reporting those as `no-such-store`
+                // would tell an operator to go create a bucket when the actual
+                // fault is the connection, the account, or its permissions.
+                KeyValueErrorKind::GetBucket => {
+                    match e.source().and_then(|s| s.downcast_ref::<GetStreamError>()) {
+                        Some(g) => match g.kind() {
+                            GetStreamErrorKind::EmptyName
+                            | GetStreamErrorKind::InvalidStreamName => OpenError::NoSuchStore,
+                            GetStreamErrorKind::JetStream(api)
+                                if api.error_code() == ErrorCode::STREAM_NOT_FOUND =>
+                            {
+                                OpenError::NoSuchStore
+                            }
+                            GetStreamErrorKind::JetStream(_) | GetStreamErrorKind::Request => {
+                                other()
+                            }
+                        },
+                        // No `get_stream` failure underneath to classify.
+                        None => other(),
+                    }
+                }
+                // A JetStream/transport failure is a real error, not "not found".
+                KeyValueErrorKind::JetStream => other(),
+            }
+        })
+    }
+
+    /// Resolve `identifier` to its bucket, creating it when the policy allows
+    /// and it does not exist.
+    ///
+    /// The lookup comes first so an already-existing bucket is opened without
+    /// stream-create permission and without re-sending a config that would
+    /// conflict with how it was originally created. `create_key_value` is
+    /// idempotent for an identical config, so two opens racing to create the
+    /// same bucket both succeed.
+    ///
+    /// The span carries the mapping an operator otherwise cannot see: the
+    /// identifier the guest asked for, the physical bucket it resolved to, the
+    /// create policy in force, and — once known — whether the bucket already
+    /// existed or was created here.
+    #[instrument(
+        name = "wasi.keyvalue.bucket.open",
+        skip(self, context),
+        fields(
+            %identifier,
+            bucket = tracing::field::Empty,
+            create = self.create.as_str(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    pub async fn open(
+        &self,
+        context: &Context,
+        identifier: &str,
+    ) -> Result<(Store, OpenOutcome), OpenError> {
+        let span = tracing::Span::current();
+        let physical = self.physical_name(identifier);
+        span.record("bucket", physical.as_str());
+
+        match self.get(context, &physical).await {
+            Ok(store) => {
+                span.record("outcome", OpenOutcome::Existing.as_str());
+                Ok((store, OpenOutcome::Existing))
+            }
+            Err(OpenError::NoSuchStore) if self.create == CreatePolicy::Never => {
+                span.record("outcome", "refused");
+                tracing::warn!(
+                    bucket = %physical,
+                    %identifier,
+                    "keyvalue bucket does not exist and this host does not create buckets; \
+                     create it in JetStream, or start the host with \
+                     `--keyvalue-nats-create missing`"
+                );
+                Err(OpenError::NoSuchStore)
+            }
+            Err(OpenError::NoSuchStore) => {
+                let store = context
+                    .create_key_value(self.kv_config(physical.clone()))
+                    .await
+                    .map_err(|e| {
+                        tracing::error!(
+                            error = ?e,
+                            bucket = %physical,
+                            "failed to create keyvalue bucket in JetStream"
+                        );
+                        OpenError::Other(format!(
+                            "failed to create keyvalue bucket in JetStream({physical}): {e}"
+                        ))
+                    })?;
+                span.record("outcome", OpenOutcome::Created.as_str());
+                tracing::info!(bucket = %physical, "created keyvalue bucket in JetStream");
+                Ok((store, OpenOutcome::Created))
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn parse_number<T: std::str::FromStr>(
+    config: &HashMap<String, String>,
+    key: &str,
+) -> anyhow::Result<Option<T>>
+where
+    T::Err: std::fmt::Display,
+{
+    config
+        .get(key)
+        .map(|v| {
+            v.parse::<T>()
+                .map_err(|e| anyhow::anyhow!("invalid keyvalue bucket {key} '{v}': {e}"))
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    /// With no config, an identifier is its own bucket name.
+    #[test]
+    fn identifier_is_the_bucket_by_default() {
+        let policy = BucketPolicy::default();
+        assert_eq!(policy.physical_name("counters"), "counters");
+    }
+
+    /// A prefix namespaces every identifier.
+    #[test]
+    fn prefix_namespaces_identifiers() {
+        let policy = BucketPolicy::from_config(
+            &config(&[("bucket_prefix", "team-a_")]),
+            &BucketPolicy::default(),
+        )
+        .expect("must parse");
+        assert_eq!(policy.physical_name("counters"), "team-a_counters");
+    }
+
+    /// An explicit bucket pins the interface: the guest's identifier no longer
+    /// selects the store, and the prefix still applies.
+    #[test]
+    fn explicit_bucket_pins_and_is_prefixed() {
+        let policy = BucketPolicy::from_config(
+            &config(&[("bucket", "SESSIONS"), ("bucket_prefix", "prod_")]),
+            &BucketPolicy::default(),
+        )
+        .expect("must parse");
+        assert_eq!(policy.physical_name("counters"), "prod_SESSIONS");
+        assert_eq!(policy.physical_name(""), "prod_SESSIONS");
+    }
+
+    /// The create policy defaults to the caller's default and is overridden by
+    /// config.
+    #[test]
+    fn create_policy_defaults_and_overrides() {
+        let policy = BucketPolicy::from_config(&config(&[]), &BucketPolicy::create_missing())
+            .expect("must parse");
+        assert_eq!(policy.create, CreatePolicy::Missing);
+
+        let policy = BucketPolicy::from_config(
+            &config(&[("create", "never")]),
+            &BucketPolicy::create_missing(),
+        )
+        .expect("must parse");
+        assert_eq!(policy.create, CreatePolicy::Never);
+    }
+
+    /// Creation settings are parsed into their typed forms.
+    #[test]
+    fn creation_settings_are_parsed() {
+        let policy = BucketPolicy::from_config(
+            &config(&[
+                ("create", "missing"),
+                ("replicas", "3"),
+                ("storage", "memory"),
+                ("max_age", "24h"),
+                ("history", "5"),
+                ("max_bytes", "1048576"),
+            ]),
+            // A `missing` ceiling, since `create` may only be tightened.
+            &BucketPolicy::create_missing(),
+        )
+        .expect("must parse");
+
+        assert_eq!(policy.create, CreatePolicy::Missing);
+        assert_eq!(policy.replicas, Some(3));
+        assert!(matches!(policy.storage, Some(StorageType::Memory)));
+        assert_eq!(policy.max_age, Some(Duration::from_secs(24 * 60 * 60)));
+        assert_eq!(policy.history, Some(5));
+        assert_eq!(policy.max_bytes, Some(1_048_576));
+
+        let kv = policy.kv_config("b".to_string());
+        assert_eq!(kv.num_replicas, 3);
+        assert_eq!(kv.history, 5);
+        assert_eq!(kv.max_bytes, 1_048_576);
+        assert_eq!(kv.max_age, Duration::from_secs(24 * 60 * 60));
+    }
+
+    /// Unset creation settings leave JetStream's defaults alone.
+    #[test]
+    fn unset_creation_settings_keep_jetstream_defaults() {
+        let policy = BucketPolicy::create_missing();
+        let kv = policy.kv_config("b".to_string());
+        let defaults = Config {
+            bucket: "b".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(kv.num_replicas, defaults.num_replicas);
+        assert_eq!(kv.history, defaults.history);
+        assert_eq!(kv.max_bytes, defaults.max_bytes);
+        assert_eq!(kv.max_age, defaults.max_age);
+    }
+
+    /// A bad value is rejected at config time rather than at the first open.
+    #[test]
+    fn invalid_values_are_rejected() {
+        for pair in [
+            ("create", "sometimes"),
+            ("storage", "tape"),
+            ("max_age", "many moons"),
+            ("replicas", "three"),
+            ("max_bytes", "lots"),
+        ] {
+            BucketPolicy::from_config(&config(&[pair]), &BucketPolicy::default())
+                .expect_err(&format!("{pair:?} must be rejected"));
+        }
+    }
+
+    /// An interface inherits every key the embedder configured, and overrides
+    /// only the ones it sets itself.
+    #[test]
+    fn interface_config_overrides_defaults_key_by_key() {
+        let defaults = BucketPolicy {
+            prefix: "host_".to_string(),
+            create: CreatePolicy::Missing,
+            replicas: Some(3),
+            max_age: Some(Duration::from_secs(60)),
+            ..BucketPolicy::default()
+        };
+
+        let inherited = BucketPolicy::from_config(&config(&[]), &defaults).expect("must parse");
+        assert_eq!(inherited.prefix, "host_");
+        assert_eq!(inherited.create, CreatePolicy::Missing);
+        assert_eq!(inherited.replicas, Some(3));
+        assert_eq!(inherited.max_age, Some(Duration::from_secs(60)));
+
+        let overridden = BucketPolicy::from_config(
+            &config(&[("bucket_prefix", "iface_"), ("replicas", "1")]),
+            &defaults,
+        )
+        .expect("must parse");
+        assert_eq!(overridden.prefix, "iface_");
+        assert_eq!(overridden.replicas, Some(1));
+        // Untouched keys still come from the defaults.
+        assert_eq!(overridden.create, CreatePolicy::Missing);
+        assert_eq!(overridden.max_age, Some(Duration::from_secs(60)));
+    }
+
+    /// Policies that differ produce different fingerprints, so they never share
+    /// a pooled backend; identical ones collapse onto the same key.
+    #[test]
+    fn fingerprint_separates_distinct_policies() {
+        let fingerprint = |pairs: &[(&str, &str)], defaults: &BucketPolicy| {
+            BucketPolicy::from_config(&config(pairs), defaults)
+                .expect("must parse")
+                .fingerprint()
+        };
+        let none = BucketPolicy::default();
+
+        assert_ne!(
+            fingerprint(&[("bucket_prefix", "a_")], &none),
+            fingerprint(&[("bucket_prefix", "b_")], &none)
+        );
+        assert_eq!(
+            fingerprint(&[("bucket_prefix", "a_")], &none),
+            fingerprint(&[("bucket_prefix", "a_")], &none)
+        );
+
+        // A key that is not part of the policy does not split the pool.
+        assert_eq!(
+            fingerprint(&[("bucket_prefix", "a_")], &none),
+            fingerprint(
+                &[("bucket_prefix", "a_"), ("url", "nats://127.0.0.1:4222")],
+                &none
+            )
+        );
+
+        // Inheriting a value and spelling it out are the same policy, so they
+        // share a backend...
+        let inherited = BucketPolicy {
+            prefix: "host_".to_string(),
+            ..BucketPolicy::default()
+        };
+        assert_eq!(
+            fingerprint(&[], &inherited),
+            fingerprint(&[("bucket_prefix", "host_")], &inherited)
+        );
+
+        // ...while opting out of an inherited prefix with an empty value is a
+        // different policy, and must not be pooled with one that inherits it.
+        assert_ne!(
+            fingerprint(&[], &inherited),
+            fingerprint(&[("bucket_prefix", "")], &inherited)
+        );
+    }
+
+    /// An interface may tighten the embedder's create policy but never loosen
+    /// it: a workload cannot grant itself stream creation the host withheld.
+    #[test]
+    fn create_policy_is_a_ceiling() {
+        let host_allows = BucketPolicy::create_missing();
+        let host_withholds = BucketPolicy::default();
+
+        let tightened = BucketPolicy::from_config(&config(&[("create", "never")]), &host_allows)
+            .expect("must parse");
+        assert_eq!(tightened.create, CreatePolicy::Never);
+
+        let attempted_escalation =
+            BucketPolicy::from_config(&config(&[("create", "missing")]), &host_withholds)
+                .expect("must parse");
+        assert_eq!(attempted_escalation.create, CreatePolicy::Never);
+    }
+
+    /// A pin names one store, so it is never inherited: only the interface
+    /// that states it is pinned.
+    #[test]
+    fn pin_is_not_inherited() {
+        let pinned_host = BucketPolicy {
+            bucket: Some("SHARED".to_string()),
+            ..BucketPolicy::default()
+        };
+        let policy = BucketPolicy::from_config(&config(&[]), &pinned_host).expect("must parse");
+        assert_eq!(policy.bucket, None);
+        assert_eq!(policy.physical_name("sessions"), "sessions");
+    }
+
+    /// A bucket name JetStream would never accept is refused where it was
+    /// written, not turned into a permanent `no-such-store`.
+    #[test]
+    fn bucket_names_are_checked() {
+        for pair in [("bucket_prefix", "my.app_"), ("bucket", "my bucket")] {
+            BucketPolicy::from_config(&config(&[pair]), &BucketPolicy::default())
+                .expect_err(&format!("{pair:?} must be rejected"));
+        }
+
+        BucketPolicy::from_config(
+            &config(&[("bucket_prefix", "team-a_"), ("bucket", "APP_STORE")]),
+            &BucketPolicy::default(),
+        )
+        .expect("letters, digits, '_' and '-' must be accepted");
+    }
+
+    /// Settings JetStream would refuse fail where they were written.
+    #[test]
+    fn creation_settings_are_range_checked() {
+        for pair in [
+            ("replicas", "0"),
+            ("history", "0"),
+            ("history", "65"),
+            ("max_bytes", "-2"),
+        ] {
+            BucketPolicy::from_config(&config(&[pair]), &BucketPolicy::default())
+                .expect_err(&format!("{pair:?} must be rejected"));
+        }
+
+        // -1 is JetStream's "unlimited", and the top of the history range is
+        // allowed.
+        BucketPolicy::from_config(
+            &config(&[("max_bytes", "-1"), ("history", "64")]),
+            &BucketPolicy::default(),
+        )
+        .expect("the boundary values must be accepted");
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue/redis.rs
@@ -3,7 +3,10 @@
 //! This module implements `wasi:keyvalue@0.2.0-draft` interfaces using
 //! Redis as the backend storage.
 //! The `open` identifier is used as a key prefix (`{identifier}:{key}`) to
-//! namespace keys within a single Redis database.
+//! namespace keys within a single Redis database. The prefix is host-global,
+//! not per workload: two workloads that open the same identifier against one
+//! Redis database share the store. Give a deployment its own database (or its
+//! own server) to separate them.
 
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -101,6 +101,17 @@ impl ClusterHostBuilder {
         Ok(self)
     }
 
+    /// Registers the multiplexed plugin set with embedder defaults. See
+    /// [`crate::host::HostBuilder::with_multiplexed_plugins_with`].
+    #[cfg(feature = "wasm_component_model_implements")]
+    pub fn with_multiplexed_plugins_with(
+        mut self,
+        defaults: &crate::plugin::MultiplexedDefaults,
+    ) -> anyhow::Result<Self> {
+        self.host_builder = self.host_builder.with_multiplexed_plugins_with(defaults)?;
+        Ok(self)
+    }
+
     pub fn with_artifact_cleaner(mut self, frequency: Duration, max_age: Duration) -> Self {
         self.cleanup_interval = Some(frequency);
         self.cleanup_age = Some(max_age);

--- a/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
@@ -277,6 +277,64 @@ async fn nats_bucket_policy_governs_creation_and_naming() -> Result<()> {
     Ok(())
 }
 
+/// A bucket is created by `open` and by nothing else: an operation on an
+/// identifier that was never opened must not bring a stream into existence,
+/// however permissive the policy is.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn only_open_may_create_a_bucket() -> Result<()> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    let backend = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::with_defaults(
+            BucketPolicy::create_missing(),
+        )))
+        .build_registry(&HashSet::from([kv_iface("kv", "nats", &nats_url)]))
+        .await?
+        .get("kv")
+        .expect("kv routed")
+        .clone();
+
+    // Reads and writes against an unopened identifier fail as no-such-store...
+    for result in [
+        backend.get("never-opened", "k").await.err(),
+        backend.set("never-opened", "k", b"v".to_vec()).await.err(),
+        backend.increment("never-opened", "k", 1).await.err(),
+    ] {
+        assert!(
+            matches!(
+                result,
+                Some(wash_runtime::plugin::wasi_keyvalue::StoreError::NoSuchStore)
+            ),
+            "an operation on an unopened identifier must be no-such-store, got {result:?}"
+        );
+    }
+
+    // ...and left no stream behind.
+    async_nats::jetstream::new(async_nats::connect(&nats_url).await?)
+        .get_key_value("never-opened")
+        .await
+        .expect_err("no operation other than `open` may create a bucket");
+
+    // The same identifier works once opened, so the refusals above were the
+    // create path being withheld, not a broken backend.
+    backend.open("never-opened").await.map_err(err)?;
+    backend
+        .set("never-opened", "k", b"v".to_vec())
+        .await
+        .map_err(err)?;
+
+    Ok(())
+}
+
 /// `wasi:keyvalue` and `wasmcloud:keyvalue` resolve NATS buckets identically:
 /// both plugins register the same providers, so an embedder's bucket policy —
 /// a `wash host`'s `--keyvalue-nats-*` flags, a `wash dev` project's

--- a/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
@@ -20,7 +20,9 @@ use testcontainers::{
     runners::AsyncRunner,
 };
 
-use wash_runtime::plugin::wasi_keyvalue::{MultiplexedKeyValue, NatsProvider, RedisProvider};
+use wash_runtime::plugin::wasi_keyvalue::{
+    BucketPolicy, MultiplexedAsyncKeyValue, MultiplexedKeyValue, NatsProvider, RedisProvider,
+};
 use wash_runtime::wit::WitInterface;
 
 fn kv_iface(name: &str, backend: &str, url: &str) -> WitInterface {
@@ -82,7 +84,7 @@ async fn multiplexed_routes_to_redis_and_nats() -> Result<()> {
     // --- build the routing registry from two named host interfaces ---
     let plugin = MultiplexedKeyValue::new()
         .with_provider(Arc::new(RedisProvider))
-        .with_provider(Arc::new(NatsProvider));
+        .with_provider(Arc::new(NatsProvider::default()));
     let interfaces = HashSet::from([
         kv_iface("redis-kv", "redis", &redis_url),
         kv_iface("nats-kv", "nats", &nats_url),
@@ -155,6 +157,238 @@ async fn multiplexed_routes_to_redis_and_nats() -> Result<()> {
     assert_eq!(keys, vec!["ctr".to_string(), "k".to_string()]);
 
     Ok(())
+}
+
+/// The bucket policy on a named NATS interface: `create` decides whether an
+/// identifier may bring a bucket into existence, `bucket_prefix` decides which
+/// physical bucket it lands in, and `bucket` pins every identifier to one
+/// store.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn nats_bucket_policy_governs_creation_and_naming() -> Result<()> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // A host that withholds creation: its interfaces open only what exists,
+    // and one asking for `create: missing` does not get it.
+    let strict = kv_iface("strict", "nats", &nats_url);
+    let mut escalating = kv_iface("escalating", "nats", &nats_url);
+    escalating
+        .config
+        .insert("create".to_string(), "missing".to_string());
+
+    let withholding = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::default()))
+        .build_registry(&HashSet::from([strict, escalating]))
+        .await?;
+    let strict_be = withholding.get("strict").expect("strict routed").clone();
+    let escalating_be = withholding
+        .get("escalating")
+        .expect("escalating routed")
+        .clone();
+
+    for (name, backend) in [("strict", &strict_be), ("escalating", &escalating_be)] {
+        let e = backend
+            .open("counters")
+            .await
+            .expect_err("an absent bucket must not open on a host that withholds creation");
+        assert!(
+            matches!(
+                e,
+                wash_runtime::plugin::wasi_keyvalue::StoreError::NoSuchStore
+            ),
+            "{name}: expected no-such-store, got {e:?}"
+        );
+    }
+
+    // A host that allows creation, with a prefix and a pin.
+    let mut creating = kv_iface("creating", "nats", &nats_url);
+    creating
+        .config
+        .insert("bucket_prefix".to_string(), "team-a_".to_string());
+
+    let mut pinned = kv_iface("pinned", "nats", &nats_url);
+    pinned
+        .config
+        .insert("bucket".to_string(), "PINNED".to_string());
+
+    let allowing = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::with_defaults(
+            BucketPolicy::create_missing(),
+        )))
+        .build_registry(&HashSet::from([creating, pinned]))
+        .await?;
+    let creating_be = allowing.get("creating").expect("creating routed").clone();
+    let pinned_be = allowing.get("pinned").expect("pinned routed").clone();
+
+    // `create = missing` creates it, under the prefixed physical name.
+    creating_be.open("counters").await.map_err(err)?;
+    creating_be
+        .set("counters", "k", b"v".to_vec())
+        .await
+        .map_err(err)?;
+
+    let js = async_nats::jetstream::new(async_nats::connect(&nats_url).await?);
+    js.get_key_value("team-a_counters")
+        .await
+        .context("the prefixed bucket must exist")?;
+    js.get_key_value("counters")
+        .await
+        .expect_err("the unprefixed name must not have been created");
+
+    // Now that the physical bucket exists, the withholding host's interface
+    // reaches it by the name it was configured with — the prefix is what
+    // separates them, so an unprefixed `counters` is still absent.
+    strict_be
+        .open("team-a_counters")
+        .await
+        .map_err(err)
+        .context("an existing bucket must open under create = never")?;
+    assert_eq!(
+        strict_be
+            .get("team-a_counters", "k")
+            .await
+            .map_err(err)?
+            .as_deref(),
+        Some(b"v".as_slice())
+    );
+
+    // A pinned interface ignores the identifier entirely: both opens land in
+    // `PINNED`.
+    pinned_be.open("one").await.map_err(err)?;
+    pinned_be
+        .set("one", "k", b"pinned".to_vec())
+        .await
+        .map_err(err)?;
+    pinned_be.open("two").await.map_err(err)?;
+    assert_eq!(
+        pinned_be.get("two", "k").await.map_err(err)?.as_deref(),
+        Some(b"pinned".as_slice()),
+        "a pinned policy must resolve every identifier to one bucket"
+    );
+
+    Ok(())
+}
+
+/// `wasi:keyvalue` and `wasmcloud:keyvalue` resolve NATS buckets identically:
+/// both plugins register the same providers, so an embedder's bucket policy —
+/// a `wash host`'s `--keyvalue-nats-*` flags, a `wash dev` project's
+/// `dev.wasi_keyvalue_nats` — reaches a named import of either package, and an
+/// interface still overrides it key by key.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn embedder_defaults_reach_both_keyvalue_packages() -> Result<()> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // What an embedder configured: create missing buckets, under a prefix.
+    let defaults = BucketPolicy {
+        prefix: "host_".to_string(),
+        create: wash_runtime::plugin::wasi_keyvalue::CreatePolicy::Missing,
+        ..BucketPolicy::default()
+    };
+
+    let wasi_kv = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::with_defaults(defaults.clone())));
+    let wasmcloud_kv = MultiplexedAsyncKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::with_defaults(defaults.clone())));
+
+    // Neither interface configures a policy of its own, so both inherit.
+    let wasi_be = wasi_kv
+        .build_registry(&HashSet::from([kv_iface("kv", "nats", &nats_url)]))
+        .await?
+        .get("kv")
+        .expect("wasi:keyvalue routed")
+        .clone();
+    let wasmcloud_be = wasmcloud_kv
+        .build_registry(&HashSet::from([wasmcloud_kv_iface("kv", &nats_url)]))
+        .await?
+        .get("kv")
+        .expect("wasmcloud:keyvalue routed")
+        .clone();
+
+    // The inherited `create = missing` applies to both...
+    wasi_be.open("counters").await.map_err(err)?;
+    wasi_be
+        .set("counters", "k", b"v".to_vec())
+        .await
+        .map_err(err)?;
+    wasmcloud_be.open("counters").await.map_err(err)?;
+
+    // ...and so does the inherited prefix, which is why both land in the one
+    // physical bucket.
+    assert_eq!(
+        wasmcloud_be
+            .get("counters", "k")
+            .await
+            .map_err(err)?
+            .as_deref(),
+        Some(b"v".as_slice()),
+        "both packages must resolve the identifier to the same physical bucket"
+    );
+    let js = async_nats::jetstream::new(async_nats::connect(&nats_url).await?);
+    js.get_key_value("host_counters")
+        .await
+        .context("the prefixed bucket must exist")?;
+
+    // An interface that sets a key overrides the embedder for itself alone.
+    let mut own = wasmcloud_kv_iface("own", &nats_url);
+    own.config
+        .insert("bucket_prefix".to_string(), "iface_".to_string());
+    let own_be = wasmcloud_kv
+        .build_registry(&HashSet::from([own]))
+        .await?
+        .get("own")
+        .expect("own routed")
+        .clone();
+    own_be.open("counters").await.map_err(err)?;
+    assert_eq!(
+        own_be.get("counters", "k").await.map_err(err)?,
+        None,
+        "the overridden prefix must select a different bucket"
+    );
+    js.get_key_value("iface_counters")
+        .await
+        .context("the overriding interface's bucket must exist")?;
+
+    Ok(())
+}
+
+/// A named `wasmcloud:keyvalue` host interface — the async package's spelling
+/// of [`kv_iface`].
+fn wasmcloud_kv_iface(name: &str, url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: [
+            "store".to_string(),
+            "atomics".to_string(),
+            "cas".to_string(),
+            "batch".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        version: None,
+        config: HashMap::from([
+            ("backend".to_string(), "nats".to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: Some(name.to_string()),
+    }
 }
 
 /// The `KvBackend` ops return a WIT `store::Error` which isn't `std::error::Error`;

--- a/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
@@ -330,6 +330,36 @@ async fn a_deleted_bucket_reports_as_absent_and_a_recreated_one_is_empty() -> Re
         "a deleted bucket must report as absent, got {e:?}"
     );
 
+    // The batch and CAS surfaces classify the same way — a guest that only
+    // ever calls `get-many` must not be told a deleted bucket is a transport
+    // fault.
+    for e in [
+        backend
+            .get_many("counters", vec!["k".to_string()])
+            .await
+            .expect_err("get_many against a deleted bucket must fail"),
+        backend
+            .set_many("counters", vec![("k".to_string(), b"v".to_vec())])
+            .await
+            .expect_err("set_many against a deleted bucket must fail"),
+        backend
+            .delete_many("counters", vec!["k".to_string()])
+            .await
+            .expect_err("delete_many against a deleted bucket must fail"),
+        backend
+            .current("counters", "k")
+            .await
+            .expect_err("current against a deleted bucket must fail"),
+    ] {
+        assert!(
+            matches!(
+                e,
+                wash_runtime::plugin::wasi_keyvalue::StoreError::NoSuchStore
+            ),
+            "every operation must report a deleted bucket as absent, got {e:?}"
+        );
+    }
+
     // The stale handle is dropped with it, so a later open re-resolves rather
     // than reporting a bucket that is gone as present.
     backend
@@ -352,6 +382,61 @@ async fn a_deleted_bucket_reports_as_absent_and_a_recreated_one_is_empty() -> Re
     assert_eq!(
         backend.get("counters", "k").await.map_err(err)?,
         Some(b"again".to_vec())
+    );
+
+    Ok(())
+}
+
+/// `open` re-resolves rather than answering from a cached handle: a bucket
+/// deleted after it was opened must not keep reporting as present, whichever
+/// call the guest makes first.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn open_does_not_report_a_deleted_bucket_as_present() -> Result<()> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+    let js = async_nats::jetstream::new(async_nats::connect(&nats_url).await?);
+
+    // `create = never`, so a re-open cannot paper over the deletion by
+    // recreating the bucket.
+    js.create_key_value(async_nats::jetstream::kv::Config {
+        bucket: "counters".to_string(),
+        ..Default::default()
+    })
+    .await
+    .context("failed to create the bucket")?;
+
+    let backend = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::default()))
+        .build_registry(&HashSet::from([kv_iface("kv", "nats", &nats_url)]))
+        .await?
+        .get("kv")
+        .expect("kv routed")
+        .clone();
+
+    backend.open("counters").await.map_err(err)?;
+    js.delete_key_value("counters")
+        .await
+        .context("failed to delete the bucket")?;
+
+    // No operation in between to evict the handle: `open` itself must notice.
+    let e = backend
+        .open("counters")
+        .await
+        .expect_err("re-opening a deleted bucket must fail");
+    assert!(
+        matches!(
+            e,
+            wash_runtime::plugin::wasi_keyvalue::StoreError::NoSuchStore
+        ),
+        "expected no-such-store, got {e:?}"
     );
 
     Ok(())
@@ -483,7 +568,8 @@ async fn embedder_defaults_reach_both_keyvalue_packages() -> Result<()> {
         .await
         .context("the prefixed bucket must exist")?;
 
-    // An interface that sets a key overrides the embedder for itself alone.
+    // An interface that sets a prefix subdivides the embedder's namespace for
+    // itself alone — and stays inside it.
     let mut own = wasmcloud_kv_iface("own", &nats_url);
     own.config
         .insert("bucket_prefix".to_string(), "iface_".to_string());
@@ -497,11 +583,14 @@ async fn embedder_defaults_reach_both_keyvalue_packages() -> Result<()> {
     assert_eq!(
         own_be.get("counters", "k").await.map_err(err)?,
         None,
-        "the overridden prefix must select a different bucket"
+        "the interface's own prefix must select a different bucket"
     );
+    js.get_key_value("host_iface_counters")
+        .await
+        .context("the interface's bucket must nest inside the embedder's prefix")?;
     js.get_key_value("iface_counters")
         .await
-        .context("the overriding interface's bucket must exist")?;
+        .expect_err("an interface must not name a bucket outside the embedder's prefix");
 
     Ok(())
 }

--- a/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
+++ b/crates/wash-runtime/tests/integration_keyvalue_multiplexed.rs
@@ -277,6 +277,86 @@ async fn nats_bucket_policy_governs_creation_and_naming() -> Result<()> {
     Ok(())
 }
 
+/// A bucket deleted out of band reports as `no-such-store`, not as a transport
+/// error, and one recreated under the same name is simply an empty bucket.
+///
+/// A cached handle is a snapshot, so without classification an operation
+/// against a deleted stream surfaces as an opaque `Other` and the guest cannot
+/// tell an absent store from a broken connection.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_deleted_bucket_reports_as_absent_and_a_recreated_one_is_empty() -> Result<()> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_port = nats.get_host_port_ipv4(4222).await?;
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+    let js = async_nats::jetstream::new(async_nats::connect(&nats_url).await?);
+
+    let backend = MultiplexedKeyValue::new()
+        .with_provider(Arc::new(NatsProvider::with_defaults(
+            BucketPolicy::create_missing(),
+        )))
+        .build_registry(&HashSet::from([kv_iface("kv", "nats", &nats_url)]))
+        .await?
+        .get("kv")
+        .expect("kv routed")
+        .clone();
+
+    backend.open("counters").await.map_err(err)?;
+    backend
+        .set("counters", "k", b"v".to_vec())
+        .await
+        .map_err(err)?;
+
+    // The handle is now cached. Delete the bucket underneath it.
+    js.delete_key_value("counters")
+        .await
+        .context("failed to delete the bucket")?;
+
+    let e = backend
+        .get("counters", "k")
+        .await
+        .expect_err("an operation against a deleted bucket must fail");
+    assert!(
+        matches!(
+            e,
+            wash_runtime::plugin::wasi_keyvalue::StoreError::NoSuchStore
+        ),
+        "a deleted bucket must report as absent, got {e:?}"
+    );
+
+    // The stale handle is dropped with it, so a later open re-resolves rather
+    // than reporting a bucket that is gone as present.
+    backend
+        .open("counters")
+        .await
+        .map_err(err)
+        .context("create = missing must recreate the bucket on the next open")?;
+
+    // Recreated under the same name: an empty bucket, not an error and not the
+    // old contents.
+    assert_eq!(
+        backend.get("counters", "k").await.map_err(err)?,
+        None,
+        "a recreated bucket must be empty"
+    );
+    backend
+        .set("counters", "k", b"again".to_vec())
+        .await
+        .map_err(err)?;
+    assert_eq!(
+        backend.get("counters", "k").await.map_err(err)?,
+        Some(b"again".to_vec())
+    );
+
+    Ok(())
+}
+
 /// A bucket is created by `open` and by nothing else: an operation on an
 /// identifier that was never opened must not bring a stream into existence,
 /// however permissive the policy is.

--- a/crates/wash-runtime/tests/integration_nats_keyvalue_policy.rs
+++ b/crates/wash-runtime/tests/integration_nats_keyvalue_policy.rs
@@ -1,0 +1,321 @@
+#![cfg(feature = "wasm_component_model_implements")]
+//! End-to-end bucket policy: a **real guest** opening a store over HTTP, on a
+//! host backed by a **real NATS JetStream**.
+//!
+//! The unit and backend tests exercise the policy through Rust APIs. These go
+//! the whole way — guest `wasi:keyvalue/store.open` (and the async
+//! `wasmcloud:keyvalue` equivalent) through the host bindings, the plugin, the
+//! policy, and JetStream — because that is the path an operator's flags
+//! actually govern:
+//!
+//! * `create = never` must reach the guest as an error, not a created bucket;
+//! * `create = missing` must create the *prefixed* bucket and nothing else;
+//! * a bucket that already exists must open under `never` on a later host,
+//!   which is the upgrade path for a deployment that pre-creates its buckets;
+//! * `wasmcloud:keyvalue` must behave identically, since it shares the
+//!   providers.
+//!
+//! Requires Docker (NATS with JetStream); marked `#[ignore]`, so it runs under
+//! `cargo test --include-ignored` (CI's Linux leg) and not a plain `cargo test`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, Ingress},
+    },
+    plugin::wasi_keyvalue::{
+        BucketPolicy, CreatePolicy, MultiplexedAsyncKeyValue, NatsKeyValue, NatsProvider,
+    },
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+mod common;
+use common::http_incoming_handler_interface;
+
+/// Opens `wasi:keyvalue` bucket "counter" and returns the incremented count.
+const KEYVALUE_COUNTER_WASM: &[u8] = include_bytes!("wasm/keyvalue_counter.wasm");
+/// Opens async `wasmcloud:keyvalue` bucket "default-kv" and echoes a value.
+const KEYVALUE_DEFAULT_P3_WASM: &[u8] = include_bytes!("wasm/keyvalue_default_p3.wasm");
+
+/// The prefix under test: every bucket these hosts touch must land under it.
+const PREFIX: &str = "e2e-";
+
+async fn start_jetstream() -> Result<(ContainerAsync<GenericImage>, String)> {
+    let container = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let port = container.get_host_port_ipv4(4222).await?;
+    Ok((container, format!("nats://127.0.0.1:{port}")))
+}
+
+fn wasi_kv_iface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string(), "atomics".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("0.2.0-draft").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+/// An unnamed async `wasmcloud:keyvalue` interface pointed at NATS: the
+/// workload's default route, so the guest's plain import lands on it.
+fn wasmcloud_kv_iface(url: &str) -> WitInterface {
+    WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "keyvalue".to_string(),
+        interfaces: ["store".to_string(), "atomics".to_string()]
+            .into_iter()
+            .collect(),
+        version: Some(semver::Version::parse("0.2.0").unwrap()),
+        config: HashMap::from([
+            ("backend".to_string(), "nats".to_string()),
+            ("url".to_string(), url.to_string()),
+        ]),
+        name: None,
+    }
+}
+
+fn workload(
+    name: &str,
+    wasm: &'static [u8],
+    host_interfaces: Vec<WitInterface>,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: format!("{name}.wasm"),
+                digest: None,
+                bytes: bytes::Bytes::from_static(wasm),
+                local_resources: LocalResources::default(),
+                pool_size: 1,
+                max_invocations: 100,
+                max_concurrency: 1,
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    }
+}
+
+/// One request to a host's DevRouter, returning the status and body.
+async fn request(addr: std::net::SocketAddr, host_header: &str) -> Result<(u16, String)> {
+    let response = timeout(
+        Duration::from_secs(15),
+        reqwest::Client::new()
+            .get(format!("http://{addr}/"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("request timed out")??;
+    let status = response.status().as_u16();
+    Ok((status, response.text().await?))
+}
+
+/// A host serving `wasi:keyvalue` from NATS under `policy`.
+async fn start_wasi_kv_host(
+    url: &str,
+    policy: BucketPolicy,
+    host_header: &str,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    let client = async_nats::connect(url).await?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
+    let host = HostBuilder::new()
+        .with_engine(Engine::builder().build()?)
+        .with_http_handler(Arc::new(ingress))
+        .with_plugin(Arc::new(NatsKeyValue::with_bucket_policy(&client, policy)))?
+        .build()?
+        .start()
+        .await
+        .context("failed to start host")?;
+
+    host.workload_start(workload(
+        "keyvalue-counter",
+        KEYVALUE_COUNTER_WASM,
+        vec![
+            http_incoming_handler_interface(host_header, None),
+            wasi_kv_iface(),
+        ],
+    ))
+    .await
+    .context("failed to start keyvalue-counter workload")?;
+
+    Ok((addr, host))
+}
+
+/// The whole policy, end to end, through a guest's `wasi:keyvalue` import.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn guest_open_honors_bucket_policy_over_jetstream() -> Result<()> {
+    let (_container, url) = start_jetstream().await?;
+    let js = async_nats::jetstream::new(async_nats::connect(&url).await?);
+
+    // --- create = never: the guest's open fails, and nothing is created ---
+    {
+        let (addr, host) = start_wasi_kv_host(&url, BucketPolicy::default(), "kv-never").await?;
+        let (status, body) = request(addr, "kv-never").await?;
+        assert_eq!(
+            status, 500,
+            "a host that does not create buckets must surface the failure to the guest, got body: {body}"
+        );
+        // The failure must be the policy refusing the open, not some unrelated
+        // fault dressed up as a 500.
+        assert!(
+            body.contains("open") && body.contains("NoSuchStore"),
+            "expected a no-such-store on open, got: {body}"
+        );
+        js.get_key_value("counter")
+            .await
+            .expect_err("no bucket may be created under create = never");
+        drop(host);
+    }
+
+    // --- create = missing + prefix: the prefixed bucket is created and used ---
+    let creating = BucketPolicy {
+        prefix: PREFIX.to_string(),
+        create: CreatePolicy::Missing,
+        ..BucketPolicy::default()
+    };
+    {
+        let (addr, host) = start_wasi_kv_host(&url, creating.clone(), "kv-missing").await?;
+
+        let (status, body) = request(addr, "kv-missing").await?;
+        assert_eq!(status, 200, "expected a counter, got: {body}");
+        assert_eq!(body, "1");
+        let (_, body) = request(addr, "kv-missing").await?;
+        assert_eq!(body, "2", "the counter must persist in JetStream");
+
+        js.get_key_value("e2e-counter")
+            .await
+            .context("the prefixed bucket must exist")?;
+        js.get_key_value("counter")
+            .await
+            .expect_err("the unprefixed name must not have been created");
+        drop(host);
+    }
+
+    // --- a later host that creates nothing still opens the existing bucket,
+    // and continues the same counter: the upgrade path for a deployment whose
+    // buckets are pre-created ---
+    {
+        let strict = BucketPolicy {
+            prefix: PREFIX.to_string(),
+            ..BucketPolicy::default()
+        };
+        let (addr, host) = start_wasi_kv_host(&url, strict, "kv-existing").await?;
+        let (status, body) = request(addr, "kv-existing").await?;
+        assert_eq!(
+            status, 200,
+            "an existing bucket must open under create = never, got: {body}"
+        );
+        assert_eq!(body, "3", "the counter must continue in the same bucket");
+        drop(host);
+    }
+
+    Ok(())
+}
+
+/// The same policy, through a real async `wasmcloud:keyvalue` guest: the two
+/// packages share the providers, so an operator's policy must govern both.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn async_wasmcloud_keyvalue_guest_honors_bucket_policy() -> Result<()> {
+    let (_container, url) = start_jetstream().await?;
+    let js = async_nats::jetstream::new(async_nats::connect(&url).await?);
+
+    let start = |policy: BucketPolicy, host_header: &'static str| {
+        let url = url.clone();
+        async move {
+            let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+            let addr = ingress.addr();
+            let host = HostBuilder::new()
+                .with_engine(Engine::builder().build()?)
+                .with_http_handler(Arc::new(ingress))
+                .with_plugin(Arc::new(
+                    MultiplexedAsyncKeyValue::new()
+                        .with_provider(Arc::new(NatsProvider::with_defaults(policy))),
+                ))?
+                .build()?
+                .start()
+                .await
+                .context("failed to start host")?;
+            host.workload_start(workload(
+                "keyvalue-default-p3",
+                KEYVALUE_DEFAULT_P3_WASM,
+                vec![
+                    http_incoming_handler_interface(host_header, None),
+                    wasmcloud_kv_iface(&url),
+                ],
+            ))
+            .await
+            .context("failed to start keyvalue-default-p3 workload")?;
+            anyhow::Ok((addr, host))
+        }
+    };
+
+    // A host that withholds creation refuses the guest's open.
+    let (addr, host) = start(BucketPolicy::default(), "wasmcloud-kv-never").await?;
+    let (status, body) = request(addr, "wasmcloud-kv-never").await?;
+    assert_eq!(
+        status, 500,
+        "create = never must reach an async guest as an error, got body: {body}"
+    );
+    assert!(
+        body.contains("open") && body.contains("NoSuchStore"),
+        "expected a no-such-store on open, got: {body}"
+    );
+    js.get_key_value("default-kv")
+        .await
+        .expect_err("no bucket may be created under create = never");
+    drop(host);
+
+    // One that allows it creates the prefixed bucket, exactly as the
+    // `wasi:keyvalue` path does.
+    let (addr, host) = start(
+        BucketPolicy {
+            prefix: PREFIX.to_string(),
+            create: CreatePolicy::Missing,
+            ..BucketPolicy::default()
+        },
+        "wasmcloud-kv-missing",
+    )
+    .await?;
+    let (status, body) = request(addr, "wasmcloud-kv-missing").await?;
+    assert_eq!(status, 200, "expected the guest's value, got: {body}");
+    assert_eq!(body, "woof from a plain p3 keyvalue guest");
+    js.get_key_value("e2e-default-kv")
+        .await
+        .context("the prefixed bucket must exist")?;
+    drop(host);
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_nats_keyvalue_policy.rs
+++ b/crates/wash-runtime/tests/integration_nats_keyvalue_policy.rs
@@ -244,6 +244,64 @@ async fn guest_open_honors_bucket_policy_over_jetstream() -> Result<()> {
     Ok(())
 }
 
+/// The path a CLI actually takes: the embedder's policy handed to
+/// [`HostBuilder::with_multiplexed_plugins_with`], rather than a provider
+/// constructed by hand.
+///
+/// `wash dev` and `wash host` register the multiplexed set this way, so this
+/// is what proves their `--keyvalue-nats-*` flags and `dev.wasi_keyvalue_nats`
+/// block reach an `(implements ..)` import at all.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn multiplexed_plugin_set_inherits_embedder_policy() -> Result<()> {
+    let (_container, url) = start_jetstream().await?;
+    let js = async_nats::jetstream::new(async_nats::connect(&url).await?);
+
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
+    let host = HostBuilder::new()
+        .with_engine(Engine::builder().build()?)
+        .with_http_handler(Arc::new(ingress))
+        .with_multiplexed_plugins_with(
+            &wash_runtime::plugin::MultiplexedDefaults::default().with_keyvalue_nats_bucket(
+                BucketPolicy {
+                    prefix: PREFIX.to_string(),
+                    create: CreatePolicy::Missing,
+                    ..BucketPolicy::default()
+                },
+            ),
+        )?
+        .build()?
+        .start()
+        .await
+        .context("failed to start host")?;
+
+    // The interface names its backend and URL; everything about *which* bucket
+    // and whether it may be created comes from the embedder.
+    host.workload_start(workload(
+        "keyvalue-default-p3",
+        KEYVALUE_DEFAULT_P3_WASM,
+        vec![
+            http_incoming_handler_interface("builder-defaults", None),
+            wasmcloud_kv_iface(&url),
+        ],
+    ))
+    .await
+    .context("failed to start keyvalue-default-p3 workload")?;
+
+    let (status, body) = request(addr, "builder-defaults").await?;
+    assert_eq!(status, 200, "expected the guest's value, got: {body}");
+    js.get_key_value("e2e-default-kv")
+        .await
+        .context("the embedder's prefix must have reached the multiplexed plugin set")?;
+    js.get_key_value("default-kv")
+        .await
+        .expect_err("the unprefixed name must not have been created");
+    drop(host);
+
+    Ok(())
+}
+
 /// The same policy, through a real async `wasmcloud:keyvalue` guest: the two
 /// packages share the providers, so an operator's policy must govern both.
 #[tokio::test]

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -261,8 +261,9 @@ impl CliCommand for DevCommand {
             let nats_client = async_nats::connect(nats_url.as_str())
                 .await
                 .context("failed to connect to NATS for keyvalue plugin")?;
+            let policy = dev_config.keyvalue_bucket_policy()?;
             host_builder = host_builder.with_plugin(Arc::new(
-                plugin::wasi_keyvalue::NatsKeyValue::new(&nats_client),
+                plugin::wasi_keyvalue::NatsKeyValue::with_bucket_policy(&nats_client, policy),
             ))?;
             debug!(url = %nats_url, "WASI KeyValue plugin registered with NATS backend");
         } else if let Some(keyvalue_path) = &dev_config.wasi_keyvalue_path {
@@ -274,8 +275,10 @@ impl CliCommand for DevCommand {
                 "WASI KeyValue plugin registered with filesystem backend"
             );
         } else if let Some(client) = &data_nats_client {
-            host_builder = host_builder
-                .with_plugin(Arc::new(plugin::wasi_keyvalue::NatsKeyValue::new(client)))?;
+            let policy = dev_config.keyvalue_bucket_policy()?;
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasi_keyvalue::NatsKeyValue::with_bucket_policy(client, policy),
+            ))?;
             debug!("WASI KeyValue plugin registered with NATS backend (data_nats_url)");
         } else {
             host_builder = host_builder
@@ -285,7 +288,13 @@ impl CliCommand for DevCommand {
 
         #[cfg(feature = "wasm_component_model_implements")]
         {
-            host_builder = host_builder.with_multiplexed_plugins()?;
+            // The same bucket policy the standard keyvalue plugin got, so a
+            // `(implements ..)` import — `wasi:keyvalue` or `wasmcloud:keyvalue`
+            // — resolves NATS buckets the way this project configured.
+            host_builder = host_builder.with_multiplexed_plugins_with(
+                &wash_runtime::plugin::MultiplexedDefaults::default()
+                    .with_keyvalue_nats_bucket(dev_config.keyvalue_bucket_policy()?),
+            )?;
             debug!("multiplexed plugins registered (implements)");
         }
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -330,6 +330,54 @@ pub struct HostCommand {
     #[arg(long = "deny-private-ranges", default_value_t = false)]
     pub deny_private_ranges: bool,
 
+    /// Whether a `wasi:keyvalue` bucket a workload opens may be created in
+    /// JetStream.
+    ///
+    /// `never` (the default) opens only buckets that already exist, so the
+    /// buckets an operator declares are the whole allowlist. It is a ceiling,
+    /// not a default: a workload's `(implements ..)` interface may tighten it
+    /// to `never`, but cannot grant itself creation this host withheld.
+    /// `missing` creates a bucket on first open, using the settings below.
+    #[arg(long = "keyvalue-nats-create", value_enum, default_value = "never")]
+    pub keyvalue_nats_create: KeyvalueCreateMode,
+
+    /// Pin the plain (unlabeled) `wasi:keyvalue` import to this one JetStream
+    /// bucket, ignoring the name the workload passes.
+    ///
+    /// A pin names a single store, so it is not inherited by a workload's
+    /// `(implements ..)` interfaces — each of those states its own `bucket`,
+    /// or resolves its identifiers by name. The operator's controls that *do*
+    /// reach them are `--keyvalue-nats-bucket-prefix`, which bounds the names
+    /// they can reach, and `--keyvalue-nats-create`, which they cannot loosen.
+    #[arg(long = "keyvalue-nats-bucket")]
+    pub keyvalue_nats_bucket: Option<String>,
+
+    /// Prefix prepended to every JetStream bucket name, to namespace this
+    /// host's buckets away from another's on a shared NATS cluster.
+    #[arg(long = "keyvalue-nats-bucket-prefix")]
+    pub keyvalue_nats_bucket_prefix: Option<String>,
+
+    /// Replicas for a keyvalue bucket this host creates.
+    #[arg(long = "keyvalue-nats-replicas")]
+    pub keyvalue_nats_replicas: Option<usize>,
+
+    /// Storage for a keyvalue bucket this host creates.
+    #[arg(long = "keyvalue-nats-storage", value_enum)]
+    pub keyvalue_nats_storage: Option<KeyvalueStorageType>,
+
+    /// Maximum age of an entry in a keyvalue bucket this host creates, e.g.
+    /// `24h`.
+    #[arg(long = "keyvalue-nats-max-age", value_parser = humantime::parse_duration)]
+    pub keyvalue_nats_max_age: Option<Duration>,
+
+    /// Historical entries kept per key in a keyvalue bucket this host creates.
+    #[arg(long = "keyvalue-nats-history")]
+    pub keyvalue_nats_history: Option<i64>,
+
+    /// Size ceiling, in bytes, for a keyvalue bucket this host creates.
+    #[arg(long = "keyvalue-nats-max-bytes")]
+    pub keyvalue_nats_max_bytes: Option<i64>,
+
     /// Enable additional wasm proposals on the engine. Accepts a comma-separated
     /// list and/or repeated flags, e.g. `--wasm-proposal gc,threads`. Accepted
     /// names: component-model-async, component-model-map, gc,
@@ -407,6 +455,29 @@ fn host_plugin_registry_credentials(
         (Some(user), Some(password)) => Some((user.to_string(), password.to_string())),
         (None, None) => None,
         (Some(_), None) | (None, Some(_)) => None,
+    }
+}
+
+impl HostCommand {
+    /// The NATS keyvalue bucket policy these flags ask for.
+    ///
+    /// A host defaults to `create = never`: the buckets an operator declared
+    /// are the only ones reachable, so a workload's `open` identifier cannot
+    /// create JetStream streams and the host's NATS credentials need no
+    /// stream-create permission.
+    fn keyvalue_bucket_policy(&self) -> anyhow::Result<plugin::wasi_keyvalue::BucketPolicy> {
+        plugin::wasi_keyvalue::BucketPolicy {
+            prefix: self.keyvalue_nats_bucket_prefix.clone().unwrap_or_default(),
+            bucket: self.keyvalue_nats_bucket.clone(),
+            create: self.keyvalue_nats_create.into(),
+            replicas: self.keyvalue_nats_replicas,
+            storage: self.keyvalue_nats_storage.map(Into::into),
+            max_age: self.keyvalue_nats_max_age,
+            history: self.keyvalue_nats_history,
+            max_bytes: self.keyvalue_nats_max_bytes,
+        }
+        .validated()
+        .context("invalid --keyvalue-nats-* value")
     }
 }
 
@@ -524,6 +595,18 @@ impl CliCommand for HostCommand {
             engine.total_core_instances(),
         )?;
 
+        // Resolved once: the standard keyvalue plugin and the multiplexed ones
+        // must agree on how a bucket identifier resolves.
+        let keyvalue_bucket_policy = self.keyvalue_bucket_policy()?;
+        // Stated at startup because it decides whether a workload's `open` can
+        // succeed at all, and the default declines to create buckets.
+        info!(
+            create = keyvalue_bucket_policy.create.as_str(),
+            bucket_prefix = %keyvalue_bucket_policy.prefix,
+            bucket = keyvalue_bucket_policy.bucket.as_deref().unwrap_or("<per identifier>"),
+            "keyvalue bucket policy resolved (see --keyvalue-nats-*)"
+        );
+
         let mut cluster_host_builder = wash_runtime::washlet::ClusterHostBuilder::default()
             .with_engine(engine.clone())
             .with_host_config(host_config)
@@ -545,14 +628,23 @@ impl CliCommand for HostCommand {
                     messaging_limits.clone(),
                 ),
             ))?
-            .with_plugin(Arc::new(plugin::wasi_keyvalue::NatsKeyValue::new(
-                &data_nats_client,
-            )))?
+            .with_plugin(Arc::new(
+                plugin::wasi_keyvalue::NatsKeyValue::with_bucket_policy(
+                    &data_nats_client,
+                    keyvalue_bucket_policy.clone(),
+                ),
+            ))?
             .with_meters(Meters::new(ctx.enable_meters()));
 
         #[cfg(feature = "wasm_component_model_implements")]
         {
-            cluster_host_builder = cluster_host_builder.with_multiplexed_plugins()?;
+            // The same policy the standard keyvalue plugin got, so the
+            // `--keyvalue-nats-*` flags govern `(implements ..)` imports of
+            // `wasi:keyvalue` and `wasmcloud:keyvalue` too.
+            cluster_host_builder = cluster_host_builder.with_multiplexed_plugins_with(
+                &plugin::MultiplexedDefaults::default()
+                    .with_keyvalue_nats_bucket(keyvalue_bucket_policy),
+            )?;
         }
 
         if let Some(postgres_url) = &self.postgres_url {
@@ -738,6 +830,41 @@ mod tests {
         // credentials — never a basic auth with an empty half.
         assert_eq!(host_plugin_registry_credentials(Some("user"), None), None);
         assert_eq!(host_plugin_registry_credentials(None, Some("pass")), None);
+    }
+}
+
+/// CLI spelling of [`wash_runtime::plugin::wasi_keyvalue::CreatePolicy`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum KeyvalueCreateMode {
+    /// Open only buckets that already exist; anything else is `no-such-store`.
+    #[default]
+    Never,
+    /// Create a bucket on first open when it is missing.
+    Missing,
+}
+
+impl From<KeyvalueCreateMode> for wash_runtime::plugin::wasi_keyvalue::CreatePolicy {
+    fn from(mode: KeyvalueCreateMode) -> Self {
+        match mode {
+            KeyvalueCreateMode::Never => Self::Never,
+            KeyvalueCreateMode::Missing => Self::Missing,
+        }
+    }
+}
+
+/// CLI spelling of JetStream's storage backing for a created bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum KeyvalueStorageType {
+    File,
+    Memory,
+}
+
+impl From<KeyvalueStorageType> for async_nats::jetstream::stream::StorageType {
+    fn from(storage: KeyvalueStorageType) -> Self {
+        match storage {
+            KeyvalueStorageType::File => Self::File,
+            KeyvalueStorageType::Memory => Self::Memory,
+        }
     }
 }
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -338,46 +338,64 @@ pub struct HostCommand {
     /// not a default: a workload's `(implements ..)` interface may tighten it
     /// to `never`, but cannot grant itself creation this host withheld.
     /// `missing` creates a bucket on first open, using the settings below.
-    #[arg(long = "keyvalue-nats-create", value_enum, default_value = "never")]
+    #[arg(
+        long = "keyvalue-nats-create",
+        env = "WASH_KEYVALUE_NATS_CREATE",
+        value_enum,
+        default_value = "never"
+    )]
     pub keyvalue_nats_create: KeyvalueCreateMode,
 
     /// Pin the plain (unlabeled) `wasi:keyvalue` import to this one JetStream
     /// bucket, ignoring the name the workload passes.
     ///
-    /// A pin names a single store, so it is not inherited by a workload's
-    /// `(implements ..)` interfaces — each of those states its own `bucket`,
-    /// or resolves its identifiers by name. The operator's controls that *do*
-    /// reach them are `--keyvalue-nats-bucket-prefix`, which bounds the names
-    /// they can reach, and `--keyvalue-nats-create`, which they cannot loosen.
-    #[arg(long = "keyvalue-nats-bucket")]
+    /// A pin names a single store, so it reaches only the standard NATS
+    /// keyvalue plugin — not an import a workload routes through a configured
+    /// backend, whether it is `(implements ..)`-named or an unnamed interface
+    /// declaring `backend: nats`. Those state their own `bucket`, or resolve
+    /// each identifier by name. The operator's controls that *do* reach them
+    /// are `--keyvalue-nats-bucket-prefix`, which bounds the names they can
+    /// reach, and `--keyvalue-nats-create`, which they cannot loosen.
+    #[arg(long = "keyvalue-nats-bucket", env = "WASH_KEYVALUE_NATS_BUCKET")]
     pub keyvalue_nats_bucket: Option<String>,
 
     /// Prefix prepended to every JetStream bucket name, to namespace this
     /// host's buckets away from another's on a shared NATS cluster.
-    #[arg(long = "keyvalue-nats-bucket-prefix")]
+    #[arg(
+        long = "keyvalue-nats-bucket-prefix",
+        env = "WASH_KEYVALUE_NATS_BUCKET_PREFIX"
+    )]
     pub keyvalue_nats_bucket_prefix: Option<String>,
 
     /// Replicas for a keyvalue bucket this host creates.
-    #[arg(long = "keyvalue-nats-replicas")]
+    #[arg(long = "keyvalue-nats-replicas", env = "WASH_KEYVALUE_NATS_REPLICAS")]
     pub keyvalue_nats_replicas: Option<usize>,
 
     /// Storage for a keyvalue bucket this host creates.
-    #[arg(long = "keyvalue-nats-storage", value_enum)]
+    #[arg(
+        long = "keyvalue-nats-storage",
+        env = "WASH_KEYVALUE_NATS_STORAGE",
+        value_enum
+    )]
     pub keyvalue_nats_storage: Option<KeyvalueStorageType>,
 
     /// Maximum age of an entry in a keyvalue bucket this host creates, e.g.
     /// `24h`.
-    #[arg(long = "keyvalue-nats-max-age", value_parser = humantime::parse_duration)]
+    #[arg(long = "keyvalue-nats-max-age", env = "WASH_KEYVALUE_NATS_MAX_AGE", value_parser = humantime::parse_duration)]
     pub keyvalue_nats_max_age: Option<Duration>,
 
     /// Historical entries kept per key in a keyvalue bucket this host creates.
-    #[arg(long = "keyvalue-nats-history")]
+    #[arg(long = "keyvalue-nats-history", env = "WASH_KEYVALUE_NATS_HISTORY")]
     pub keyvalue_nats_history: Option<i64>,
 
     /// Size ceiling, in bytes, for a keyvalue bucket this host creates. `-1`
     /// is JetStream's "unlimited"; negative values are accepted here so it can
     /// be passed as `--keyvalue-nats-max-bytes -1` rather than only with `=`.
-    #[arg(long = "keyvalue-nats-max-bytes", allow_negative_numbers = true)]
+    #[arg(
+        long = "keyvalue-nats-max-bytes",
+        env = "WASH_KEYVALUE_NATS_MAX_BYTES",
+        allow_negative_numbers = true
+    )]
     pub keyvalue_nats_max_bytes: Option<i64>,
 
     /// Enable additional wasm proposals on the engine. Accepts a comma-separated

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -374,8 +374,10 @@ pub struct HostCommand {
     #[arg(long = "keyvalue-nats-history")]
     pub keyvalue_nats_history: Option<i64>,
 
-    /// Size ceiling, in bytes, for a keyvalue bucket this host creates.
-    #[arg(long = "keyvalue-nats-max-bytes")]
+    /// Size ceiling, in bytes, for a keyvalue bucket this host creates. `-1`
+    /// is JetStream's "unlimited"; negative values are accepted here so it can
+    /// be passed as `--keyvalue-nats-max-bytes -1` rather than only with `=`.
+    #[arg(long = "keyvalue-nats-max-bytes", allow_negative_numbers = true)]
     pub keyvalue_nats_max_bytes: Option<i64>,
 
     /// Enable additional wasm proposals on the engine. Accepts a comma-separated
@@ -809,7 +811,114 @@ impl CliCommand for HostCommand {
 
 #[cfg(all(test, feature = "host-component-plugins"))]
 mod tests {
-    use super::host_plugin_registry_credentials;
+    use clap::Parser;
+
+    use super::{HostCommand, host_plugin_registry_credentials};
+
+    /// `HostCommand` is an `Args` group, so give it a `Parser` to parse under.
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        host: HostCommand,
+    }
+
+    fn parse(args: &[&str]) -> HostCommand {
+        TestCli::parse_from(std::iter::once("wash-host").chain(args.iter().copied())).host
+    }
+
+    /// With no flags a host opens only buckets that already exist and rewrites
+    /// no names — the conservative default a deployment inherits.
+    #[test]
+    fn keyvalue_policy_defaults_to_create_never() {
+        let policy = parse(&[])
+            .keyvalue_bucket_policy()
+            .expect("the default flags must be a valid policy");
+        assert_eq!(
+            policy.create,
+            wash_runtime::plugin::wasi_keyvalue::CreatePolicy::Never
+        );
+        assert_eq!(policy.physical_name("counters"), "counters");
+    }
+
+    /// Every `--keyvalue-nats-*` flag reaches the policy.
+    #[test]
+    fn keyvalue_policy_reads_every_flag() {
+        let policy = parse(&[
+            "--keyvalue-nats-create",
+            "missing",
+            "--keyvalue-nats-bucket-prefix",
+            "team-a_",
+            "--keyvalue-nats-bucket",
+            "APP_STORE",
+            "--keyvalue-nats-replicas",
+            "3",
+            "--keyvalue-nats-storage",
+            "memory",
+            "--keyvalue-nats-max-age",
+            "24h",
+            "--keyvalue-nats-history",
+            "5",
+            "--keyvalue-nats-max-bytes",
+            "1048576",
+        ])
+        .keyvalue_bucket_policy()
+        .expect("must be a valid policy");
+
+        assert_eq!(
+            policy.create,
+            wash_runtime::plugin::wasi_keyvalue::CreatePolicy::Missing
+        );
+        assert_eq!(policy.physical_name("counters"), "team-a_APP_STORE");
+        assert_eq!(policy.replicas, Some(3));
+        assert!(matches!(
+            policy.storage,
+            Some(async_nats::jetstream::stream::StorageType::Memory)
+        ));
+        assert_eq!(policy.max_age, Some(std::time::Duration::from_secs(86400)));
+        assert_eq!(policy.history, Some(5));
+        assert_eq!(policy.max_bytes, Some(1_048_576));
+    }
+
+    /// A value JetStream would refuse fails while resolving the flags, so the
+    /// host does not start and then break at some guest's first `open`.
+    #[test]
+    fn keyvalue_policy_rejects_invalid_flags() {
+        for args in [
+            vec!["--keyvalue-nats-replicas", "0"],
+            vec!["--keyvalue-nats-history", "0"],
+            vec!["--keyvalue-nats-history", "65"],
+            vec!["--keyvalue-nats-max-bytes", "-2"],
+            vec!["--keyvalue-nats-bucket-prefix", "my.app_"],
+            vec!["--keyvalue-nats-bucket", "my bucket"],
+        ] {
+            parse(&args)
+                .keyvalue_bucket_policy()
+                .expect_err(&format!("{args:?} must be rejected"));
+        }
+    }
+
+    /// `-1` — JetStream's "unlimited" — must reach the policy rather than
+    /// being read as another flag.
+    #[test]
+    fn keyvalue_max_bytes_accepts_unlimited() {
+        let policy = parse(&["--keyvalue-nats-max-bytes", "-1"])
+            .keyvalue_bucket_policy()
+            .expect("-1 must be a valid max_bytes");
+        assert_eq!(policy.max_bytes, Some(-1));
+    }
+
+    /// An unparseable flag value is a clap error, not a policy error.
+    #[test]
+    fn keyvalue_flag_values_are_typed() {
+        for args in [
+            vec!["--keyvalue-nats-create", "sometimes"],
+            vec!["--keyvalue-nats-storage", "tape"],
+            vec!["--keyvalue-nats-max-age", "many moons"],
+        ] {
+            TestCli::try_parse_from(std::iter::once("wash-host").chain(args.iter().copied()))
+                .expect_err(&format!("{args:?} must not parse"));
+        }
+    }
 
     #[test]
     fn both_halves_yield_credentials() {

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -19,6 +19,7 @@ use wash_runtime::host::allowed_hosts::AllowedHost;
 use wash_runtime::host::allowed_ip_name::AllowedIpName;
 use wash_runtime::host::allowed_loopback::AllowedLoopbackPort;
 use wash_runtime::oci::OciPullPolicy;
+use wash_runtime::plugin::wasi_keyvalue::BucketPolicy;
 use wash_runtime::wit::WitInterface;
 
 use crate::{
@@ -759,6 +760,86 @@ pub fn wasmcloud_messaging_limits(
     Ok(limits)
 }
 
+/// How a guest's `wasi:keyvalue/store.open` identifier maps onto a JetStream KV
+/// bucket, and whether the host may create one.
+///
+/// The guest names a store; these keys decide which bucket that is. `create`
+/// is `missing` here — a `wash dev` loop against a bare JetStream server works
+/// with no configuration — while `wash host` defaults it to `never`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NatsKeyvalueConfig {
+    /// Pin the plain (unlabeled) import to this one physical bucket, ignoring
+    /// the name the guest passes. Not inherited by `(implements ..)`
+    /// interfaces — a pin names one store, so each states its own.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bucket: Option<String>,
+
+    /// Prefix prepended to every physical bucket name, to namespace one host's
+    /// buckets away from another's on a shared NATS cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bucket_prefix: Option<String>,
+
+    /// `missing` (default) creates a bucket on first open; `never` opens only
+    /// buckets that already exist and answers `no-such-store` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create: Option<String>,
+
+    /// Replicas for a bucket this host creates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replicas: Option<usize>,
+
+    /// Storage for a bucket this host creates: `file` or `memory`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage: Option<String>,
+
+    /// Maximum age of an entry in a bucket this host creates, as a humantime
+    /// duration such as `24h`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<String>,
+
+    /// Historical entries kept per key in a bucket this host creates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<i64>,
+
+    /// Size ceiling, in bytes, for a bucket this host creates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_bytes: Option<i64>,
+}
+
+impl NatsKeyvalueConfig {
+    /// The set keys, in the string form the runtime's policy parser reads, so
+    /// this config and an `(implements ..)` interface's config are parsed and
+    /// validated by exactly the same code.
+    fn policy_config(&self) -> HashMap<String, String> {
+        let mut config = HashMap::new();
+        if let Some(bucket) = &self.bucket {
+            config.insert("bucket".to_string(), bucket.clone());
+        }
+        if let Some(prefix) = &self.bucket_prefix {
+            config.insert("bucket_prefix".to_string(), prefix.clone());
+        }
+        if let Some(create) = &self.create {
+            config.insert("create".to_string(), create.clone());
+        }
+        if let Some(replicas) = self.replicas {
+            config.insert("replicas".to_string(), replicas.to_string());
+        }
+        if let Some(storage) = &self.storage {
+            config.insert("storage".to_string(), storage.clone());
+        }
+        if let Some(max_age) = &self.max_age {
+            config.insert("max_age".to_string(), max_age.clone());
+        }
+        if let Some(history) = self.history {
+            config.insert("history".to_string(), history.to_string());
+        }
+        if let Some(max_bytes) = self.max_bytes {
+            config.insert("max_bytes".to_string(), max_bytes.to_string());
+        }
+        config
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DevConfig {
     /// Command to run the component in dev mode
@@ -916,6 +997,11 @@ pub struct DevConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_keyvalue_nats_url: Option<String>,
 
+    /// Bucket naming and creation policy for the NATS keyvalue backend. Only
+    /// read when keyvalue resolves to NATS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wasi_keyvalue_nats: Option<NatsKeyvalueConfig>,
+
     /// Optional path for WASI blobstore filesystem storage. If not set, an in-memory store is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_blobstore_path: Option<PathBuf>,
@@ -982,6 +1068,25 @@ impl DevConfig {
         }
         .to_source("dev.service_file/service_image")
         .map(Some)
+    }
+
+    /// The NATS keyvalue bucket policy this dev config asks for.
+    ///
+    /// `wash dev` creates a missing bucket unless the config says otherwise,
+    /// so the first `open` of a new store works against a bare JetStream
+    /// server.
+    ///
+    /// # Errors
+    ///
+    /// Fails if any `dev.wasi_keyvalue_nats` value is malformed.
+    pub fn keyvalue_bucket_policy(&self) -> Result<BucketPolicy> {
+        let config = self
+            .wasi_keyvalue_nats
+            .as_ref()
+            .map(NatsKeyvalueConfig::policy_config)
+            .unwrap_or_default();
+        BucketPolicy::from_config(&config, &BucketPolicy::create_missing())
+            .context("dev.wasi_keyvalue_nats is not a valid bucket policy")
     }
 
     pub fn validate(&self) -> Result<()> {
@@ -1065,6 +1170,10 @@ impl DevConfig {
         }
 
         if let Err(err) = self.service_source() {
+            errors.push(format!("{err:#}"));
+        }
+
+        if let Err(err) = self.keyvalue_bucket_policy() {
             errors.push(format!("{err:#}"));
         }
 
@@ -1371,6 +1480,8 @@ fn check_url_scheme(field: &str, value: &str, expected: &[&str], errors: &mut Ve
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
+
+    use wash_runtime::plugin::wasi_keyvalue::CreatePolicy;
 
     use super::*;
 
@@ -1691,6 +1802,57 @@ workload:
         };
         let err = cfg.validate().unwrap_err().to_string();
         assert!(err.contains("tls_key_path"));
+    }
+
+    /// With nothing configured, `wash dev` creates a missing bucket and leaves
+    /// the identifier alone, so a first `open` works against a bare JetStream.
+    #[test]
+    fn dev_keyvalue_policy_defaults_to_create_missing() {
+        let policy = DevConfig::default()
+            .keyvalue_bucket_policy()
+            .expect("the empty config must be a valid policy");
+        assert_eq!(policy.create, CreatePolicy::Missing);
+        assert_eq!(policy.physical_name("counters"), "counters");
+    }
+
+    /// The configured keys reach the policy.
+    #[test]
+    fn dev_keyvalue_policy_reads_config() {
+        let cfg = DevConfig {
+            wasi_keyvalue_nats: Some(NatsKeyvalueConfig {
+                create: Some("never".to_string()),
+                bucket_prefix: Some("team-a_".to_string()),
+                replicas: Some(3),
+                max_age: Some("24h".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let policy = cfg.keyvalue_bucket_policy().expect("must be valid");
+        assert_eq!(policy.create, CreatePolicy::Never);
+        assert_eq!(policy.physical_name("counters"), "team-a_counters");
+        assert_eq!(policy.replicas, Some(3));
+        assert_eq!(
+            policy.max_age,
+            Some(std::time::Duration::from_secs(24 * 60 * 60))
+        );
+    }
+
+    /// A malformed value fails validation rather than the first `open`.
+    #[test]
+    fn dev_keyvalue_policy_rejects_bad_values() {
+        let cfg = DevConfig {
+            wasi_keyvalue_nats: Some(NatsKeyvalueConfig {
+                create: Some("sometimes".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("dev.wasi_keyvalue_nats"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -1804,6 +1804,63 @@ workload:
         assert!(err.contains("tls_key_path"));
     }
 
+    /// Locks in the YAML contract a user writes in `.wash/config.yaml`. A
+    /// renamed or moved field would leave the block silently ignored, and a
+    /// `wash dev` loop would keep creating buckets under no prefix while the
+    /// project file says otherwise.
+    #[test]
+    fn dev_keyvalue_nats_deserializes_from_yaml() {
+        let yaml = r#"
+dev:
+  wasi_keyvalue_nats_url: nats://127.0.0.1:4222
+  wasi_keyvalue_nats:
+    create: never
+    bucket_prefix: my-app_
+    bucket: MY_APP_STORE
+    replicas: 3
+    storage: memory
+    max_age: 24h
+    history: 5
+    max_bytes: 1048576
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let policy = config
+            .dev()
+            .keyvalue_bucket_policy()
+            .expect("the YAML block must be a valid policy");
+
+        assert_eq!(policy.create, CreatePolicy::Never);
+        assert_eq!(policy.physical_name("counters"), "my-app_MY_APP_STORE");
+        assert_eq!(policy.replicas, Some(3));
+        assert!(matches!(
+            policy.storage,
+            Some(async_nats::jetstream::stream::StorageType::Memory)
+        ));
+        assert_eq!(policy.max_age, Some(Duration::from_secs(86400)));
+        assert_eq!(policy.history, Some(5));
+        assert_eq!(policy.max_bytes, Some(1_048_576));
+    }
+
+    /// The block is optional: a project that sets only the URL still gets the
+    /// dev default.
+    #[test]
+    fn dev_keyvalue_nats_block_is_optional() {
+        let yaml = r#"
+dev:
+  wasi_keyvalue_nats_url: nats://127.0.0.1:4222
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(config.dev().wasi_keyvalue_nats.is_none());
+        assert_eq!(
+            config
+                .dev()
+                .keyvalue_bucket_policy()
+                .expect("must be valid")
+                .create,
+            CreatePolicy::Missing
+        );
+    }
+
     /// With nothing configured, `wash dev` creates a missing bucket and leaves
     /// the identifier alone, so a first `open` works against a bare JetStream.
     #[test]

--- a/examples/http-hello-world-persistent-storage/Cargo.lock
+++ b/examples/http-hello-world-persistent-storage/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "http-hello-world-persistent-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "wit-bindgen 0.60.0",
  "wstd",

--- a/examples/http-hello-world-persistent-storage/Cargo.toml
+++ b/examples/http-hello-world-persistent-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-hello-world-persistent-storage"
 edition = "2024"
-version = "0.1.0"
+version = "0.1.1"
 
 [lints]
 workspace = true

--- a/examples/http-hello-world-persistent-storage/README.md
+++ b/examples/http-hello-world-persistent-storage/README.md
@@ -25,8 +25,13 @@ curl 'http://localhost:8000/?name=Bailey'
 # Hello x2, Bailey!
 ```
 
-The counter is persisted via `wasi:keyvalue/store` and `wasi:keyvalue/atomics` —
-`wash dev` provides an in-memory implementation automatically.
+The counter is persisted via `wasi:keyvalue/store` and `wasi:keyvalue/atomics` in
+a bucket named `counters` — `wash dev` provides an in-memory implementation
+automatically.
+
+Deploying to a `wash host` backed by NATS JetStream: a host does not create
+buckets a workload names. Either create the `counters` bucket in JetStream
+first, or start the host with `--keyvalue-nats-create missing`.
 
 ## Build
 

--- a/examples/http-hello-world-persistent-storage/src/lib.rs
+++ b/examples/http-hello-world-persistent-storage/src/lib.rs
@@ -8,6 +8,9 @@ wit_bindgen::generate!({
 
 use wasi::keyvalue::{atomics, store};
 
+/// Name of the keyvalue bucket holding the per-name counters.
+const BUCKET: &str = "counters";
+
 #[wstd::http_server]
 async fn main(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
     match req.uri().path() {
@@ -23,7 +26,7 @@ async fn home(req: Request<Body>) -> Result<Response<Body>, wstd::http::Error> {
         _ => "World",
     };
 
-    let bucket = store::open("")
+    let bucket = store::open(BUCKET)
         .map_err(|e| wstd::http::Error::msg(format!("keyvalue open error: {:?}", e)))?;
 
     let count = atomics::increment(&bucket, name, 1)

--- a/templates/http-kv-handler/.wash/config.yaml
+++ b/templates/http-kv-handler/.wash/config.yaml
@@ -15,6 +15,23 @@ dev:
   # Requires a running NATS server with JetStream enabled.
   # wasi_keyvalue_nats_url: nats://127.0.0.1:4222
 
+  # The bucket a name passed to `open()` resolves to, and whether `wash dev`
+  # may create it. Every key is optional; `wash dev` creates missing buckets.
+  # wasi_keyvalue_nats:
+  #   # `missing` creates a bucket on first open; `never` opens only buckets
+  #   # that already exist, which is what `wash host` defaults to.
+  #   create: missing
+  #   # Namespace this project's buckets on a shared NATS server.
+  #   bucket_prefix: my-app_
+  #   # Pin every identifier to one bucket, ignoring the name in `open()`.
+  #   bucket: MY_APP_STORE
+  #   # Settings for a bucket wash creates. They do not change an existing one.
+  #   replicas: 1
+  #   storage: file
+  #   max_age: 24h
+  #   history: 1
+  #   max_bytes: 1048576
+
   # Backend: redis
   # Uncomment the line below to use Redis as the keyvalue store.
   # Requires a running Redis server.

--- a/templates/http-kv-handler/README.md
+++ b/templates/http-kv-handler/README.md
@@ -113,6 +113,40 @@ dev:
   wasi_keyvalue_nats_url: nats://127.0.0.1:4222
 ```
 
+The name passed to `open()` is a *logical* name: `dev.wasi_keyvalue_nats`
+decides which JetStream bucket it resolves to and whether wash may create that
+bucket.
+
+```yaml
+# .wash/config.yaml
+dev:
+  wasi_keyvalue_nats_url: nats://127.0.0.1:4222
+  wasi_keyvalue_nats:
+    create: missing      # `missing` (the `wash dev` default) or `never`
+    bucket_prefix: my-app_
+    # bucket: MY_APP_STORE   # pin every identifier to one bucket
+    # replicas / storage / max_age / history / max_bytes apply to buckets wash creates
+```
+
+`wash host` defaults to `create: never` (`--keyvalue-nats-create`), so in a
+deployment only buckets an operator declared are reachable and a workload
+cannot create JetStream streams by naming them. An identifier with no bucket
+behind it returns `no-such-store`.
+
+These settings apply to `wasmcloud:keyvalue` as well as `wasi:keyvalue`: both
+resolve NATS buckets through the same policy, including for an
+`(implements ..)` import, which can override any key in its own interface
+config.
+
+JetStream buckets are shared by every workload on the host, so two workloads
+that open the same identifier see the same data. `bucket_prefix` is a
+host-wide setting, so it separates one host or deployment from another sharing
+a NATS cluster — it does not separate two workloads on the same host. To keep
+those apart, give them different identifiers, or bind each to its own
+`(implements ..)` interface with its own `bucket`. (The in-memory backend
+isolates buckets per workload, so a component that looks isolated under a bare
+`wash dev` shares state once it is pointed at NATS or Redis.)
+
 Start a local NATS server with JetStream:
 
 ```shell


### PR DESCRIPTION

This adds a configurable NATS bucket naming and creation policy for wasi:keyvalue and wasmcloud:keyvalue nats backends.

A guest names a store; the host decides which JetStream bucket that is and whether it may be created. This PR gives that decision a home, a `BucketPolicy` shared by both NATS keyvalue backends and wires it to the config surfaces an operator actually uses.

Before this, the two NATS backends disagreed: the standard `wasi:keyvalue` plugin turned any identifier a guest passed into a JetStream bucket and unconditionally created it with `Config::default()`, while the multiplexed backend refused anything that did not already exist. Neither had any configuration at all beyond the connection URL, and nothing namespaced buckets on a shared cluster.

The example that prompted this, `examples/http-hello-world-persistent-storage`, now opens a named `counters` bucket instead of `""`, and is bumped to `0.1.1` so CI publishes it.

## What you can configure

The same keys are read from a named `(implements ..)` interface's `config`, from `dev.wasi_keyvalue_nats` in a project's `.wash/config.yaml`, and from `wash host --keyvalue-nats-*` flags:

Config options:
| Key | Meaning |
| --- | --- |
| `bucket` | Pin the import to one physical bucket, ignoring the identifier the guest passes |
| `bucket_prefix` | Prepended to every physical bucket name. This is a namespacing knob for a shared NATS cluster. |
| `create` | `never` (open only what exists) or `missing` (create on first open) |
| `replicas`, `storage`, `max_age`, `history`, `max_bytes` | Settings a bucket this host creates is given; they never alter an existing bucket |

A key design goal is that all of this comes from the operator and not the guest.

**Behavior change: `wash host` no longer creates buckets**. `wash host` now defaults to `create = never`. Only buckets an operator declared are reachable, an unknown identifier answers `no-such-store` rather than silently minting a JetStream stream, and opening an existing bucket no longer requires stream-create permission on the host's NATS credentials.

`wash dev` still defaults to `create = missing`, so a project (and the quickstart example) works with no configuration at all.

**Upgrading:** a deployment that relied on implicit creation must either pre-create the bucket in JetStream or start the host with `--keyvalue-nats-create missing`.

Other fixes:
- The multiplexed provider's pool key now covers the *resolved* policy, not the raw config, so two interfaces sharing a NATS URL but not a bucket mapping no longer share a backend.
- Cached bucket handles expire and are evicted.
- JetStream being disabled for the account, or credentials without `$JS.API.STREAM.INFO`, now surface as real errors
- new `wasi_keyvalue_bucket_opens_total{outcome}` counter
