### PR TITLE
fix(test): postgres test flake

### DIFF
--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -13,6 +13,8 @@ pub mod tls;
 #[cfg(feature = "wasmcloud-postgres")]
 pub mod postgres;
 
+pub mod streaming;
+
 use anyhow::{Context, Result};
 use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
 use tokio::time::timeout;

--- a/crates/wash-runtime/tests/common/streaming.rs
+++ b/crates/wash-runtime/tests/common/streaming.rs
@@ -1,0 +1,89 @@
+//! Timing a streamed HTTP response body.
+//!
+//! A streaming host forwards each piece of a body as it is produced, so a
+//! client reading the body sees the arrivals spaced out over the time the guest
+//! took to produce them. A host that collects the body before responding emits
+//! it as one burst, whatever it was collecting.
+//!
+//! The *spread* between the first and last arrival is what separates the two,
+//! and it is the only part of the measurement that survives a slow host: fixed
+//! latency ahead of the first piece — a cold instance, a connection coming up,
+//! a loaded machine — pushes every timestamp out together, leaving the spread
+//! where it was. Comparing the first arrival against a fraction of the last
+//! measures that latency instead, and reports it as buffering.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use tokio::time::timeout;
+
+/// A drained response body and when its chunks arrived.
+pub struct Arrivals {
+    /// The reassembled body.
+    pub body: Vec<u8>,
+    /// When the first non-empty chunk arrived.
+    pub first_at: Duration,
+    /// When the last one did.
+    pub last_at: Duration,
+}
+
+impl Arrivals {
+    /// How long the arrivals spanned.
+    pub fn spread(&self) -> Duration {
+        self.last_at - self.first_at
+    }
+
+    /// The body as text.
+    pub fn text(&self) -> Result<String> {
+        String::from_utf8(self.body.clone()).context("body not utf8")
+    }
+
+    /// Assert the arrivals spanned at least `min_spread`, naming what was
+    /// expected to stream. Pick a floor comfortably under the pacing the guest
+    /// performs (half of it leaves room for a chunk or two coalescing) and well
+    /// above the milliseconds a single burst spans.
+    #[track_caller]
+    pub fn assert_streamed(&self, what: &str, min_spread: Duration) {
+        let spread = self.spread();
+        assert!(
+            spread >= min_spread,
+            "{what} did not stream: all chunks landed within {spread:?}, expected them \
+             spread over at least {min_spread:?} (first at {:?}, last at {:?})",
+            self.first_at,
+            self.last_at,
+        );
+    }
+}
+
+/// Drain `response`'s body, timing each chunk's arrival against `start` — an
+/// [`Instant`] the caller takes *before* sending the request, so a host that
+/// withholds the response until the body is complete cannot hide the wait in
+/// the response head.
+pub async fn time_arrivals(response: reqwest::Response, start: Instant) -> Result<Arrivals> {
+    let mut stream = response.bytes_stream();
+    let mut first_at: Option<Duration> = None;
+    let mut last_at = Duration::ZERO;
+    let mut body = Vec::new();
+    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
+        .await
+        .context("body chunk timed out")?
+        .transpose()?
+    {
+        // Empty chunks carry no arrival: they are the transfer encoding's, not
+        // the guest's.
+        if chunk.is_empty() {
+            continue;
+        }
+        let now = start.elapsed();
+        first_at.get_or_insert(now);
+        last_at = now;
+        body.extend_from_slice(&chunk);
+    }
+    let first_at = first_at.context("response body was empty")?;
+    Ok(Arrivals {
+        body,
+        first_at,
+        last_at,
+    })
+}

--- a/crates/wash-runtime/tests/fixtures/postgres-stream-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/postgres-stream-p3/src/lib.rs
@@ -9,6 +9,8 @@
 //!   - `/paced` — eight rows emitted ~120ms apart (a per-row `pg_sleep`),
 //!     forwarded to the response body as each arrives. A test times the chunks
 //!     to prove rows stream through incrementally rather than being buffered.
