### PR TITLE
fix(runtime-operator): stop deleting hosts on bus loss

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -328,6 +328,7 @@ gocloud.dev v0.39.0 h1:EYABYGhAalPUaMrbSKOr5lejxoxvXj99nE8XFtsDgds=
 gocloud.dev v0.39.0/go.mod h1:drz+VyYNBvrMTW0KZiBAYEdl8lbNZx+OQ7oQvdrFmSQ=
 gocloud.dev v0.45.0/go.mod h1:0kXKmkCLG6d31N7NyLZWzt7jDSQura9zD/mWgiB6THI=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -169,7 +168,7 @@ func main() {
 	operatorCfg := runtime_operator.EmbeddedOperatorConfig{
 		DisableArtifactController: disableArtifactController,
 		NatsURL:                   natsUrl,
-		HeartbeatTTL:              60 * time.Second,
+		HeartbeatTTL:              runtime_operator.DefaultHeartbeatTTL,
 		HostCPUThreshold:          cpuBackpressureThreshold,
 		HostMemoryThreshold:       memoryBackpressureThreshold,
 		Namespace:                 operatorNamespace,

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -50,7 +51,77 @@ type HostReconciler struct {
 	// pod runs; tenant attribution lives on the Host's Environment field.
 	OperatorNamespace string
 
+	// fleet gates host deletion; the heartbeat subscription writes to it.
+	fleet fleetWitness
+
 	reconciler condition.AnyConditionedReconciler
+}
+
+// fleetWitness records whether the operator is hearing the fleet.
+//
+// A host's probe and its pushed heartbeats both travel over the operator's one
+// NATS connection, so a deaf operator sees every host fall silent at once and
+// deleteUnresponsiveHost deletes them all, each finalizer taking its Workloads
+// with it. Arrival is the evidence, not the connection's own state: NATS can
+// hold the socket up while it has lost its routes to the hosts, or has dropped
+// this subscription for overrunning its backlog.
+//
+// The signal is fleet-wide, so it catches total deafness only. A partition that
+// isolates some hosts while others keep publishing still reaps the unreachable
+// ones, as it did before this existed.
+type fleetWitness struct {
+	mu sync.Mutex
+	// lastHeard is when a heartbeat from any host last arrived.
+	lastHeard time.Time
+	// heardSince is when the operator resumed hearing the fleet after its most
+	// recent gap, or the zero time while it is hearing nothing.
+	heardSince time.Time
+}
+
+// heard records a heartbeat arriving from some host.
+func (w *fleetWitness) heard(now time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastHeard = now
+}
+
+// observe advances the grace period, or clears it if nothing has been heard
+// within window. It must run on every reconcile rather than only when a host
+// looks silent, or the clock reads zero through a healthy uptime and the first
+// host to genuinely die waits an extra window to be reaped.
+func (w *fleetWitness) observe(now time.Time, window time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.lastHeard.IsZero() || now.Sub(w.lastHeard) >= window {
+		w.heardSince = time.Time{}
+		return
+	}
+	if w.heardSince.IsZero() {
+		w.heardSince = now
+	}
+}
+
+// settled reports whether the operator has been hearing the fleet without a gap
+// for a full window. It re-checks arrival itself rather than trusting the last
+// observe: callers reach it after a heartbeat probe that can burn
+// hostHeartbeatTimeout, and the fleet can fall silent inside that.
+//
+// The gap is what makes recent arrival alone insufficient: hosts publish every
+// 15s, so for that long after the bus returns a live host has yet to be heard
+// from while its neighbours have already ticked. Requiring the whole window
+// keeps the ones that have not ticked from being condemned on their neighbours.
+func (w *fleetWitness) settled(now time.Time, window time.Duration) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.lastHeard.IsZero() || now.Sub(w.lastHeard) >= window {
+		return false
+	}
+	if w.heardSince.IsZero() {
+		return false
+	}
+	return now.Sub(w.heardSince) >= window
 }
 
 func (r *HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -58,6 +129,10 @@ func (r *HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 }
 
 func (r *HostReconciler) reconcileReporting(ctx context.Context, host *runtimev1alpha1.Host) error {
+	// Reporting is the first condition, so this runs on every reconcile pass
+	// that can reach the readiness verdict.
+	r.fleet.observe(time.Now(), r.UnreachableTimeout)
+
 	client := NewWashHostClient(r.Bus, host.HostID)
 
 	ctx, cancel := context.WithTimeout(ctx, hostHeartbeatTimeout)
@@ -89,8 +164,17 @@ func (r *HostReconciler) reconcileReady(_ context.Context, host *runtimev1alpha1
 		return nil
 	}
 
-	if host.Status.LastSeen.Add(r.UnreachableTimeout).After(metav1.Now().Time) {
+	now := time.Now()
+	if host.Status.LastSeen.Add(r.UnreachableTimeout).After(now) {
 		return condition.ErrStatusUnknown(fmt.Errorf("host is not reporting"))
+	}
+
+	// A definite failure here costs the host every Workload on it, so it is
+	// only reachable once the operator has been hearing the rest of the fleet
+	// long enough that this host's silence is the host's own.
+	if !r.fleet.settled(now, r.UnreachableTimeout) {
+		return condition.ErrStatusUnknown(
+			fmt.Errorf("host has not reported recently, but the operator has not been hearing the fleet for %s", r.UnreachableTimeout))
 	}
 
 	return fmt.Errorf("host has not reported recently")
@@ -165,6 +249,7 @@ func (r *HostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		bus:               r.Bus,
 		client:            r.Client,
 		operatorNamespace: r.OperatorNamespace,
+		fleet:             &r.fleet,
 	}
 	if err := mgr.Add(statusUpdater); err != nil {
 		return err
@@ -199,6 +284,8 @@ type hostStatusUpdater struct {
 	client client.Client
 	// operatorNamespace is the namespace every Host object is created in.
 	operatorNamespace string
+	// fleet is stamped on every heartbeat that arrives.
+	fleet *fleetWitness
 }
 
 func (h *hostStatusUpdater) Start(ctx context.Context) error {
@@ -227,6 +314,10 @@ func (h *hostStatusUpdater) handleHeartbeat(ctx context.Context, log logr.Logger
 		log.Error(err, "failed to decode heartbeat message")
 		return
 	}
+
+	// Stamped before the bookkeeping below, which can fail on its own: arrival
+	// is what proves the path from hosts to the operator works.
+	h.fleet.heard(time.Now())
 
 	// Every Host object lives in the operator's own namespace. Tenant
 	// attribution is recorded on the Host's Environment field,
@@ -273,7 +364,9 @@ func (h *hostStatusUpdater) handleHeartbeat(ctx context.Context, log logr.Logger
 
 	// Patching the status subresource to update the LastSeen timestamp in case
 	// the other fields reported are not yet available (such as system/OS information).
-	statusPatch, err := hostStatusPatch(&host.Status)
+	// Built from the stored status: hostStatusPatch supplies the CRD's required
+	// fields only where they are still empty, and `host` carries a zero status.
+	statusPatch, err := hostStatusPatch(&existing.Status)
 	if err != nil {
 		log.Error(err, "failed to build Host status patch", "host", req.FriendlyName, "hostID", req.Id)
 		return

--- a/runtime-operator/internal/controller/runtime/host_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/host_controller_test.go
@@ -27,11 +27,18 @@ import (
 	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus"
 )
 
-// Shared test fixtures for host OS arch and version, factored out so repeated
-// literals stay consistent across the suite.
+// Shared test fixtures for the values a host reports about itself, factored
+// out so repeated literals stay consistent across the suite.
 const (
-	testOSArch  = "arm64"
-	testVersion = "1.2.3"
+	testOSArch   = "arm64"
+	testOSName   = "linux"
+	testOSKernel = "6.1.0"
+	testVersion  = "1.2.3"
+	testCPUUsage = "0.5"
+	// testHeartbeatHostID is the host these tests heartbeat as. Distinct from
+	// workload_route_controller_test.go's testHostID, which names the host a
+	// route is expected to resolve to.
+	testHeartbeatHostID = "host-id-1"
 )
 
 // requiredHostStatusKeys are the status fields the Host CRD marks as required.
@@ -86,10 +93,10 @@ func TestHostStatusPatch_EmptyStatusInjectsRequiredKeys(t *testing.T) {
 func TestHostStatusPatch_ReportedFieldsPreserved(t *testing.T) {
 	keys := patchStatusKeys(t, &runtimev1alpha1.HostStatus{
 		Version:           testVersion,
-		OSName:            "linux",
+		OSName:            testOSName,
 		OSArch:            testOSArch,
-		OSKernel:          "6.1.0",
-		SystemCPUUsage:    "0.5",
+		OSKernel:          testOSKernel,
+		SystemCPUUsage:    testCPUUsage,
 		SystemMemoryTotal: 16000,
 		SystemMemoryFree:  8000,
 	})
@@ -240,7 +247,7 @@ func TestHostApply_UpsertIsIdempotent(t *testing.T) {
 	const name = "ssa-host"
 
 	// First apply: object does not exist yet -> SSA creates it.
-	if err := applyHost(ctx, c, ns, name, "host-id-1", "node-a", 8080, "tenant-a",
+	if err := applyHost(ctx, c, ns, name, testHeartbeatHostID, "node-a", 8080, "tenant-a",
 		map[string]string{"hostgroup": "default"}); err != nil {
 		t.Fatalf("first apply (create) failed: %v", err)
 	}
@@ -249,13 +256,13 @@ func TestHostApply_UpsertIsIdempotent(t *testing.T) {
 	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, created); err != nil {
 		t.Fatalf("get after create: %v", err)
 	}
-	if created.HostID != "host-id-1" || created.Hostname != "node-a" || created.HTTPPort != 8080 {
+	if created.HostID != testHeartbeatHostID || created.Hostname != "node-a" || created.HTTPPort != 8080 {
 		t.Errorf("create did not persist spec/metadata: %+v", created)
 	}
 
 	// Second apply with changed fields: object exists -> SSA updates in place,
 	// with no client-side Get and so no possibility of AlreadyExists.
-	if err := applyHost(ctx, c, ns, name, "host-id-1", "node-a-renamed", 9090, "tenant-a",
+	if err := applyHost(ctx, c, ns, name, testHeartbeatHostID, "node-a-renamed", 9090, "tenant-a",
 		map[string]string{"hostgroup": "default"}); err != nil {
 		t.Fatalf("second apply (update) failed: %v", err)
 	}
@@ -290,7 +297,7 @@ func hostWith(hostID, hostname string, httpPort uint32, env string, labels map[s
 // case that must not register as a change.
 func TestHostSpecChanged(t *testing.T) {
 	base := func() *runtimev1alpha1.Host {
-		return hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default"})
+		return hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default"})
 	}
 
 	tests := []struct {
@@ -300,12 +307,12 @@ func TestHostSpecChanged(t *testing.T) {
 	}{
 		{"identical", base(), false},
 		{"hostID changed", hostWith("host-id-2", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default"}), true},
-		{"hostname changed", hostWith("host-id-1", "node-b", 8080, "tenant-a", map[string]string{"hostgroup": "default"}), true},
-		{"httpPort changed", hostWith("host-id-1", "node-a", 9090, "tenant-a", map[string]string{"hostgroup": "default"}), true},
-		{"environment changed", hostWith("host-id-1", "node-a", 8080, "tenant-b", map[string]string{"hostgroup": "default"}), true},
-		{"label value changed", hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "other"}), true},
-		{"label added", hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default", "extra": "x"}), true},
-		{"label removed", hostWith("host-id-1", "node-a", 8080, "tenant-a", nil), true},
+		{"hostname changed", hostWith(testHeartbeatHostID, "node-b", 8080, "tenant-a", map[string]string{"hostgroup": "default"}), true},
+		{"httpPort changed", hostWith(testHeartbeatHostID, "node-a", 9090, "tenant-a", map[string]string{"hostgroup": "default"}), true},
+		{"environment changed", hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-b", map[string]string{"hostgroup": "default"}), true},
+		{"label value changed", hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "other"}), true},
+		{"label added", hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", map[string]string{"hostgroup": "default", "extra": "x"}), true},
+		{"label removed", hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", nil), true},
 	}
 
 	for _, tt := range tests {
@@ -319,8 +326,8 @@ func TestHostSpecChanged(t *testing.T) {
 	// A nil label map and an empty one are equivalent and must not be reported
 	// as a change: req.GetLabels() yields nil when the heartbeat carries none.
 	t.Run("nil vs empty labels", func(t *testing.T) {
-		existing := hostWith("host-id-1", "node-a", 8080, "tenant-a", nil)
-		next := hostWith("host-id-1", "node-a", 8080, "tenant-a", map[string]string{})
+		existing := hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", nil)
+		next := hostWith(testHeartbeatHostID, "node-a", 8080, "tenant-a", map[string]string{})
 		if hostSpecChanged(existing, next) {
 			t.Errorf("nil and empty label maps must compare equal")
 		}
@@ -348,19 +355,37 @@ func (m *mockBus) Subscribe(string, int) (wasmbus.Subscription, error)          
 func (m *mockBus) QueueSubscribe(string, string, int) (wasmbus.Subscription, error) { return nil, nil }
 func (m *mockBus) Publish(*wasmbus.Message) error                                   { return nil }
 
+// testUnreachableTimeout is the unreachable window the readiness tests judge
+// hosts against. Long enough that no test trips it by wall-clock drift.
+const testUnreachableTimeout = time.Hour
+
+// settledFleetReconciler builds a HostReconciler that has been hearing the
+// fleet without a gap for longer than the unreachable window, which is the
+// steady state every host is judged in once the operator has been running for
+// a while.
+func settledFleetReconciler() *HostReconciler {
+	r := &HostReconciler{UnreachableTimeout: testUnreachableTimeout}
+	// Drive the witness the way production does: a run of heartbeats reaching
+	// back past the window, the most recent of them just now.
+	r.fleet.heard(time.Now().Add(-2 * testUnreachableTimeout))
+	r.fleet.observe(time.Now().Add(-2*testUnreachableTimeout), testUnreachableTimeout)
+	r.fleet.heard(time.Now())
+	return r
+}
+
 // TestReconcileReporting verifies the heartbeat response is mapped onto Host
 // status, including the float32->string CPU formatting and the unsigned->signed
 // memory/count casts, and that the host's heartbeat subject is addressed.
 func TestReconcileReporting(t *testing.T) {
 	hb := &runtimev2.HostHeartbeat{
-		SystemCpuUsage:    0.5, // exactly representable, so FormatFloat yields "0.5"
+		SystemCpuUsage:    0.5, // exactly representable, so FormatFloat yields testCPUUsage
 		SystemMemoryTotal: 16000,
 		SystemMemoryFree:  8000,
 		ComponentCount:    3,
 		WorkloadCount:     2,
-		OsName:            "linux",
+		OsName:            testOSName,
 		OsArch:            testOSArch,
-		OsKernel:          "6.1.0",
+		OsKernel:          testOSKernel,
 		Version:           testVersion,
 	}
 	data, err := protojson.Marshal(hb)
@@ -370,7 +395,7 @@ func TestReconcileReporting(t *testing.T) {
 
 	bus := &mockBus{reply: &wasmbus.Message{Data: data}}
 	r := &HostReconciler{Bus: bus}
-	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+	host := &runtimev1alpha1.Host{HostID: testHeartbeatHostID}
 
 	if err := r.reconcileReporting(context.Background(), host); err != nil {
 		t.Fatalf("reconcileReporting: %v", err)
@@ -379,8 +404,8 @@ func TestReconcileReporting(t *testing.T) {
 	if want := "runtime.host.host-id-1.heartbeat"; bus.gotSubject != want {
 		t.Errorf("heartbeat subject = %q, want %q", bus.gotSubject, want)
 	}
-	if host.Status.SystemCPUUsage != "0.5" {
-		t.Errorf("SystemCPUUsage = %q, want %q", host.Status.SystemCPUUsage, "0.5")
+	if host.Status.SystemCPUUsage != testCPUUsage {
+		t.Errorf("SystemCPUUsage = %q, want %q", host.Status.SystemCPUUsage, testCPUUsage)
 	}
 	if host.Status.SystemMemoryTotal != 16000 {
 		t.Errorf("SystemMemoryTotal = %d, want 16000", host.Status.SystemMemoryTotal)
@@ -391,8 +416,8 @@ func TestReconcileReporting(t *testing.T) {
 	if host.Status.ComponentCount != 3 || host.Status.WorkloadCount != 2 {
 		t.Errorf("counts = (%d,%d), want (3,2)", host.Status.ComponentCount, host.Status.WorkloadCount)
 	}
-	if host.Status.OSName != "linux" || host.Status.OSArch != testOSArch ||
-		host.Status.OSKernel != "6.1.0" || host.Status.Version != testVersion {
+	if host.Status.OSName != testOSName || host.Status.OSArch != testOSArch ||
+		host.Status.OSKernel != testOSKernel || host.Status.Version != testVersion {
 		t.Errorf("OS/version fields not mapped: %+v", host.Status)
 	}
 	if host.Status.LastSeen.IsZero() {
@@ -405,7 +430,7 @@ func TestReconcileReporting(t *testing.T) {
 func TestReconcileReporting_Error(t *testing.T) {
 	bus := &mockBus{err: errors.New("bus down")}
 	r := &HostReconciler{Bus: bus}
-	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+	host := &runtimev1alpha1.Host{HostID: testHeartbeatHostID}
 
 	if err := r.reconcileReporting(context.Background(), host); err == nil {
 		t.Fatalf("expected error when the heartbeat request fails")
@@ -419,10 +444,8 @@ func TestReconcileReporting_Error(t *testing.T) {
 // ready, a recent-but-not-reporting host is Unknown (still within the
 // unreachable window), and a long-silent host is a definite failure.
 func TestReconcileReady(t *testing.T) {
-	const timeout = time.Hour
-
 	t.Run("reporting true is ready", func(t *testing.T) {
-		r := &HostReconciler{UnreachableTimeout: timeout}
+		r := settledFleetReconciler()
 		host := &runtimev1alpha1.Host{}
 		host.Status.SetConditions(condition.ReadyCondition(runtimev1alpha1.HostConditionReporting))
 		if err := r.reconcileReady(context.Background(), host); err != nil {
@@ -431,7 +454,7 @@ func TestReconcileReady(t *testing.T) {
 	})
 
 	t.Run("recently seen but not reporting is unknown", func(t *testing.T) {
-		r := &HostReconciler{UnreachableTimeout: timeout}
+		r := settledFleetReconciler()
 		host := &runtimev1alpha1.Host{}
 		host.Status.LastSeen = metav1.Now()
 		err := r.reconcileReady(context.Background(), host)
@@ -444,9 +467,9 @@ func TestReconcileReady(t *testing.T) {
 	})
 
 	t.Run("silent past the unreachable window is failed", func(t *testing.T) {
-		r := &HostReconciler{UnreachableTimeout: timeout}
+		r := settledFleetReconciler()
 		host := &runtimev1alpha1.Host{}
-		host.Status.LastSeen = metav1.NewTime(time.Now().Add(-2 * timeout))
+		host.Status.LastSeen = metav1.NewTime(time.Now().Add(-2 * testUnreachableTimeout))
 		err := r.reconcileReady(context.Background(), host)
 		if err == nil {
 			t.Fatalf("expected an error for a long-silent host")
@@ -455,6 +478,172 @@ func TestReconcileReady(t *testing.T) {
 			t.Errorf("past the unreachable window the error must be a definite failure, not Unknown: %v", err)
 		}
 	})
+}
+
+// TestReconcileReporting_StartsFleetGraceClock pins the grace clock to a call
+// site that runs on every pass. Wound only where it is read — the failure path
+// — it would read zero through a healthy uptime.
+func TestReconcileReporting_StartsFleetGraceClock(t *testing.T) {
+	r := &HostReconciler{
+		Bus:                &mockBus{err: errors.New("no responders")},
+		UnreachableTimeout: testUnreachableTimeout,
+	}
+	// Some host was heard from, so the operator is not deaf — this one host's
+	// probe just failed.
+	start := time.Now()
+	r.fleet.heard(start)
+
+	if err := r.reconcileReporting(context.Background(), &runtimev1alpha1.Host{HostID: testHeartbeatHostID}); err == nil {
+		t.Fatalf("expected the heartbeat probe to fail")
+	}
+
+	if r.fleet.settled(start, testUnreachableTimeout) {
+		t.Errorf("the window cannot already be satisfied the instant the clock starts")
+	}
+
+	// Well past the window, with the fleet still being heard.
+	later := start.Add(2 * testUnreachableTimeout)
+	r.fleet.heard(later)
+	if !r.fleet.settled(later, testUnreachableTimeout) {
+		t.Errorf("the window must be satisfied once the fleet has been heard for it")
+	}
+}
+
+// TestFleetWitness_SilenceDuringProbe covers the gap between the two calls: a
+// pass observes while the fleet is still inside the window, then spends up to
+// hostHeartbeatTimeout in the probe, by which point it is not. settled has to
+// re-check arrival rather than trust that observation.
+func TestFleetWitness_SilenceDuringProbe(t *testing.T) {
+	var w fleetWitness
+
+	busDied := time.Now()
+	w.heard(busDied)
+	w.heardSince = busDied.Add(-2 * time.Hour)
+
+	observeAt := busDied.Add(testUnreachableTimeout - hostHeartbeatTimeout + time.Second)
+	w.observe(observeAt, testUnreachableTimeout)
+
+	settledAt := observeAt.Add(hostHeartbeatTimeout)
+	if w.settled(settledAt, testUnreachableTimeout) {
+		t.Errorf("settled with the last heartbeat %v ago, past the %v window",
+			settledAt.Sub(busDied), testUnreachableTimeout)
+	}
+}
+
+// TestReconcileReady_FleetUnheard pins the guard that keeps the operator's own
+// deafness from being charged to the hosts, whose Workloads a definite
+// not-ready verdict deletes.
+func TestReconcileReady_FleetUnheard(t *testing.T) {
+	silentHost := func() *runtimev1alpha1.Host {
+		host := &runtimev1alpha1.Host{}
+		host.Status.LastSeen = metav1.NewTime(time.Now().Add(-2 * testUnreachableTimeout))
+		return host
+	}
+	observe := func(r *HostReconciler) {
+		r.fleet.observe(time.Now(), r.UnreachableTimeout)
+	}
+
+	t.Run("fleet heard past the window still fails the host", func(t *testing.T) {
+		// The counterweight to every case below: a host that really is gone
+		// must still be reaped, or its Workloads are never rescheduled.
+		r := settledFleetReconciler()
+		observe(r)
+		err := r.reconcileReady(context.Background(), silentHost())
+		if err == nil {
+			t.Fatalf("expected an error for a long-silent host")
+		}
+		if condition.IsStatusUnknown(err) {
+			t.Errorf("a dead host must be a definite failure once the fleet has been heard a full window, got %v", err)
+		}
+	})
+
+	t.Run("unheard fleet holds the host at unknown", func(t *testing.T) {
+		// A dead fleet and a deaf operator are indistinguishable here, and
+		// holding costs nothing: a fleet nobody can hear has nowhere to
+		// reschedule to either.
+		r := settledFleetReconciler()
+		r.fleet.lastHeard = time.Now().Add(-2 * testUnreachableTimeout)
+		observe(r)
+		err := r.reconcileReady(context.Background(), silentHost())
+		if err == nil {
+			t.Fatalf("expected an error for a long-silent host")
+		}
+		if !condition.IsStatusUnknown(err) {
+			t.Errorf("a silent host must stay Unknown while the operator hears nothing, got %v", err)
+		}
+	})
+
+	t.Run("freshly started operator holds the host at unknown", func(t *testing.T) {
+		// No priming: nothing heard yet, exactly as on the first reconcile
+		// after the process starts with LastSeen timestamps that went stale
+		// while it was down.
+		r := &HostReconciler{Bus: &mockBus{}, UnreachableTimeout: testUnreachableTimeout}
+		observe(r)
+		err := r.reconcileReady(context.Background(), silentHost())
+		if err == nil {
+			t.Fatalf("expected an error for a long-silent host")
+		}
+		if !condition.IsStatusUnknown(err) {
+			t.Errorf("a silent host must stay Unknown until the fleet has been heard a full window, got %v", err)
+		}
+	})
+
+	t.Run("hearing the fleet again restarts the grace period", func(t *testing.T) {
+		// Why arrival alone cannot be the gate: hosts publish every 15s, so
+		// just after the bus returns one has ticked and its neighbours have
+		// not, and they would be condemned on the strength of the one.
+		r := settledFleetReconciler()
+		r.fleet.lastHeard = time.Now().Add(-2 * testUnreachableTimeout)
+		observe(r)
+		if err := r.reconcileReady(context.Background(), silentHost()); !condition.IsStatusUnknown(err) {
+			t.Fatalf("expected Unknown while the operator hears nothing, got %v", err)
+		}
+
+		r.fleet.heard(time.Now())
+		observe(r)
+		err := r.reconcileReady(context.Background(), silentHost())
+		if !condition.IsStatusUnknown(err) {
+			t.Errorf("the window must restart from the first heartbeat back, not carry over, got %v", err)
+		}
+	})
+}
+
+// TestHeartbeatHandler_WitnessesFleet pins the wiring the whole guard rests on:
+// the readiness verdict is gated on heartbeats having arrived, so the handler
+// they arrive at has to record that they did.
+func TestHeartbeatHandler_WitnessesFleet(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := runtimev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add runtime v1alpha1: %v", err)
+	}
+
+	var fleet fleetWitness
+	// A fake client cannot serve the Server-Side Apply this handler makes, so
+	// the Host bookkeeping below fails — which is the point. Arrival is the
+	// evidence, and it has to be recorded before anything that can fail.
+	updater := &hostStatusUpdater{
+		client:            fake.NewClientBuilder().WithScheme(s).Build(),
+		operatorNamespace: testNamespace,
+		fleet:             &fleet,
+	}
+
+	start := time.Now()
+	if fleet.settled(start, testUnreachableTimeout) {
+		t.Fatalf("nothing heard yet, so the fleet cannot be settled")
+	}
+
+	updater.handleHeartbeat(context.Background(), logr.Discard(),
+		heartbeatBytes(t, "hb-host", testHeartbeatHostID, "node-a"))
+
+	// The handler's stamp is what lets a run start here; without it observe
+	// finds nothing heard and the witness never settles.
+	fleet.observe(start, testUnreachableTimeout)
+
+	later := start.Add(2 * testUnreachableTimeout)
+	fleet.heard(later)
+	if !fleet.settled(later, testUnreachableTimeout) {
+		t.Errorf("an arrived heartbeat must be recorded as hearing the fleet")
+	}
 }
 
 // newHostFinalizeClient builds a fake client wired with the same Status.HostID
@@ -491,9 +680,9 @@ func workloadForHost(name, hostID string) *runtimev1alpha1.Workload {
 // assigned to it: workloads on other hosts are untouched, and a workload
 // already being deleted is left alone rather than re-deleted.
 func TestFinalize(t *testing.T) {
-	assigned := workloadForHost("assigned", "host-id-1")
+	assigned := workloadForHost("assigned", testHeartbeatHostID)
 
-	deleting := workloadForHost("deleting", "host-id-1")
+	deleting := workloadForHost("deleting", testHeartbeatHostID)
 	now := metav1.Now()
 	deleting.DeletionTimestamp = &now
 	// A fake-client object carrying a DeletionTimestamp must also carry a
@@ -505,7 +694,7 @@ func TestFinalize(t *testing.T) {
 
 	c := newHostFinalizeClient(t, assigned, deleting, otherHost)
 	r := &HostReconciler{Client: c}
-	host := &runtimev1alpha1.Host{HostID: "host-id-1"}
+	host := &runtimev1alpha1.Host{HostID: testHeartbeatHostID}
 
 	if err := r.finalize(context.Background(), host); err != nil {
 		t.Fatalf("finalize: %v", err)
@@ -618,13 +807,13 @@ func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
 	ns := createTestNamespace(t, ctx, c, "host-heartbeat-skip")
 
 	counter := &applyCountingClient{Client: c}
-	updater := &hostStatusUpdater{client: counter, operatorNamespace: ns}
+	updater := &hostStatusUpdater{client: counter, operatorNamespace: ns, fleet: &fleetWitness{}}
 	log := logr.Discard()
 
 	const name = "hb-host"
 
 	// First heartbeat: object does not exist -> create via SSA.
-	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-a"))
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, testHeartbeatHostID, "node-a"))
 	if got := counter.applies.Load(); got != 1 {
 		t.Fatalf("first heartbeat: applies = %d, want 1", got)
 	}
@@ -640,7 +829,7 @@ func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
 	}
 
 	// Identical heartbeat: spec unchanged -> no apply, but LastSeen still refreshes.
-	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-a"))
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, testHeartbeatHostID, "node-a"))
 	if got := counter.applies.Load(); got != 1 {
 		t.Fatalf("redundant heartbeat must not re-apply: applies = %d, want 1", got)
 	}
@@ -653,7 +842,7 @@ func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
 	}
 
 	// Changed heartbeat: hostname differs -> apply again.
-	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-1", "node-b"))
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, testHeartbeatHostID, "node-b"))
 	if got := counter.applies.Load(); got != 2 {
 		t.Fatalf("changed heartbeat must re-apply: applies = %d, want 2", got)
 	}
@@ -663,5 +852,69 @@ func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
 	}
 	if updated.Hostname != "node-b" {
 		t.Errorf("hostname = %q, want node-b after change", updated.Hostname)
+	}
+
+	// A restarted host that reuses its friendly name reports a new host ID, and
+	// the operator addresses every RPC by that ID — so this is the one field the
+	// skip must never swallow.
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, "host-id-2", "node-b"))
+	if got := counter.applies.Load(); got != 3 {
+		t.Fatalf("changed hostID must re-apply: applies = %d, want 3", got)
+	}
+	reidentified := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, reidentified); err != nil {
+		t.Fatalf("get after hostID change: %v", err)
+	}
+	if reidentified.HostID != "host-id-2" {
+		t.Errorf("hostID = %q, want host-id-2 after change", reidentified.HostID)
+	}
+}
+
+// TestHeartbeatHandler_PreservesReportedStatus is the call-site counterpart to
+// TestHostStatusPatch_ReportedFieldsPreserved: the placeholders must come from
+// the stored status, so a heartbeat leaves what reconcileReporting measured.
+func TestHeartbeatHandler_PreservesReportedStatus(t *testing.T) {
+	c, ctx := startHostEnvtest(t)
+	ns := createTestNamespace(t, ctx, c, "host-heartbeat-status")
+
+	updater := &hostStatusUpdater{client: c, operatorNamespace: ns, fleet: &fleetWitness{}}
+	log := logr.Discard()
+
+	const name = "hb-status-host"
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, testHeartbeatHostID, "node-a"))
+
+	// Stand in for reconcileReporting having polled the host.
+	reported := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, reported); err != nil {
+		t.Fatalf("get after first heartbeat: %v", err)
+	}
+	reported.Status.Version = testVersion
+	reported.Status.OSName = testOSName
+	reported.Status.OSArch = testOSArch
+	reported.Status.OSKernel = testOSKernel
+	reported.Status.SystemCPUUsage = testCPUUsage
+	reported.Status.SystemMemoryTotal = 16000
+	reported.Status.SystemMemoryFree = 8000
+	if err := c.Status().Update(ctx, reported); err != nil {
+		t.Fatalf("seed reported status: %v", err)
+	}
+	seenBefore := reported.Status.LastSeen
+
+	updater.handleHeartbeat(ctx, log, heartbeatBytes(t, name, testHeartbeatHostID, "node-a"))
+
+	after := &runtimev1alpha1.Host{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, after); err != nil {
+		t.Fatalf("get after steady-state heartbeat: %v", err)
+	}
+	if after.Status.Version != testVersion || after.Status.OSName != testOSName ||
+		after.Status.OSArch != testOSArch || after.Status.OSKernel != testOSKernel {
+		t.Errorf("heartbeat clobbered reported OS/version fields: %+v", after.Status)
+	}
+	if after.Status.SystemCPUUsage != testCPUUsage ||
+		after.Status.SystemMemoryTotal != 16000 || after.Status.SystemMemoryFree != 8000 {
+		t.Errorf("heartbeat clobbered reported system metrics: %+v", after.Status)
+	}
+	if !after.Status.LastSeen.After(seenBefore.Time) && !after.Status.LastSeen.Equal(&seenBefore) {
+		t.Errorf("LastSeen went backwards: %v -> %v", seenBefore, after.Status.LastSeen)
 	}
 }

--- a/runtime-operator/internal/controller/runtime/host_pod_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_pod_controller.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,10 +79,8 @@ func (r *HostPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	if podIP := pod.Status.PodIP; podIP != "" {
-		if err := r.deleteHostForIP(ctx, podIP); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err := r.deleteHostForPod(ctx, pod); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	base := pod.DeepCopy()
@@ -89,11 +88,23 @@ func (r *HostPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, r.Patch(ctx, pod, client.MergeFrom(base))
 }
 
-// deleteHostForIP deletes the Host CRD whose Hostname matches podIP. The
-// list is always scoped to the operator's own namespace — that is the one
-// and only place Host objects live, regardless of where the underlying
-// host pod runs. Uses a field index so it does not scan every Host.
-func (r *HostPodReconciler) deleteHostForIP(ctx context.Context, podIP string) error {
+// deleteHostForPod deletes the Host CRD registered by the given terminating
+// Pod, identified by matching Host.Hostname to the Pod's IP. The list is always
+// scoped to the operator's own namespace — that is the one and only place Host
+// objects live, regardless of where the underlying host pod runs. Uses a field
+// index so it does not scan every Host.
+//
+// Kubernetes recycles Pod IPs, and this controller's finalizer holds the
+// terminating Pod in the API long after kubelet released its IP, so a
+// replacement Pod may already hold that IP and have registered a Host under it.
+// A Host created at or after this Pod was condemned is the replacement's, and
+// deleting it would take a live host's Workloads with it.
+func (r *HostPodReconciler) deleteHostForPod(ctx context.Context, pod *corev1.Pod) error {
+	podIP := pod.Status.PodIP
+	if podIP == "" {
+		return nil
+	}
+
 	var hosts runtimev1alpha1.HostList
 	if err := r.List(ctx, &hosts,
 		client.InNamespace(r.OperatorNamespace),
@@ -101,17 +112,49 @@ func (r *HostPodReconciler) deleteHostForIP(ctx context.Context, podIP string) e
 	); err != nil {
 		return err
 	}
+
+	log := ctrl.LoggerFrom(ctx)
+	condemnedAt := podCondemnedAt(pod)
 	for i := range hosts.Items {
-		if err := r.Delete(ctx, &hosts.Items[i]); client.IgnoreNotFound(err) != nil {
+		host := &hosts.Items[i]
+		if !host.CreationTimestamp.Time.Before(condemnedAt) {
+			log.Info("keeping Host registered at or after this pod was condemned; its pod IP was recycled",
+				"host", host.Name, "hostID", host.HostID, "podIP", podIP,
+				"hostCreated", host.CreationTimestamp.Time, "podCondemnedAt", condemnedAt)
+			continue
+		}
+		if err := r.Delete(ctx, host); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// podCondemnedAt returns the instant the Pod was told to go away, the earliest
+// its IP could have been released to another Pod.
+//
+// DeletionTimestamp is the grace deadline, request time +
+// DeletionGracePeriodSeconds, so on the Kubernetes default it sits 30s in the
+// future and covers every Host a replacement registered during the grace window.
+//
+// Both timestamps carry one-second resolution, so a Host created in the same
+// second is kept — erring toward an orphan the unreachable-host path reaps a
+// window later, over deleting a live host's Workloads.
+// A Pod that is not terminating returns the zero time, which spares every Host.
+func podCondemnedAt(pod *corev1.Pod) time.Time {
+	if pod.DeletionTimestamp == nil {
+		return time.Time{}
+	}
+	condemned := pod.DeletionTimestamp.Time
+	if grace := pod.DeletionGracePeriodSeconds; grace != nil {
+		condemned = condemned.Add(-time.Duration(*grace) * time.Second)
+	}
+	return condemned
+}
+
 // SetupWithManager registers the controller and the Host field index it depends on.
 func (r *HostPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Index Host objects by Hostname (= pod IP) so deleteHostForIP can do a
+	// Index Host objects by Hostname (= pod IP) so deleteHostForPod can do a
 	// direct lookup rather than listing every Host and filtering in memory.
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),

--- a/runtime-operator/internal/controller/runtime/host_pod_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/host_pod_controller_test.go
@@ -1,0 +1,197 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	runtimev1alpha1 "go.wasmcloud.dev/runtime-operator/v2/api/runtime/v1alpha1"
+)
+
+// newHostPodClient builds a fake client wired with the same Hostname index
+// deleteHostForPod relies on in production, seeded with the given objects.
+func newHostPodClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := runtimev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add runtime v1alpha1: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithIndex(&runtimev1alpha1.Host{}, hostnameFieldIndex,
+			func(obj client.Object) []string {
+				host, ok := obj.(*runtimev1alpha1.Host)
+				if !ok || host.Hostname == "" {
+					return nil
+				}
+				return []string{host.Hostname}
+			}).
+		Build()
+}
+
+func hostAt(name, hostname string, created time.Time) *runtimev1alpha1.Host {
+	return &runtimev1alpha1.Host{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         testNamespace,
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		HostID:   name + "-id",
+		Hostname: hostname,
+	}
+}
+
+// terminatingPod builds a Pod condemned at condemnedAt with the given grace
+// period, mirroring how the API server records a delete: DeletionTimestamp is
+// the grace *deadline*, condemnedAt + grace, not the moment of the request.
+func terminatingPod(podIP string, condemnedAt time.Time, grace int64) *corev1.Pod {
+	deadline := metav1.NewTime(condemnedAt.Add(time.Duration(grace) * time.Second))
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "hostgroup-a",
+			Namespace:                  testNamespace,
+			Labels:                     map[string]string{HostPodLabel: "pool-a"},
+			DeletionTimestamp:          &deadline,
+			DeletionGracePeriodSeconds: &grace,
+			Finalizers:                 []string{podHostFinalizerName},
+		},
+		Status: corev1.PodStatus{PodIP: podIP},
+	}
+}
+
+// TestDeleteHostForPod covers the Pod-IP-to-Host mapping the finalizer uses.
+// Kubernetes recycles Pod IPs, and this controller's own finalizer holds the
+// terminating Pod object in the API well past the point where its IP was
+// released — so the Host registered under that IP may already belong to the
+// replacement Pod, and deleting it would cascade into a live host's Workloads.
+func TestDeleteHostForPod(t *testing.T) {
+	const podIP = "10.1.2.3"
+	condemnedAt := time.Now()
+
+	t.Run("deletes the host this pod registered", func(t *testing.T) {
+		host := hostAt("own-host", podIP, condemnedAt.Add(-10*time.Minute))
+		c := newHostPodClient(t, host)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod(podIP, condemnedAt, 0)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(host), &runtimev1alpha1.Host{}); !apierrors.IsNotFound(err) {
+			t.Errorf("the pod's own host should have been deleted, got err=%v", err)
+		}
+	})
+
+	t.Run("spares a host registered after this pod was deleted", func(t *testing.T) {
+		recycled := hostAt("replacement-host", podIP, condemnedAt.Add(2*time.Second))
+		c := newHostPodClient(t, recycled)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod(podIP, condemnedAt, 0)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(recycled), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("a host that registered after the pod was deleted must be left alone, got err=%v", err)
+		}
+	})
+
+	t.Run("spares a replacement registered inside the grace window", func(t *testing.T) {
+		// The chart pins terminationGracePeriodSeconds to 0, but the
+		// Kubernetes default is 30s and a hand-written manifest or a drain
+		// gets one. DeletionTimestamp then sits in the future, covering the
+		// live hosts a replacement registered while this Pod wound down.
+		recycled := hostAt("replacement-host", podIP, condemnedAt.Add(8*time.Second))
+		c := newHostPodClient(t, recycled)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod(podIP, condemnedAt, 30)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(recycled), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("a host registered during the grace window belongs to the replacement pod, got err=%v", err)
+		}
+	})
+
+	t.Run("still deletes its own host when a grace period is set", func(t *testing.T) {
+		host := hostAt("own-host", podIP, condemnedAt.Add(-10*time.Minute))
+		c := newHostPodClient(t, host)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod(podIP, condemnedAt, 30)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(host), &runtimev1alpha1.Host{}); !apierrors.IsNotFound(err) {
+			t.Errorf("the pod's own host should still be deleted, got err=%v", err)
+		}
+	})
+
+	t.Run("leaves hosts on other IPs alone", func(t *testing.T) {
+		other := hostAt("other-host", "10.1.2.4", condemnedAt.Add(-10*time.Minute))
+		c := newHostPodClient(t, other)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod(podIP, condemnedAt, 0)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(other), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("host on another IP must be untouched, got err=%v", err)
+		}
+	})
+
+	t.Run("pod without an IP deletes nothing", func(t *testing.T) {
+		host := hostAt("own-host", podIP, condemnedAt.Add(-10*time.Minute))
+		c := newHostPodClient(t, host)
+		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+		pod := terminatingPod("", condemnedAt, 0)
+		if err := r.deleteHostForPod(context.Background(), pod); err != nil {
+			t.Fatalf("deleteHostForPod: %v", err)
+		}
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(host), &runtimev1alpha1.Host{}); err != nil {
+			t.Errorf("a pod with no IP must not delete any host, got err=%v", err)
+		}
+	})
+}
+
+// TestHostPodReconcile_RemovesFinalizerAfterCleanup walks the terminating-pod
+// path end to end: the host is deleted and the finalizer released so
+// Kubernetes can finish removing the Pod.
+func TestHostPodReconcile_RemovesFinalizerAfterCleanup(t *testing.T) {
+	const podIP = "10.1.2.3"
+	condemnedAt := time.Now()
+
+	host := hostAt("own-host", podIP, condemnedAt.Add(-10*time.Minute))
+	pod := terminatingPod(podIP, condemnedAt, 0)
+	c := newHostPodClient(t, host, pod)
+	r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pod)}
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if err := c.Get(ctx, client.ObjectKeyFromObject(host), &runtimev1alpha1.Host{}); !apierrors.IsNotFound(err) {
+		t.Errorf("host should have been deleted, got err=%v", err)
+	}
+	// Releasing the last finalizer lets the fake client complete the deletion.
+	if err := c.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Errorf("pod finalizer should have been removed, got err=%v", err)
+	}
+}

--- a/runtime-operator/operator.go
+++ b/runtime-operator/operator.go
@@ -13,12 +13,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// DefaultHeartbeatTTL is how long a host may go unheard-from before it is
+// considered unreachable: four missed heartbeats at the host's 15s interval.
+const DefaultHeartbeatTTL = 60 * time.Second
+
+// MinHeartbeatTTL is the shortest TTL the operator honours. Hosts publish every
+// 15s, so under two intervals a live fleet reads as unheard between ticks and
+// no host is ever reaped.
+const MinHeartbeatTTL = 30 * time.Second
+
 type EmbeddedOperatorConfig struct {
 	// NATS connection string. Used to communicate with hosts.
 	NatsURL string
 	// NATS options. Used to configure the NATS connection.
 	NatsOptions []nats.Option
-	// Heartbeat TTL. Used to determine how long to wait before considering a host unreachable.
+	// Heartbeat TTL. Used to determine how long to wait before considering a
+	// host unreachable. Unset means DefaultHeartbeatTTL; anything under
+	// MinHeartbeatTTL is raised to it.
 	HeartbeatTTL time.Duration
 	// Host CPU threshold (percentage).
 	// Used to calculate workload scheduling, avoiding hosts that are over this threshold.
@@ -66,6 +77,15 @@ func NewEmbeddedOperator(
 	// namespaced Role for Host CRUD binds there.
 	if cfg.Namespace == "" {
 		return nil, errors.New("EmbeddedOperatorConfig.Namespace is required")
+	}
+
+	switch {
+	case cfg.HeartbeatTTL <= 0:
+		cfg.HeartbeatTTL = DefaultHeartbeatTTL
+	case cfg.HeartbeatTTL < MinHeartbeatTTL:
+		mgr.GetLogger().Info("HeartbeatTTL raised to the minimum the host heartbeat interval allows",
+			"configured", cfg.HeartbeatTTL, "using", MinHeartbeatTTL)
+		cfg.HeartbeatTTL = MinHeartbeatTTL
 	}
 
 	nc, err := wasmbus.NatsConnect(cfg.NatsURL, cfg.NatsOptions...)


### PR DESCRIPTION
A Host's Ready verdict is built from two signals that both travel over the operator's own NATS connection: the request/reply probe in reconcileReporting, and the pushed heartbeats that advance Status.LastSeen. When both fail, reconcileReady returns a definite failure, the deleteUnresponsiveHost post-hook deletes the Host, and HostReconciler.finalize deletes every Workload assigned to it.

So an operator that cannot reach the bus is indistinguishable from a fleet that died all at once. A NATS outage, the chart by default runs it at replicas: 1, silences every host simultaneously, and UnreachableTimeout later every Host CR is gone along with every Workload on it.

The two failures also coincide at startup: an operator down longer than the window comes back to LastSeen timestamps that went stale while it was down, so a probe that fails because its own connection is not up yet is read as the host being dead rather than the operator not being ready. The symptom is `kubectl get hosts` empty while the hostgroup pods are Running, alongside a flood of "failed to stop workload on host: context deadline exceeded" from the workload finalizers.

busSettled now gates the definite-failure branch: a silent host stays Unknown, and so is never deleted, unless the operator's own connection is up and has been up for a full UnreachableTimeout. The window restarts on reconnect and at process start, so a restarted operator waits for hosts to re-announce themselves instead of condemning them.

Alongside those changes:

- handleHeartbeat passed &host.Status to hostStatusPatch, but `host` is a freshly built object whose status is always zero. It now patches from the stored status. TestHostStatusPatch_ReportedFieldsPreserved covered the helper but not the call site, so the suite stayed green.
- The pod finalizer deleted any Host matching a terminating pod's IP. Kubernetes recycles pod IPs, and this controller's own finalizer holds the
  terminating Pod in the API long after kubelet released its IP, so a replacement pod can already own it and have registered a Host under it. Hosts registered at or after the pod was condemned are now left alone.
- A HeartbeatTTL of zero put every Host past its unreachable window on the first reconcile, deleting the fleet within two passes of startup. Unset now means DefaultHeartbeatTTL, which cmd/main.go uses too.
