### PR TITLE
fix(wash-runtime): compile workloads off the async runtime

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -159,6 +159,50 @@ impl<T: HostApi> HostApi for Arc<T> {
     }
 }
 
+/// The claim-then-start protocol a caller needs when it has work to do between
+/// deciding to start a workload and having something the host can run.
+///
+/// Kept off [`HostApi`] deliberately. Its three calls only make sense together,
+/// every reservation has to reach [`WorkloadReservation::workload_start_reserved`]
+/// or [`WorkloadReservation::workload_release`], or the id sits in `Starting`
+/// with nothing on the way to fill it — and that is bookkeeping to keep inside
+/// this crate rather than an obligation to hand to everyone who implements the
+/// host's API.
+pub(crate) trait WorkloadReservation {
+    /// Claim a workload id before doing the work a start needs.
+    ///
+    /// A caller that has to fetch images first would otherwise leave the id in
+    /// no map for as long as that takes: `workload_status` reports it missing
+    /// and `workload_stop` reports it already gone, so a stop arriving in that
+    /// window tells its caller the teardown is done while the start goes on to
+    /// run the workload. Reserving first puts the id in `Starting` for the
+    /// whole window, where both of those read it correctly and a stop hands the
+    /// teardown back to the start.
+    ///
+    /// `Err` carries the refusal to report, and reserves nothing.
+    fn workload_reserve(
+        &self,
+        workload_id: &str,
+    ) -> impl Future<Output = Result<Reservation, String>>;
+
+    /// Give back an id claimed by [`WorkloadReservation::workload_reserve`]
+    /// whose start never began. Does nothing if the id has moved on to another
+    /// owner.
+    fn workload_release(
+        &self,
+        workload_id: &str,
+        reservation: Reservation,
+    ) -> impl Future<Output = ()>;
+
+    /// Start a workload under an id already claimed by
+    /// [`WorkloadReservation::workload_reserve`].
+    fn workload_start_reserved(
+        &self,
+        reservation: Reservation,
+        request: WorkloadStartRequest,
+    ) -> impl Future<Output = anyhow::Result<WorkloadStartResponse>>;
+}
+
 /// A claim on one workload id, minted whenever a task takes responsibility for
 /// that id and never reused within a host.
 ///
@@ -737,10 +781,22 @@ impl Host {
         let service_present = request.workload.service.is_some();
         let workload_id = request.workload_id.clone();
 
-        // Initialize the workload using the engine, receiving the unresolved workload
-        let unresolved_workload = self
-            .engine
-            .initialize_workload(&request.workload_id, request.workload)?;
+        // Initialize the workload using the engine, receiving the unresolved workload.
+        //
+        // Cranelift compiles every component here, guarded by the moka cache.
+        // This occupies whichever thread runs it for as long as compilation takes.
+        // On a runtime thread, that may stall async-nats connection task alongside it
+        // and a host that stops draining its socket is disconnected as a slow consumer.
+        let engine = self.engine.clone();
+        let init_id = request.workload_id;
+        let workload = request.workload;
+        let span = tracing::Span::current();
+        let unresolved_workload = tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
+            engine.initialize_workload(&init_id, workload)
+        })
+        .await
+        .context("workload initialization task failed")??;
 
         // `resolve` binds the workload's plugins, and gives back whatever it
         // bound if any part of that fails.