+//!   - `/warmup` — one trivial row over the same forwarding path, so a test can
+//!     pay instantiation and connection setup before it starts timing.
 //!   - anything else — reads `items` and forwards it (a small sanity default).
 
 mod bindings {
@@ -58,6 +60,11 @@ fn route(path: &str) -> (&'static str, bool) {
              CROSS JOIN LATERAL (SELECT pg_sleep(0.12) WHERE g.i IS NOT NULL) AS s",
             true,
         )
+    } else if path.starts_with("/warmup") {
+        // One row, no sleeps and no table: the cheapest trip that still walks
+        // the whole path a timed request will (instantiate, connect, stream a
+        // row, write the response body).
+        ("SELECT 'ok'::text", true)
     } else {
         ("SELECT val FROM items ORDER BY id", true)
     }

--- a/crates/wash-runtime/tests/integration_p3_streams.rs
+++ b/crates/wash-runtime/tests/integration_p3_streams.rs
@@ -13,21 +13,20 @@
 //!
 //! `test_p3_incoming_handler_streams_incrementally`: a single paced handler
 //! (`stream-pacer-p3`) proves that the incoming-handler body actually
-//! streams (first byte arrives long before the last) rather than being
-//! buffered to completion before the response is sent.
+//! streams — its chunks arrive spread over the time the guest took to produce
+//! them — rather than being buffered to completion before the response is sent.
 //!
 //! `test_p3_cross_component_stream_streams_incrementally`: the cross-component
 //! analog of the pacer test. The producer paces its bytes, and the test times
 //! their arrival at the client to prove the `stream<u8>` stays concurrent as
-//! it crosses the linker (first chunk arrives well before the last) rather
-//! than being buffered at the linker boundary. The pacer test alone can't show
+//! it crosses the linker (the bytes arrive spread over time) rather than being
+//! buffered at the linker boundary. The pacer test alone can't show
 //! this — it never crosses the linker — and the byte-for-byte test above can't
 //! either, since a buffer-then-forward implementation would satisfy it too.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::{Context, Result};
-use futures::StreamExt;
 use std::{
     collections::HashMap,
     time::{Duration, Instant},
@@ -40,6 +39,7 @@ use wash_runtime::{
 };
 
 mod common;
+use common::streaming::time_arrivals;
 use common::{http_only_host_interfaces, start_host_with_p3_http_handler};
 
 const STREAM_PRODUCER_P3_WASM: &[u8] = include_bytes!("wasm/stream_producer_p3.wasm");
@@ -122,15 +122,18 @@ async fn test_p3_cross_component_stream_to_http() -> Result<()> {
 ///
 /// `stream-pacer-p3` emits 10 chunks 100ms apart. We time arrivals from
 /// *before* the request is sent:
-///   - Streaming: the response headers come back immediately, so the first
-///     chunk lands within ~one tick while the last lands ~0.9s later.
+///   - Streaming: the response headers come back immediately and each chunk
+///     follows its tick, so the arrivals span ~0.9s.
 ///   - Buffering (the old `body.collect().await` path): the handler can't
-///     return a response until the whole body is produced, so the first and
-///     last chunks arrive together near the ~0.9s mark.
+///     return a response until the whole body is produced, so every chunk
+///     arrives in one burst at the end.
 ///
-/// Asserting `first < last / 2` fails on the buffered path and passes on the
-/// streaming path. Margins are deliberately loose to stay CI-stable.
-#[tokio::test]
+/// The spread between first and last arrival tells those apart, and a slow
+/// host — which delays the whole body alike — cannot turn one into the other.
+/// Multi-threaded on purpose: on a current-thread runtime the guest's work
+/// blocks this task's reads, and pacing the host performed would be recorded
+/// as chunks arriving together.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
     let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
@@ -180,45 +183,14 @@ async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
         response.status()
     );
 
-    let mut stream = response.bytes_stream();
-    let mut first_at: Option<Duration> = None;
-    let mut last_at = Duration::ZERO;
-    let mut body = Vec::new();
-    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
-        .await
-        .context("body chunk timed out")?
-        .transpose()?
-    {
-        if chunk.is_empty() {
-            continue;
-        }
-        let now = start.elapsed();
-        first_at.get_or_insert(now);
-        last_at = now;
-        body.extend_from_slice(&chunk);
-    }
+    let arrivals = time_arrivals(response, start).await?;
 
-    let first_at = first_at.context("response body was empty")?;
-
-    // Sanity: the producer really did pace its output over time. Both the
-    // streaming and buffering paths satisfy this (the producer takes ~0.9s
-    // either way); it just guards against a degenerate instant body.
-    assert!(
-        last_at >= Duration::from_millis(400),
-        "expected paced output to span >=400ms, last chunk at {last_at:?}"
-    );
-
-    // The streaming assertion: the first chunk must arrive well before the
-    // last. Under the old buffered path first ≈ last and this fails.
-    assert!(
-        first_at < last_at / 2,
-        "response body was buffered, not streamed: first chunk at {first_at:?}, \
-         last at {last_at:?} (first should be < last/2)"
-    );
+    // Ten chunks a tick apart span ~0.9s streamed, milliseconds buffered.
+    arrivals.assert_streamed("the paced response body", Duration::from_millis(400));
 
     let expected: String = (0..10).map(|i| format!("chunk-{i}\n")).collect();
     assert_eq!(
-        String::from_utf8(body).context("body not utf8")?,
+        arrivals.text()?,
         expected,
         "streamed body should reassemble to all paced chunks in order"
     );
@@ -233,19 +205,21 @@ async fn test_p3_incoming_handler_streams_incrementally() -> Result<()> {
 /// component, linked in at runtime) drains that reader and forwards each byte
 /// to its HTTP response body. We time arrivals at the client from *before* the
 /// request:
-///   - Concurrent/streamed: the producer's first byte propagates across the
-///     linker and out to the client within ~one tick, while the last lands
-///     ~0.75s later.
+///   - Concurrent/streamed: each byte propagates across the linker and out to
+///     the client on its own tick, so the arrivals span ~0.75s.
 ///   - Buffered at the boundary: if the linker collected the producer's
 ///     `stream<u8>` to completion before handing it over (or the consumer
-///     buffered it), first ≈ last and the response would only start near the
-///     end.
+///     buffered it), the bytes reach the client in one burst at the end.
+///
+/// As in the pacer test, the spread between arrivals is what tells those
+/// apart, and the runtime is multi-threaded so the guest's work does not block
+/// this task's reads.
 ///
 /// This is the cross-component counterpart to
 /// `test_p3_incoming_handler_streams_incrementally`, which never crosses the
 /// linker, and a sharper check than `test_p3_cross_component_stream_to_http`,
 /// which only asserts the final bytes and so passes even on a buffered path.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_p3_cross_component_stream_streams_incrementally() -> Result<()> {
     let (addr, host) = start_host_with_p3_http_handler("127.0.0.1:0").await?;
 
@@ -305,45 +279,14 @@ async fn test_p3_cross_component_stream_streams_incrementally() -> Result<()> {
         response.status()
     );
 
-    let mut stream = response.bytes_stream();
-    let mut first_at: Option<Duration> = None;
-    let mut last_at = Duration::ZERO;
-    let mut body = Vec::new();
-    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
-        .await
-        .context("body chunk timed out")?
-        .transpose()?
-    {
-        if chunk.is_empty() {
-            continue;
-        }
-        let now = start.elapsed();
-        first_at.get_or_insert(now);
-        last_at = now;
-        body.extend_from_slice(&chunk);
-    }
+    let arrivals = time_arrivals(response, start).await?;
 
-    let first_at = first_at.context("response body was empty")?;
-
-    // Sanity: the producer really did pace its bytes across the linker (16
-    // bytes at a 50ms tick ≈ 0.75s). Loose bound to stay CI-stable.
-    assert!(
-        last_at >= Duration::from_millis(300),
-        "expected paced output to span >=300ms, last chunk at {last_at:?}"
-    );
-
-    // The concurrency assertion: the producer's bytes reach the client
-    // incrementally through the linker, not all bunched at the end. Under a
-    // buffered path first ≈ last and this fails.
-    assert!(
-        first_at < last_at / 2,
-        "cross-component stream was buffered, not streamed: first chunk at \
-         {first_at:?}, last at {last_at:?} (first should be < last/2)"
-    );
+    // 16 bytes at a 50ms tick span ~0.75s crossing the linker one at a time.
+    arrivals.assert_streamed("the cross-component stream", Duration::from_millis(300));
 
     // And it must still reassemble to the producer's output byte-for-byte.
     assert_eq!(
-        String::from_utf8(body).context("body not utf8")?,
+        arrivals.text()?,
         "abcdefghijklmnop",
         "streamed body should reassemble to the producer's output"
     );

--- a/crates/wash-runtime/tests/integration_postgres_streaming.rs
+++ b/crates/wash-runtime/tests/integration_postgres_streaming.rs
@@ -10,12 +10,13 @@
 //!   handful of rows at a time. An exact count+sum proves every row arrived,
 //!   in order and once, at a scale far beyond any buffer.
 //!
-//! - `async_query_streams_rows_incrementally` (`/paced`): eight ~9KB rows
-//!   emitted ~120ms apart (a per-row `pg_sleep`), forwarded to the response body
-//!   as each arrives. Timing chunk arrivals from *before* the request proves the
-//!   rows stream through incrementally — a host that buffered the result set
-//!   (`try_collect`) would withhold every row until the query finished, so the
-//!   first chunk would land with the last. (The rows are large on purpose:
+//! - `async_query_streams_rows_incrementally` (`/paced`, after a `/warmup` call
+//!   that keeps setup out of the timed window): eight ~9KB rows emitted ~120ms
+//!   apart (a per-row `pg_sleep`), forwarded to the response body as each
+//!   arrives. Timing chunk arrivals proves the rows stream through
+//!   incrementally — a host that buffered the result set (`try_collect`) would
+//!   withhold every row until the query finished and then emit one burst, so the
+//!   arrivals would span almost no time at all. (The rows are large on purpose:
 //!   postgres output-buffers small rows and flushes them together at query end,
 //!   so only a row that overflows its ~8KB send buffer is delivered on its own.)
 //!   Mirrors the byte-stream pacer test.
@@ -27,12 +28,12 @@
 
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
-use futures::StreamExt;
+use anyhow::{Context, Result, bail};
 use tokio::time::timeout;
 
 mod common;
 use common::postgres::{start_postgres, start_postgres_workload};
+use common::streaming::time_arrivals;
 
 #[tokio::test]
 #[ignore = "requires Docker (postgres); run with `cargo test --include-ignored`"]
@@ -71,17 +72,65 @@ async fn async_query_streams_a_huge_result_set() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+/// Drive the fixture's `/warmup` route until it round-trips its row, so the
+/// timed request that follows measures the query and not the setup around it:
+/// the container may still be refusing connections, and the first call also pays
+/// instantiating the guest and opening the plugin's connection.
+async fn warm_up(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = "no response".to_string();
+    while Instant::now() < deadline {
+        let response = timeout(
+            Duration::from_secs(10),
+            client
+                .get(format!("http://{addr}/warmup"))
+                .header("HOST", host_header)
+                .send(),
+        )
+        .await
+        .context("warm-up request timed out")?
+        .context("warm-up request failed")?;
+        let status = response.status();
+        let body = timeout(Duration::from_secs(10), response.text())
+            .await
+            .context("warm-up body timed out")?
+            .context("warm-up body failed")?;
+        if status.is_success() && body.trim() == "ok" {
+            // Let the instance land back in the pool before the clock starts:
+            // the workload runs `pool_size: 1`, and a call arriving while that
+            // one instance is still checked out is served from a store of its
+            // own — paying instantiation inside the timed window.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            return Ok(());
+        }
+        last = format!("{status} {:?}", body.trim());
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    bail!(
+        "warm-up never round-tripped a row (last response {last}); a staged fixture \
+         predating the `/warmup` route answers from `items` instead — rebuild it with \
+         `cargo xtask build-fixtures`"
+    )
+}
+
+// A timing test wants the host's HTTP server, the guest's driver and this task
+// on separate threads: on a current-thread runtime the guest's CPU work blocks
+// the body-reading loop below, and pacing the host performed would be recorded
+// as chunks arriving together.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "requires Docker (postgres); run with `cargo test --include-ignored`"]
 async fn async_query_streams_rows_incrementally() -> Result<()> {
     let (_container, host_addr) = start_postgres().await?;
     let (addr, _host) = start_postgres_workload(&host_addr, "pg-paced").await?;
 
-    // Time from before the request: a buffering host withholds the whole result
-    // set, so the response — and its first chunk — cannot arrive until the query
-    // finishes (~0.96s), landing first ≈ last.
-    let start = Instant::now();
     let client = reqwest::Client::new();
+    warm_up(&client, addr, "pg-paced").await?;
+
+    let start = Instant::now();
     let response = timeout(
         Duration::from_secs(15),
         client
@@ -98,43 +147,16 @@ async fn async_query_streams_rows_incrementally() -> Result<()> {
         response.status()
     );
 
-    let mut stream = response.bytes_stream();
-    let mut first_at: Option<Duration> = None;
-    let mut last_at = Duration::ZERO;
-    let mut body = Vec::new();
-    while let Some(chunk) = timeout(Duration::from_secs(10), stream.next())
-        .await
-        .context("body chunk timed out")?
-        .transpose()?
-    {
-        if chunk.is_empty() {
-            continue;
-        }
-        let now = start.elapsed();
-        first_at.get_or_insert(now);
-        last_at = now;
-        body.extend_from_slice(&chunk);
-    }
-    let first_at = first_at.context("response body was empty")?;
+    let arrivals = time_arrivals(response, start).await?;
 
-    // Sanity: the query really did pace its rows over time (8 × ~120ms). Guards
-    // against a degenerate instant result that would make the check below vacuous.
-    assert!(
-        last_at >= Duration::from_millis(500),
-        "expected paced rows to span >=500ms, last chunk at {last_at:?}"
-    );
-
-    // The streaming assertion: the first row must arrive well before the last.
-    // Under a buffered (`try_collect`) host, first ≈ last and this fails.
-    assert!(
-        first_at < last_at / 2,
-        "rows were buffered, not streamed: first chunk at {first_at:?}, last at {last_at:?} \
-         (first should be < last/2)"
-    );
+    // Eight rows paced ~120ms apart span the query's ~0.96s when the host
+    // forwards each as it arrives; collected into one burst they span
+    // milliseconds.
+    arrivals.assert_streamed("the paced rows", Duration::from_millis(400));
 
     // The reassembled body must be all eight rows, in order and intact: each is
     // 9000 `x`s followed by a newline.
-    let text = String::from_utf8(body).context("body not utf8")?;
+    let text = arrivals.text()?;
     let lines: Vec<&str> = text.lines().collect();
     assert_eq!(
         lines.len(),


### PR DESCRIPTION
These streaming tests asserted first_at < last_at / 2, which only holds when little fixed latency precedes the first chunk. On overloaded GH runners, this flakes.

Any constant delay (a cold instance, a connection coming up, or in our case a loaded runner) shifts both timestamps equally, walking the ratio toward 1 and failing a host that streamed perfectly.

They now assert the spread instead (last_at - first_at >= floor)

A buffered body arrives as one burst spanning milliseconds no matter how slow the host was to start. The postgres test also warms up before the clock starts and all three now run on a multi-threaded runtime, so setup and guest CPU work stay outside the measurement.