@@ -847,127 +903,17 @@ impl HostApi for Host {
         &self,
         request: WorkloadStartRequest,
     ) -> anyhow::Result<WorkloadStartResponse> {
-        // Reserve the workload ID while holding the write lock so concurrent
-        // starts cannot both observe it as available. An ID remains reserved
-        // in every lifecycle state until workload_stop removes it. The
-        // reservation stamped on the slot is what lets the commit below tell
-        // this start's slot from one a later start claimed.
-        let reservation = self.reserve();
-        {
-            let mut workloads = self.workloads.write().await;
-            if workloads.contains_key(&request.workload_id) {
-                let message = format!(
-                    "Workload ID [{}] already exists (the exising workload must be stopped to reuse the ID)",
-                    request.workload_id
-                );
-                // Logged here rather than at the single site below, because
-                // this refusal returns before the start ever begins. At `warn`,
-                // not `error`: this is the guard that makes a replayed start
-                // request idempotent, and a scheduler retrying one is not a
-                // host malfunction.
-                tracing::warn!(
-                    workload_id = request.workload_id,
-                    reason = message,
-                    "refused to start workload"
-                );
-                return Ok(WorkloadStartResponse {
-                    workload_status: WorkloadStatus {
-                        workload_id: request.workload_id.clone(),
-                        workload_state: WorkloadState::Error,
-                        message,
-                    },
-                });
-            }
-            workloads.insert(
-                request.workload_id.clone(),
-                HostWorkload::Starting(reservation),
-            );
-        }
-
         let workload_id = request.workload_id.clone();
-        let started = self.workload_start_inner(request).await;
-
-        // Commit under the same lock the id was reserved under, and only into
-        // the slot this start reserved. Anything else in that slot means the
-        // workload was stopped or failed while this was still starting: writing
-        // `Running` over it would resurrect a workload nobody is tracking, and
-        // simply dropping the result — which is what an `and_modify` that finds
-        // no entry does — would leave its plugins bound and its service running
-        // detached.
-        let (workload_state, message, orphaned) = {
-            let mut workloads = self.workloads.write().await;
-            let slot = workloads.get(&workload_id);
-            let mine = matches!(slot, Some(HostWorkload::Starting(held)) if *held == reservation);
-            // A stop that arrived mid-start handed the teardown back by marking
-            // the slot `Stopping` under this start's own reservation.
-            let handed_back =
-                matches!(slot, Some(HostWorkload::Stopping(held)) if *held == reservation);
-            match started {
-                Ok(resolved) if mine => {
-                    workloads.insert(
-                        workload_id.clone(),
-                        HostWorkload::Running(Box::new(resolved)),
-                    );
-                    (
-                        WorkloadState::Running,
-                        "Workload started successfully".to_string(),
-                        None,
-                    )
-                }
-                // Stopped (or failed) while starting. The stop could not tear
-                // this down because it did not exist yet, so that falls to us.
-                // The `Stopping` marker is left in place for the whole teardown:
-                // it keeps the id reserved, so a new start cannot claim it and
-                // then be unbound by our teardown.
-                Ok(resolved) => (
-                    WorkloadState::Stopping,
-                    "Workload was stopped while starting".to_string(),
-                    Some(resolved),
-                ),
-                Err(err) => {
-                    // `{:#}` so the whole context chain reaches the caller and
-                    // the log below: the outer layer alone ("failed to pull
-                    // image for component 'x'") never names the cause.
-                    let message = format!("{err:#}");
-                    if mine {
-                        workloads.insert(workload_id.clone(), HostWorkload::Error(message.clone()));
-                    } else if handed_back {
-                        // A stop is waiting on this start to finish. Nothing is
-                        // bound — `workload_start_inner` released it before
-                        // returning — so the id can go now.
-                        workloads.remove(&workload_id);
-                    }
-                    (WorkloadState::Error, message, None)
-                }
-            }
-        };
-
-        // A start that failed is reported to whoever asked and nowhere else.
-        // Say so locally too: the operator diagnosing it — a pull against a
-        // registry this host does not trust, a plugin that would not bind — is
-        // reading the host's log, and without this the host has nothing to say.
-        if workload_state == WorkloadState::Error {
-            // `reason`, not `message`: `message` is the field tracing gives
-            // the event's own text, and a second one under that name displaces
-            // it.
-            tracing::error!(workload_id, reason = message, "failed to start workload");
+        match self.workload_reserve(&workload_id).await {
+            Ok(reservation) => self.workload_start_reserved(reservation, request).await,
+            Err(message) => Ok(WorkloadStartResponse {
+                workload_status: WorkloadStatus {
+                    workload_id,
+                    workload_state: WorkloadState::Error,
+                    message,
+                },
+            }),
         }
-
-        if let Some(resolved) = orphaned {
-            release(&workload_id, &resolved).await;
-            // Only if the `Stopping` marker is still this start's. It may not be
-            // — a failure reported mid-start writes `Error` over it — and then
-            // the slot is not ours to drop.
-            self.finish_teardown(&workload_id, reservation, None).await;
-        }
-
-        Ok(WorkloadStartResponse {
-            workload_status: WorkloadStatus {
-                workload_id,
-                workload_state,
-                message,
-            },
-        })
     }
 
     #[instrument(skip_all, fields(workload.id = request.workload_id))]
@@ -1099,6 +1045,140 @@ impl HostApi for Host {
         Ok(WorkloadStopResponse {
             workload_status: WorkloadStatus {
                 workload_id: request.workload_id,
+                workload_state,
+                message,
+            },
+        })
+    }
+}
+
+impl WorkloadReservation for Host {
+    #[instrument(skip_all, fields(workload.id = workload_id))]
+    async fn workload_reserve(&self, workload_id: &str) -> Result<Reservation, String> {
+        // Reserve the workload ID while holding the write lock so concurrent
+        // starts cannot both observe it as available. An ID remains reserved
+        // in every lifecycle state until workload_stop removes it. The
+        // reservation stamped on the slot is what lets the commit in
+        // `workload_start_reserved` tell this start's slot from one a later
+        // start claimed.
+        let reservation = self.reserve();
+        let mut workloads = self.workloads.write().await;
+        if workloads.contains_key(workload_id) {
+            let message = format!(
+                "Workload ID [{workload_id}] already exists (the exising workload must be stopped to reuse the ID)"
+            );
+            // Logged here rather than where the response is built, because this
+            // refusal returns before the start ever begins. At `warn`, not
+            // `error`: this is the guard that makes a replayed start request
+            // idempotent, and a scheduler retrying one is not a host
+            // malfunction.
+            tracing::warn!(workload_id, reason = message, "refused to start workload");
+            return Err(message);
+        }
+        workloads.insert(workload_id.to_string(), HostWorkload::Starting(reservation));
+        Ok(reservation)
+    }
+
+    #[instrument(skip_all, fields(workload.id = workload_id))]
+    async fn workload_release(&self, workload_id: &str, reservation: Reservation) {
+        let mut workloads = self.workloads.write().await;
+        // Either state this reservation can still be in holds nothing bound: a
+        // start that never began, or one a stop handed the teardown back to
+        // before it had built anything. Anything else belongs to someone else.
+        if matches!(
+            workloads.get(workload_id),
+            Some(HostWorkload::Starting(held) | HostWorkload::Stopping(held)) if *held == reservation
+        ) {
+            workloads.remove(workload_id);
+        }
+    }
+
+    #[instrument(skip_all)]
+    async fn workload_start_reserved(
+        &self,
+        reservation: Reservation,
+        request: WorkloadStartRequest,
+    ) -> anyhow::Result<WorkloadStartResponse> {
+        let workload_id = request.workload_id.clone();
+        let started = self.workload_start_inner(request).await;
+
+        // Commit under the same lock the id was reserved under, and only into
+        // the slot this start reserved. Anything else in that slot means the
+        // workload was stopped or failed while this was still starting: writing
+        // `Running` over it would resurrect a workload nobody is tracking, and
+        // simply dropping the result — which is what an `and_modify` that finds
+        // no entry does — would leave its plugins bound and its service running
+        // detached.
+        let (workload_state, message, orphaned) = {
+            let mut workloads = self.workloads.write().await;
+            let slot = workloads.get(&workload_id);
+            let mine = matches!(slot, Some(HostWorkload::Starting(held)) if *held == reservation);
+            // A stop that arrived mid-start handed the teardown back by marking
+            // the slot `Stopping` under this start's own reservation.
+            let handed_back =
+                matches!(slot, Some(HostWorkload::Stopping(held)) if *held == reservation);
+            match started {
+                Ok(resolved) if mine => {
+                    workloads.insert(
+                        workload_id.clone(),
+                        HostWorkload::Running(Box::new(resolved)),
+                    );
+                    (
+                        WorkloadState::Running,
+                        "Workload started successfully".to_string(),
+                        None,
+                    )
+                }
+                // Stopped (or failed) while starting. The stop could not tear
+                // this down because it did not exist yet, so that falls to us.
+                // The `Stopping` marker is left in place for the whole teardown:
+                // it keeps the id reserved, so a new start cannot claim it and
+                // then be unbound by our teardown.
+                Ok(resolved) => (
+                    WorkloadState::Stopping,
+                    "Workload was stopped while starting".to_string(),
+                    Some(resolved),
+                ),
+                Err(err) => {
+                    // `{:#}` so the whole context chain reaches the caller and
+                    // the log below: the outer layer alone ("failed to pull
+                    // image for component 'x'") never names the cause.
+                    let message = format!("{err:#}");
+                    if mine {
+                        workloads.insert(workload_id.clone(), HostWorkload::Error(message.clone()));
+                    } else if handed_back {
+                        // A stop is waiting on this start to finish. Nothing is
+                        // bound — `workload_start_inner` released it before
+                        // returning — so the id can go now.
+                        workloads.remove(&workload_id);
+                    }
+                    (WorkloadState::Error, message, None)
+                }
+            }
+        };
+
+        // A start that failed is reported to whoever asked and nowhere else.
+        // Say so locally too: the operator diagnosing it — a pull against a
+        // registry this host does not trust, a plugin that would not bind — is
+        // reading the host's log, and without this the host has nothing to say.
+        if workload_state == WorkloadState::Error {
+            // `reason`, not `message`: `message` is the field tracing gives
+            // the event's own text, and a second one under that name displaces
+            // it.
+            tracing::error!(workload_id, reason = message, "failed to start workload");
+        }
+
+        if let Some(resolved) = orphaned {
+            release(&workload_id, &resolved).await;
+            // Only if the `Stopping` marker is still this start's. It may not be
+            // — a failure reported mid-start writes `Error` over it — and then
+            // the slot is not ours to drop.
+            self.finish_teardown(&workload_id, reservation, None).await;
+        }
+
+        Ok(WorkloadStartResponse {
+            workload_status: WorkloadStatus {
+                workload_id,
                 workload_state,
                 message,
             },

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -3,17 +3,35 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::component_source::{ComponentSource, LoadedComponent};
-use crate::host::{Host, HostApi, HostConfig};
+use crate::host::{Host, HostApi, HostConfig, WorkloadReservation};
 use crate::oci::{self, OciConfig};
 use crate::plugin::HostPlugin;
 use anyhow::{Context as _, anyhow};
 use futures::StreamExt as _;
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 pub const HOST_API_PREFIX: &str = "runtime.host";
 pub const OPERATOR_API_PREFIX: &str = "runtime.operator";
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+/// How many `workload.start` requests a host pulls and compiles at once.
+///
+/// This is not a tuning knob: it bounds how many images are held in memory and
+/// compiled at once. The compile is the half that sets it — each permitted
+/// start ends in a Cranelift compile on the blocking pool, and a host pod with
+/// a couple of cores oversubscribed several times over starves the runtime
+/// threads it shares that CPU with, which is the stall this path exists to
+/// avoid. Sized to what a small pod can compile at once, not to what its
+/// network could pull.
+const MAX_CONCURRENT_STARTS: usize = 4;
+/// How long shutdown waits for in-flight commands before abandoning them.
+///
+/// A start stalled on an unreachable registry runs to its own pull timeout, and
+/// waiting all of them out would hold shutdown for minutes — past the grace
+/// period a terminating pod gets, so it is killed before `host.stop()` unbinds
+/// anything. Better to abandon them and stop the host, which unbinds whatever
+/// they had bound anyway.
+const COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub mod types {
     pub mod v2 {
@@ -37,6 +55,7 @@ pub struct ClusterHostBuilder {
     cleanup_interval: Option<Duration>,
     cleanup_age: Option<Duration>,
     host_config: Option<HostConfig>,
+    max_concurrent_starts: Option<usize>,
 }
 
 impl ClusterHostBuilder {
@@ -101,9 +120,31 @@ impl ClusterHostBuilder {
         Ok(self)
     }
 
+    /// A zero frequency is read as unset and takes the default. Passing it on
+    /// would panic `tokio::time::interval` inside the spawned task, where the
+    /// host reports itself started and then serves nothing; clamping it to some
+    /// tiny period instead trades that for the cleanup walking the OCI cache
+    /// thousands of times a second, inline in the loop that serves requests.
     pub fn with_artifact_cleaner(mut self, frequency: Duration, max_age: Duration) -> Self {
-        self.cleanup_interval = Some(frequency);
+        self.cleanup_interval = (!frequency.is_zero()).then_some(frequency);
         self.cleanup_age = Some(max_age);
+        self
+    }
+
+    /// Sets how often the host publishes to `runtime.operator.heartbeat.{id}`.
+    /// It has to stay well inside the operator's unreachable window, which
+    /// deletes a host it has not heard from along with its workloads.
+    /// Zero is read as unset and takes the default, for the same reason as
+    /// [`ClusterHostBuilder::with_artifact_cleaner`].
+    pub fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat_interval = (!interval.is_zero()).then_some(interval);
+        self
+    }
+
+    /// Caps how many `workload.start` requests this host serves at once.
+    /// Zero is raised to one: a host that cannot start anything is not a host.
+    pub fn with_max_concurrent_starts(mut self, starts: usize) -> Self {
+        self.max_concurrent_starts = Some(starts.max(1));
         self
     }
 
@@ -157,6 +198,7 @@ impl ClusterHostBuilder {
             heartbeat_interval,
             cleanup_interval: self.cleanup_interval.unwrap_or(Duration::from_secs(300)),
             cleanup_age: self.cleanup_age.unwrap_or(Duration::from_secs(3600)),
+            max_concurrent_starts: self.max_concurrent_starts.unwrap_or(MAX_CONCURRENT_STARTS),
         })
     }
 }
@@ -167,6 +209,7 @@ pub struct ClusterHost {
     heartbeat_interval: Duration,
     cleanup_interval: Duration,
     cleanup_age: Duration,
+    max_concurrent_starts: usize,
 }
 
 impl ClusterHost {
@@ -188,6 +231,7 @@ impl ClusterHost {
 
         let heartbeat_interval = self.heartbeat_interval;
         let cleanup_interval = self.cleanup_interval;
+        let max_concurrent_starts = self.max_concurrent_starts;
         let host_id = host.id().to_string();
         let host = host.clone();
 
@@ -214,14 +258,61 @@ impl ClusterHost {
                     .context("failed to subscribe for API requests")?;
                 let mut heartbeat_timer = tokio::time::interval(heartbeat_interval);
 
+                // Only `workload.start` waits on this permit; stops and status
+                // never do, so neither queues behind a pull.
+                let starts = Arc::new(tokio::sync::Semaphore::new(max_concurrent_starts));
+                // Commands run as their own tasks, so shutdown has to wait for
+                // them: `host.stop()` unbinds every plugin, and a start still
+                // running past it would bind against stopped plugins and leave
+                // a service nothing tears down.
+                let mut commands = tokio::task::JoinSet::new();
+
                 let mut oci_cleanup_timer = tokio::time::interval(cleanup_interval);
 
                 loop {
                     tokio::select! {
                         // Shutdown signal
                         _ = &mut one_shot_rx => {
-                            api_subscription.unsubscribe().await.context("failed to unsubscribe from API requests")?;
+                            if let Err(e) = api_subscription.unsubscribe().await {
+                                error!("failed to unsubscribe from API requests: {e}");
+                            }
+                            // Anything still queued gives its workload id back
+                            // and returns rather than starting something this
+                            // host is about to tear down.
+                            starts.close();
+                            let drained = tokio::time::timeout(COMMAND_DRAIN_TIMEOUT, async {
+                                while let Some(finished) = commands.join_next().await {
+                                    if let Err(e) = finished {
+                                        error!("command task failed during shutdown: {e}");
+                                    }
+                                }
+                            })
+                            .await;
+                            if drained.is_err() {
+                                warn!(
+                                    "commands still running after {COMMAND_DRAIN_TIMEOUT:?}; \
+                                     abandoning them to stop the host"
+                                );
+                                commands.abort_all();
+                                // `abort_all` only asks. Wait for the tasks to
+                                // reach their next await and unwind, or
+                                // `host.stop()` unbinds plugins underneath one
+                                // still binding them.
+                                while commands.join_next().await.is_some() {}
+                            }
                             return host.stop().await.context("failed to stop host");
+                        }
+                        // Reaps finished commands. A panicked one is fatal: it
+                        // may have died holding a workload id it claimed and
+                        // never committed or released, and no later stop can
+                        // free that slot — the id would be refused as "already
+                        // exists" for the life of the host. Taking the host
+                        // down is what a panic here did before commands ran as
+                        // their own tasks, and a restart is what clears it.
+                        Some(finished) = commands.join_next() => {
+                            if let Err(e) = finished {
+                                return Err(anyhow!("command task failed: {e}"));
+                            }
                         }
                         // OCI cache cleanup
                         _ = oci_cleanup_timer.tick() => {
@@ -232,24 +323,55 @@ impl ClusterHost {
                         }
                         // Send heartbeat
                         _ = heartbeat_timer.tick() => {
-                            let heartbeat = host_heartbeat(&host).await?;
-                            let heartbeat_bytes = serde_json::to_vec(&heartbeat)
-                                .context("failed to serialize heartbeat")?;
-                            nats_client.publish(heartbeat_subject.clone(), heartbeat_bytes.into()).await.context("failed to publish heartbeat")?;
+                            // Returning here would drop `commands`, aborting
+                            // in-flight starts after they have reserved their
+                            // ids, and skip the `host.stop()` that unbinds
+                            // their plugins. A missed heartbeat is worth none
+                            // of that; the next tick tries again.
+                            match host_heartbeat(&host).await.and_then(|heartbeat| {
+                                serde_json::to_vec(&heartbeat).context("failed to serialize heartbeat")
+                            }) {
+                                Ok(heartbeat_bytes) => {
+                                    if let Err(e) = nats_client
+                                        .publish(heartbeat_subject.clone(), heartbeat_bytes.into())
+                                        .await
+                                    {
+                                        error!("failed to publish heartbeat: {e}");
+                                    }
+                                }
+                                Err(e) => error!("failed to build heartbeat: {e}"),
+                            }
                         }
                         // Handle API requests
                         Some(msg) = api_subscription.next() => {
-                            let response = handle_command(host.as_ref(), &msg, host.config()).await;
-                            match response {
-                                Ok(resp_bytes) => {
-                                    if let Some(reply_to) = msg.reply {
-                                        nats_client.publish(reply_to, resp_bytes.into()).await.context("failed to publish API response")?;
+                            // `select!` runs one branch to completion, so a
+                            // command awaited here would hold up the heartbeat
+                            // above for as long as it takes to pull and compile.
+                            // A host whose heartbeats stop looks unreachable to
+                            // the operator, which deletes it and its workloads.
+                            //
+                            // Commands naming one workload are ordered by the
+                            // host's reservation on that id, not by this loop:
+                            // a start claims the id before it fetches anything,
+                            // and a stop that finds the claim hands the teardown
+                            // back to the start holding it.
+                            let host = host.clone();
+                            let nats_client = nats_client.clone();
+                            let starts = Arc::clone(&starts);
+                            commands.spawn(async move {
+                                match handle_command(host.as_ref(), &msg, host.config(), &starts).await {
+                                    Ok(resp_bytes) => {
+                                        if let Some(reply_to) = msg.reply
+                                            && let Err(e) = nats_client.publish(reply_to, resp_bytes.into()).await
+                                        {
+                                            error!("failed to publish API response: {e}");
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("error handling command: {e}");
                                     }
                                 }
-                                Err(e) => {
-                                    error!("error handling command: {e}");
-                                }
-                            }
+                            });
                         }
                     }
                 }
@@ -365,9 +487,10 @@ fn from_api<'de, T: serde::Deserialize<'de>>(bytes: &'de [u8]) -> Result<T, anyh
 
 #[instrument(level = "debug", skip_all, fields(subject = %msg.subject))]
 async fn handle_command(
-    host: &impl HostApi,
+    host: &(impl HostApi + WorkloadReservation),
     msg: &async_nats::Message,
     config: &HostConfig,
+    starts: &tokio::sync::Semaphore,
 ) -> Result<Vec<u8>, anyhow::Error> {
     let command = msg.subject.split('.').skip(3).collect::<Vec<_>>().join(".");
 
@@ -380,7 +503,7 @@ async fn handle_command(
         }
         "workload.start" => {
             let req: types::v2::WorkloadStartRequest = from_api(payload)?;
-            let res = workload_start(host, req, config).await?;
+            let res = workload_start(host, req, config, starts).await?;
             to_api(&res)
         }
         "workload.stop" => {
@@ -471,9 +594,10 @@ fn workload_start_error(workload_id: &str, message: String) -> types::v2::Worklo
     workload.namespace=?req.workload.as_ref().map(|w| &w.namespace).unwrap_or(&"<none>".to_string())),
     )]
 async fn workload_start(
-    host: &impl HostApi,
+    host: &impl WorkloadReservation,
     req: types::v2::WorkloadStartRequest,
     config: &HostConfig,
+    starts: &tokio::sync::Semaphore,
 ) -> anyhow::Result<types::v2::WorkloadStartResponse> {
     let Some(types::v2::Workload {
         namespace,
@@ -492,104 +616,145 @@ async fn workload_start(
         anyhow::bail!("workload_id is required");
     }
 
-    let (components, host_interfaces) = if let Some(wit_world) = wit_world {
-        let mut pulled_components = Vec::with_capacity(wit_world.components.len());
-        for component in &wit_world.components {
-            let oci_config = image_pull_secret_to_oci_config(config, &component.image_pull_secret);
-            let source = ComponentSource::Oci {
-                image: component.image.clone(),
-                pull_policy: component.image_pull_policy().into(),
-            };
-            // `load` already names the reference it failed on; this says which
-            // of the workload's components asked for it, so a multi-component
-            // start reports something the operator can act on.
-            let loaded =
-                match source.load(oci_config).await.with_context(|| {
+    // Claimed before any image is fetched. Until the host holds the id a
+    // status reports it missing and a stop reports it already gone, so a stop
+    // arriving here would tell the operator the teardown is done while this
+    // start goes on to run the workload.
+    let reservation = match host.workload_reserve(&workload_id).await {
+        Ok(reservation) => reservation,
+        // Reported, not logged again: the host logs this refusal at `warn`
+        // precisely because a scheduler replaying a start is not a malfunction,
+        // and `workload_start_error` would raise the same event to `error`.
+        Err(message) => {
+            return Ok(types::v2::WorkloadStartResponse {
+                workload_status: Some(types::v2::WorkloadStatus {
+                    workload_id,
+                    workload_state: types::v2::WorkloadState::Error.into(),
+                    message,
+                }),
+            });
+        }
+    };
+
+    // Queued with the id already claimed. Waiting for a permit is time like
+    // any other in which a stop or a status has to find this workload.
+    let _permit = match starts.acquire().await {
+        Ok(permit) => permit,
+        Err(e) => {
+            host.workload_release(&workload_id, reservation).await;
+            return Ok(workload_start_error(
+                &workload_id,
+                format!("host is no longer accepting starts: {e}"),
+            ));
+        }
+    };
+
+    // Every exit from here gives the id back, so a start that never began
+    // cannot leave it reserved against the next one.
+    let prepared = async {
+        let (components, host_interfaces) = if let Some(wit_world) = wit_world {
+            let mut pulled_components = Vec::with_capacity(wit_world.components.len());
+            for component in &wit_world.components {
+                let oci_config =
+                    image_pull_secret_to_oci_config(config, &component.image_pull_secret);
+                let source = ComponentSource::Oci {
+                    image: component.image.clone(),
+                    pull_policy: component.image_pull_policy().into(),
+                };
+                // `load` already names the reference it failed on; this says which
+                // of the workload's components asked for it, so a multi-component
+                // start reports something the operator can act on.
+                let loaded = match source.load(oci_config).await.with_context(|| {
                     format!("failed to pull image for component '{}'", component.name)
                 }) {
                     Ok(loaded) => loaded,
-                    Err(e) => return Ok(workload_start_error(&workload_id, format!("{e:#}"))),
+                    Err(e) => return Err(format!("{e:#}")),
                 };
-            let local_resources = match component.local_resources.clone() {
+                let local_resources = match component.local_resources.clone() {
+                    Some(lr) => match crate::types::LocalResources::try_from(lr) {
+                        Ok(lr) => lr,
+                        Err(e) => {
+                            return Err(format!(
+                                "invalid local_resources for component {}: {e:#}",
+                                component.name
+                            ));
+                        }
+                    },
+                    None => crate::types::LocalResources::default(),
+                };
+                pulled_components.push(component_from_wire(component, loaded, local_resources))
+            }
+            (
+                pulled_components,
+                wit_world
+                    .host_interfaces
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            )
+        } else {
+            (vec![], vec![])
+        };
+
+        let service = if let Some(service) = service {
+            let oci_config = image_pull_secret_to_oci_config(config, &service.image_pull_secret);
+            let source = ComponentSource::Oci {
+                image: service.image.clone(),
+                pull_policy: service.image_pull_policy().into(),
+            };
+            // Distinguishes a service pull failure from a component one; both
+            // otherwise report the same reference and cause.
+            let loaded = match source
+                .load(oci_config)
+                .await
+                .context("failed to pull image for the workload service")
+            {
+                Ok(loaded) => loaded,
+                Err(e) => return Err(format!("{e:#}")),
+            };
+            let local_resources = match service.local_resources.clone() {
                 Some(lr) => match crate::types::LocalResources::try_from(lr) {
                     Ok(lr) => lr,
                     Err(e) => {
-                        return Ok(workload_start_error(
-                            &workload_id,
-                            format!(
-                                "invalid local_resources for component {}: {e:#}",
-                                component.name
-                            ),
-                        ));
+                        return Err(format!("invalid local_resources for service: {e:#}"));
                     }
                 },
                 None => crate::types::LocalResources::default(),
             };
-            pulled_components.push(component_from_wire(component, loaded, local_resources))
-        }
-        (
-            pulled_components,
-            wit_world
-                .host_interfaces
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        )
-    } else {
-        (vec![], vec![])
-    };
+            Some(crate::types::Service {
+                bytes: loaded.bytes,
+                digest: loaded.digest,
+                local_resources,
+                max_restarts: service.max_restarts,
+            })
+        } else {
+            None
+        };
 
-    let service = if let Some(service) = service {
-        let oci_config = image_pull_secret_to_oci_config(config, &service.image_pull_secret);
-        let source = ComponentSource::Oci {
-            image: service.image.clone(),
-            pull_policy: service.image_pull_policy().into(),
-        };
-        // Distinguishes a service pull failure from a component one; both
-        // otherwise report the same reference and cause.
-        let loaded = match source
-            .load(oci_config)
-            .await
-            .context("failed to pull image for the workload service")
-        {
-            Ok(loaded) => loaded,
-            Err(e) => return Ok(workload_start_error(&workload_id, format!("{e:#}"))),
-        };
-        let local_resources = match service.local_resources.clone() {
-            Some(lr) => match crate::types::LocalResources::try_from(lr) {
-                Ok(lr) => lr,
-                Err(e) => {
-                    return Ok(workload_start_error(
-                        &workload_id,
-                        format!("invalid local_resources for service: {e:#}"),
-                    ));
-                }
+        let volumes = volumes.into_iter().map(Into::into).collect();
+
+        let request = crate::types::WorkloadStartRequest {
+            workload_id: workload_id.clone(),
+            workload: crate::types::Workload {
+                namespace,
+                name,
+                annotations,
+                service,
+                components,
+                host_interfaces,
+                volumes,
             },
-            None => crate::types::LocalResources::default(),
         };
-        Some(crate::types::Service {
-            bytes: loaded.bytes,
-            digest: loaded.digest,
-            local_resources,
-            max_restarts: service.max_restarts,
-        })
-    } else {
-        None
-    };
+        Ok(request)
+    }
+    .await;
 
-    let volumes = volumes.into_iter().map(Into::into).collect();
-
-    let request = crate::types::WorkloadStartRequest {
-        workload_id: workload_id.clone(),
-        workload: crate::types::Workload {
-            namespace,
-            name,
-            annotations,
-            service,
-            components,
-            host_interfaces,
-            volumes,
-        },
+    let request = match prepared {
+        Ok(request) => request,
+        Err(message) => {
+            host.workload_release(&workload_id, reservation).await;
+            return Ok(workload_start_error(&workload_id, message));
+        }
     };
 
     info!(
@@ -598,7 +763,10 @@ async fn workload_start(
         name=?request.workload.name,
         "Starting workload");
 
-    Ok(host.workload_start(request).await?.into())
+    Ok(host
+        .workload_start_reserved(reservation, request)
+        .await?
+        .into())
 }
 
 #[instrument(skip_all, fields(workload_id = %req.workload_id))]

--- a/crates/wash-runtime/tests/integration_start_off_runtime.rs
+++ b/crates/wash-runtime/tests/integration_start_off_runtime.rs
@@ -1,0 +1,86 @@
+//! Pins that starting a workload leaves the async runtime free to make
+//! progress.
+//!
+//! Compiling a component is synchronous, CPU-bound Cranelift work. Run on a
+//! runtime thread it holds that thread for the whole compile, and the host's
+//! NATS connection task is one of the things that then cannot be polled — a
+//! host that stops draining its socket is dropped by the server as a slow
+//! consumer, which the operator sees as a host that has gone away.
+//!
+//! This is why the check is not an end-to-end one: from outside, a host that
+//! compiled on its runtime thread and one that did not both just start the
+//! workload. The difference is which thread was busy, and the way to make that
+//! observable is to give the runtime exactly one worker.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use wash_runtime::host::{Host, HostApi};
+use wash_runtime::types::{Component, Workload, WorkloadStartRequest};
+
+/// Big enough that compiling it is unmistakably longer than the scheduling
+/// noise around it.
+const COMPONENT_WASM: &[u8] = include_bytes!("wasm/http_egress_pool.wasm");
+
+/// `#[tokio::test]` runs on a current-thread runtime: one worker. Synchronous
+/// work on it stops everything else, so "the compile blocked the runtime" and
+/// "it did not" are different in kind rather than in degree. On a multi-threaded
+/// runtime, occupying one worker out of many hides until the machine is loaded
+/// — which is exactly how this reached production.
+#[tokio::test]
+async fn compiling_a_workload_leaves_the_runtime_free() -> Result<()> {
+    let host = Host::builder().build()?;
+
+    // Ticks whenever the runtime has a moment to poll it.
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let ticker = tokio::spawn({
+        let ticks = Arc::clone(&ticks);
+        async move {
+            loop {
+                ticks.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+    tokio::task::yield_now().await;
+    let before = ticks.load(Ordering::SeqCst);
+
+    let response = host
+        .workload_start(WorkloadStartRequest {
+            workload_id: "compile-off-runtime".to_string(),
+            workload: Workload {
+                namespace: "wasmcloud".to_string(),
+                name: "compile-off-runtime".to_string(),
+                annotations: Default::default(),
+                service: None,
+                components: vec![Component {
+                    name: "compiled".to_string(),
+                    bytes: COMPONENT_WASM.into(),
+                    digest: None,
+                    local_resources: Default::default(),
+                    pool_size: 0,
+                    max_invocations: 0,
+                    max_concurrency: 0,
+                }],
+                host_interfaces: vec![],
+                volumes: vec![],
+            },
+        })
+        .await?;
+
+    let during = ticks.load(Ordering::SeqCst) - before;
+    ticker.abort();
+
+    // Whether the workload itself came up is beside the point — it may want
+    // plugins this bare host has not got. The compile ran either way, and that
+    // is what had to leave the runtime thread.
+    let _ = response;
+
+    assert!(
+        during > 100,
+        "the runtime polled another task only {during} times while a component compiled; \
+         a compile on the runtime thread starves the host's NATS connection task with it"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_washlet_api.rs
+++ b/crates/wash-runtime/tests/integration_washlet_api.rs
@@ -8,8 +8,9 @@
 //!   workload ID (the operator records it from the response without checking
 //!   the state), and leaves the original workload untouched; the ID becomes
 //!   reusable only after an explicit `workload.stop`.
-//! - A start that fails before the host reserves the ID (OCI pull failure in
-//!   the washlet) does not consume the ID.
+//! - A start claims its workload ID before fetching anything, so a stop or a
+//!   status arriving mid-start reports the workload rather than a gap; a start
+//!   that then fails (OCI pull failure in the washlet) gives the ID back.
 //! - `finalize`'s idempotent teardown: stop/status of an unknown ID answer
 //!   `WORKLOAD_STATE_NOT_FOUND` instead of erroring.
 //! - Host registration: the published heartbeat and the `heartbeat` RPC carry
@@ -48,71 +49,106 @@ struct TestHarness {
     _container: ContainerAsync<GenericImage>,
 }
 
-async fn setup() -> Result<TestHarness> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init()
-        .ok();
+/// A NATS container and a washlet on it, configured the way the code under
+/// test is: `with_*` setters over the knobs a test cares about, defaults for
+/// the rest.
+#[derive(Default)]
+struct TestHarnessBuilder {
+    heartbeat_interval: Option<Duration>,
+    max_concurrent_starts: Option<usize>,
+}
 
-    let container = GenericImage::new("nats", "2.12.8-alpine")
-        .with_exposed_port(4222.tcp())
-        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
-        .start()
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to start NATS container: {e}"))?;
-    let port = container
-        .get_host_port_ipv4(4222)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to get NATS host port: {e}"))?;
-    let nats_url = format!("nats://127.0.0.1:{port}");
+impl TestHarnessBuilder {
+    fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat_interval = Some(interval);
+        self
+    }
 
-    // The washlet holds its own client; the tests drive the API over a
-    // separate connection, mirroring the operator being a distinct peer.
-    let washlet_client = Arc::new(
-        async_nats::connect(&nats_url)
+    fn with_max_concurrent_starts(mut self, starts: usize) -> Self {
+        self.max_concurrent_starts = Some(starts);
+        self
+    }
+
+    async fn start(self) -> Result<TestHarness> {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init()
+            .ok();
+
+        let container = GenericImage::new("nats", "2.12.8-alpine")
+            .with_exposed_port(4222.tcp())
+            .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+            .start()
             .await
-            .context("failed to connect washlet NATS client")?,
-    );
-    let api_client = async_nats::connect(&nats_url)
-        .await
-        .context("failed to connect API NATS client")?;
+            .map_err(|e| anyhow::anyhow!("failed to start NATS container: {e}"))?;
+        let port = container
+            .get_host_port_ipv4(4222)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to get NATS host port: {e}"))?;
+        let nats_url = format!("nats://127.0.0.1:{port}");
 
-    let cluster_host = ClusterHostBuilder::default()
-        .with_host_group(HOST_GROUP)
-        .with_environment(ENVIRONMENT)
-        .with_nats_client(washlet_client)
-        .build()
-        .context("failed to build cluster host")?;
-    let host_id = cluster_host.host().id().to_string();
+        // The washlet holds its own client; the tests drive the API over a
+        // separate connection, mirroring the operator being a distinct peer.
+        let washlet_client = Arc::new(
+            async_nats::connect(&nats_url)
+                .await
+                .context("failed to connect washlet NATS client")?,
+        );
+        let api_client = async_nats::connect(&nats_url)
+            .await
+            .context("failed to connect API NATS client")?;
 
-    // Subscribe (and flush, so the server has registered the SUB) before the
-    // host starts publishing.
-    let heartbeat_sub = api_client
-        .subscribe(heartbeat_subject(&host_id))
-        .await
-        .context("failed to subscribe to heartbeats")?;
-    api_client
-        .flush()
-        .await
-        .context("failed to flush heartbeat subscription")?;
+        let mut builder = ClusterHostBuilder::default()
+            .with_host_group(HOST_GROUP)
+            .with_environment(ENVIRONMENT)
+            .with_nats_client(washlet_client);
+        if let Some(interval) = self.heartbeat_interval {
+            builder = builder.with_heartbeat_interval(interval);
+        }
+        if let Some(starts) = self.max_concurrent_starts {
+            builder = builder.with_max_concurrent_starts(starts);
+        }
+        let cluster_host = builder.build().context("failed to build cluster host")?;
+        let host_id = cluster_host.host().id().to_string();
 
-    let (_host, shutdown) = cluster_host
-        .start()
-        .await
-        .context("failed to start cluster host")?;
+        // Subscribe (and flush, so the server has registered the SUB) before the
+        // host starts publishing.
+        let heartbeat_sub = api_client
+            .subscribe(heartbeat_subject(&host_id))
+            .await
+            .context("failed to subscribe to heartbeats")?;
+        api_client
+            .flush()
+            .await
+            .context("failed to flush heartbeat subscription")?;
 
-    let harness = TestHarness {
-        api_client,
-        host_id,
-        heartbeat_sub,
-        shutdown: Box::pin(shutdown),
-        _container: container,
-    };
-    harness.wait_for_api().await?;
-    Ok(harness)
+        let (_host, shutdown) = cluster_host
+            .start()
+            .await
+            .context("failed to start cluster host")?;
+
+        let harness = TestHarness {
+            api_client,
+            host_id,
+            heartbeat_sub,
+            shutdown: Box::pin(shutdown),
+            _container: container,
+        };
+        harness.wait_for_api().await?;
+        Ok(harness)
+    }
+}
+
+/// The harness every test that needs no particular configuration starts from.
+async fn setup() -> Result<TestHarness> {
+    TestHarness::builder().start().await
 }
 
 impl TestHarness {
+    fn builder() -> TestHarnessBuilder {
+        TestHarnessBuilder::default()
+    }
+
     fn subject(&self, command: &str) -> String {
         rpc_subject(&self.host_id, command)
     }
@@ -195,6 +231,86 @@ where
         .await
         .context("washlet API request failed")?;
     serde_json::from_slice(&reply.payload).context("failed to deserialize response")
+}
+
+/// A registry that completes the TCP connect and then says nothing, so a pull
+/// against it hangs where a refused connection would fail fast.
+struct StallingRegistry {
+    addr: std::net::SocketAddr,
+    reached: Arc<std::sync::atomic::AtomicUsize>,
+    accept: tokio::task::JoinHandle<()>,
+}
+
+impl StallingRegistry {
+    async fn bind() -> Result<Self> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind stalling registry")?;
+        let addr = listener
+            .local_addr()
+            .context("failed to read stalling registry address")?;
+        let reached = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let accept = tokio::spawn({
+            let reached = Arc::clone(&reached);
+            async move {
+                // Accepted and held, never answered.
+                let mut accepted = Vec::new();
+                while let Ok((stream, _)) = listener.accept().await {
+                    reached.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    accepted.push(stream);
+                }
+            }
+        });
+        Ok(Self {
+            addr,
+            reached,
+            accept,
+        })
+    }
+
+    /// Connections accepted so far: one per start that got as far as pulling.
+    fn reached(&self) -> usize {
+        self.reached.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Fires a start whose only component pulls from here, so it hangs. The
+    /// handle is the caller's to abort; the reply never comes.
+    fn spawn_start(&self, harness: &TestHarness, workload_id: &str) -> tokio::task::JoinHandle<()> {
+        let mut request = empty_start_request(workload_id);
+        request.workload = request.workload.map(|workload| v2::Workload {
+            wit_world: Some(v2::WitWorld {
+                components: vec![v2::Component {
+                    name: "stalled".to_string(),
+                    image: format!("{}/{workload_id}:latest", self.addr),
+                    ..Default::default()
+                }],
+                host_interfaces: vec![],
+            }),
+            ..workload
+        });
+        let client = harness.api_client.clone();
+        let subject = harness.subject("workload.start");
+        tokio::spawn(async move {
+            let _: Result<v2::WorkloadStartResponse> = rpc(&client, subject, &request).await;
+        })
+    }
+}
+
+impl Drop for StallingRegistry {
+    fn drop(&mut self) {
+        self.accept.abort();
+    }
+}
+
+/// Polls `condition` until it holds or `limit` elapses.
+async fn wait_for(limit: Duration, mut condition: impl FnMut() -> bool) -> Result<()> {
+    tokio::time::timeout(limit, async {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .context("condition did not hold in time")
 }
 
 fn status_of(status: Option<v2::WorkloadStatus>) -> Result<v2::WorkloadStatus> {
@@ -298,9 +414,9 @@ async fn unknown_workload_ids_answer_not_found() -> Result<()> {
     harness.shutdown().await
 }
 
-/// An OCI pull failure happens in the washlet, before the host reserves the
-/// workload ID. The Error response must not consume the ID: a corrected
-/// start with the same ID succeeds without an intervening stop.
+/// An OCI pull failure leaves the workload ID free. The ID is claimed before
+/// the pull, so this pins the release on the failure path: a corrected start
+/// with the same ID succeeds without an intervening stop.
 #[tokio::test]
 #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn pull_failure_does_not_consume_workload_id() -> Result<()> {
@@ -309,17 +425,16 @@ async fn pull_failure_does_not_consume_workload_id() -> Result<()> {
 
     // A closed local port makes the pull fail fast with connection refused.
     let mut request = empty_start_request(workload_id);
-    request
-        .workload
-        .as_mut()
-        .expect("request has a workload")
-        .wit_world = Some(v2::WitWorld {
-        components: vec![v2::Component {
-            name: "unpullable".to_string(),
-            image: "127.0.0.1:1/nope:latest".to_string(),
-            ..Default::default()
-        }],
-        host_interfaces: vec![],
+    request.workload = request.workload.map(|workload| v2::Workload {
+        wit_world: Some(v2::WitWorld {
+            components: vec![v2::Component {
+                name: "unpullable".to_string(),
+                image: "127.0.0.1:1/nope:latest".to_string(),
+                ..Default::default()
+            }],
+            host_interfaces: vec![],
+        }),
+        ..workload
     });
 
     let failed = harness.start(&request).await?;
@@ -337,7 +452,7 @@ async fn pull_failure_does_not_consume_workload_id() -> Result<()> {
         );
     }
 
-    // The failed pull never reached the host, so the ID is still free.
+    // The failed start gave the ID back, so it is free again.
     assert_eq!(
         harness.status(workload_id).await?.workload_state(),
         v2::WorkloadState::NotFound
@@ -350,6 +465,200 @@ async fn pull_failure_does_not_consume_workload_id() -> Result<()> {
         started.message
     );
 
+    harness.shutdown().await
+}
+
+/// A start holds the washlet's request handler for as long as its image pull
+/// and compilation take. Heartbeats have to keep flowing while it does: the
+/// operator deletes a host it has not heard from inside its unreachable
+/// window, and every workload on that host goes with it.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn heartbeats_continue_while_a_start_is_in_flight() -> Result<()> {
+    const HEARTBEAT: Duration = Duration::from_millis(200);
+    let mut harness = TestHarness::builder()
+        .with_heartbeat_interval(HEARTBEAT)
+        .start()
+        .await?;
+    let registry = StallingRegistry::bind().await?;
+
+    let start = registry.spawn_start(&harness, "washlet-api-e2e-slow-start");
+
+    // Wait until the start is genuinely stuck on the pull, so the window below
+    // measures a busy host rather than an idle one.
+    wait_for(Duration::from_secs(10), || registry.reached() > 0)
+        .await
+        .context("no start reached the stalling registry")?;
+
+    // Drop whatever was published before the start: those heartbeats sit in the
+    // subscriber's buffer and would count toward the window on their own. The
+    // budget has to be long enough for the reader task to hand over what it has
+    // already taken off the socket, and `Ok(None)` means the subscription
+    // closed, which no amount of waiting will improve.
+    while let Ok(Some(_)) =
+        tokio::time::timeout(Duration::from_millis(50), harness.heartbeat_sub.next()).await
+    {}
+
+    // Count what the host publishes while that start is stuck on the pull.
+    let window = HEARTBEAT * 6;
+    let deadline = tokio::time::Instant::now() + window;
+    let mut heard = 0usize;
+    while let Ok(Some(_)) = tokio::time::timeout_at(deadline, harness.heartbeat_sub.next()).await {
+        heard += 1;
+    }
+
+    assert!(
+        heard >= 3,
+        "only {heard} heartbeats in {window:?} while a start was in flight; \
+         the request handler is holding the washlet's select loop"
+    );
+
+    start.abort();
+    harness.shutdown().await
+}
+
+/// Handling requests off the loop let starts overlap, so something has to cap
+/// how many images a host pulls and compiles at once. Only starts wait on it:
+/// a stop or a status stuck behind a slow start is a host that looks wedged.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn concurrent_workload_starts_are_bounded() -> Result<()> {
+    const LIMIT: usize = 2;
+    let harness = TestHarness::builder()
+        .with_max_concurrent_starts(LIMIT)
+        .start()
+        .await?;
+
+    // Each start that gets a permit reaches the registry and hangs there, so
+    // the connections it accepts count the starts in flight.
+    let registry = StallingRegistry::bind().await?;
+
+    let inflight: Vec<_> = (0..LIMIT + 2)
+        .map(|i| registry.spawn_start(&harness, &format!("washlet-api-e2e-bounded-{i}")))
+        .collect();
+
+    // Wait for the permitted starts to arrive rather than guessing at a delay,
+    // then hold to see whether any more follow them through.
+    wait_for(Duration::from_secs(10), || registry.reached() >= LIMIT)
+        .await
+        .context("the permitted starts never reached the registry")?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let reached_now = registry.reached();
+    assert!(
+        reached_now <= LIMIT,
+        "{reached_now} starts reached the registry at once, past the cap of {LIMIT}"
+    );
+
+    // A status query must not be stuck behind the starts holding the permits.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        harness.status("washlet-api-e2e-bounded-unknown"),
+    )
+    .await
+    .context("status queued behind the in-flight starts")??;
+
+    for task in inflight {
+        task.abort();
+    }
+    harness.shutdown().await
+}
+
+/// A start waiting for a concurrency permit has claimed its id too. The wait is
+/// time like any other in which a stop can arrive, and a stop that finds no
+/// workload tells the operator the teardown is done — so the record goes while
+/// the start is still queued to run it.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_stop_during_a_queued_start_reports_the_workload() -> Result<()> {
+    // One permit, held by a start that never finishes pulling, so the workload
+    // below is still waiting for it.
+    let harness = TestHarness::builder()
+        .with_max_concurrent_starts(1)
+        .start()
+        .await?;
+    let registry = StallingRegistry::bind().await?;
+
+    let holder = registry.spawn_start(&harness, "washlet-api-e2e-permit-holder");
+    wait_for(Duration::from_secs(10), || registry.reached() > 0)
+        .await
+        .context("the first start never reached the stalling registry")?;
+
+    let queued_id = "washlet-api-e2e-permit-queued";
+    let queued = registry.spawn_start(&harness, queued_id);
+
+    // Wait for the queued start to claim its id. It cannot be pulling — the one
+    // permit is taken — so this is the claim and nothing else, and until it
+    // lands there is no race for the stop below to lose.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match harness.status(queued_id).await {
+                Ok(observed) if observed.workload_state() != v2::WorkloadState::NotFound => return,
+                _ => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    })
+    .await
+    .context("a start queued for a permit never claimed its workload id")?;
+
+    let stopped = tokio::time::timeout(Duration::from_secs(5), harness.stop(queued_id))
+        .await
+        .context("stop did not answer while a start was queued")??;
+    assert_ne!(
+        stopped.workload_state(),
+        v2::WorkloadState::NotFound,
+        "stop reported a queued start as already gone: {}",
+        stopped.message
+    );
+
+    holder.abort();
+    queued.abort();
+    harness.shutdown().await
+}
+
+/// A workload id is claimed before its images are fetched, so a stop arriving
+/// while a start is still pulling finds the workload rather than a gap. It has
+/// to: NOT_FOUND tells the operator the teardown is complete, so it drops the
+/// record and the start goes on to run a workload nothing is tracking. The stop
+/// answers promptly — the start owns the teardown and finishes it — so the
+/// operator is neither misled nor left waiting out its own timeout.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_stop_during_a_start_reports_the_workload() -> Result<()> {
+    let harness = setup().await?;
+    let workload_id = "washlet-api-e2e-stop-races-start";
+
+    let registry = StallingRegistry::bind().await?;
+
+    let start = registry.spawn_start(&harness, workload_id);
+
+    wait_for(Duration::from_secs(10), || registry.reached() > 0)
+        .await
+        .context("the start never reached the stalling registry")?;
+
+    let stopped = tokio::time::timeout(Duration::from_secs(5), harness.stop(workload_id))
+        .await
+        .context("stop did not answer while a start was in flight")??;
+    assert_ne!(
+        stopped.workload_state(),
+        v2::WorkloadState::NotFound,
+        "stop reported a workload that is on its way up as already gone: {}",
+        stopped.message
+    );
+
+    // And a status in the same window reports it too, rather than answering
+    // for an id the host does not know yet.
+    let observed = tokio::time::timeout(Duration::from_secs(5), harness.status(workload_id))
+        .await
+        .context("status did not answer while a start was in flight")??;
+    assert_ne!(
+        observed.workload_state(),
+        v2::WorkloadState::NotFound,
+        "status reported a workload that is on its way up as missing: {}",
+        observed.message
+    );
+
+    start.abort();
     harness.shutdown().await
 }
 


### PR DESCRIPTION
This change makes it to so that the host continues servicing NATS while a workload starts. A host that goes quiet stops heartbeating, and the operator deletes a Host it has not heard from along with every Workload.

A burst of image pulls and compiles held up the async-nats connection task from draining nats messages.

This change moves compilation into `spawn_blocking`, Commands move off the select loop into a `JoinSet`.

Handling commands concurrently means a stop can now overtake a start, and washlet fetched every image before the host reserved anything.

Now the workload id is claimed before any image is fetched, through a crate-private `WorkloadReservation`, and given back on every path that fails before start begins.

`MAX_CONCURRENT_STARTS` bounds how many starts pull and compile at once, since nothing capped that once they could overlap.

This does not cover every compile. `Host::intersect_interfaces` and host component plugin loading still call `Component::new` on whichever thread reaches them, and a future caller of `initialize_workload` inherits the original problem, because the hop lives at the call site rather than in the engine. Right now this only impacts dev hosts and fixing it would be a larger refactor that I'm not going to do now.