### PR TITLE
Enforce `max-guest-memory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,6 +3632,8 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.5",
  "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -14,8 +14,9 @@
        land on the command line). See host-plugin-config.yaml, which renders
        the ConfigMap this deployment mounts. */}}
 {{- /* A host group's own `resources` replaces the chart-wide block wholesale
-       (no merge), and carries the wasmtime knobs `defaultHeapMemory` and
-       `coreInstances` alongside the Kubernetes requests/limits. */}}
+       (no merge), and carries the host knobs `defaultHeapMemory`,
+       `coreInstances` and `guestMemoryMode` alongside the Kubernetes
+       requests/limits. */}}
 {{- $resources := .resources | default $top.Values.runtime.resources | default dict }}
 {{- $partition := include "runtime-operator.hostPluginPartition" . | fromJson }}
 {{- $cliPlugins := $partition.cli }}
@@ -141,12 +142,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- /* Host memory budgets, from the effective `resources`:
-                   `limits.memory` is the host's total guest memory budget, and
-                   defaultHeapMemory/coreInstances are wasmtime knobs parked
-                   alongside it (stripped back out of the `resources:` block
-                   below). Unset means unset — the host then derives its budget
-                   from its cgroup and leaves the pool knobs at wasmtime's
-                   defaults.
+                   `limits.memory` is the host's total guest memory budget,
+                   guestMemoryMode says whether that budget is enforced or only
+                   counted, and defaultHeapMemory/coreInstances are wasmtime
+                   knobs parked alongside them (all three stripped back out of
+                   the `resources:` block below). Unset means unset — the host
+                   then derives its budget from its cgroup, counts against it
+                   rather than enforcing it, and leaves the pool knobs at
+                   wasmtime's defaults.
 
                    These go through the flags' `WASH_*` env fallbacks rather
                    than `args` on purpose. The chart is routinely paired with a
@@ -166,6 +169,10 @@ spec:
             {{- end }}
             {{- with $resources.coreInstances }}
             - name: WASH_CORE_INSTANCES
+              value: "{{ . }}"
+            {{- end }}
+            {{- with $resources.guestMemoryMode }}
+            - name: WASH_GUEST_MEMORY_MODE
               value: "{{ . }}"
             {{- end }}
             {{- with $top.Values.runtime.env }}
@@ -298,7 +305,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
-          {{- with omit $resources "defaultHeapMemory" "coreInstances" }}
+          {{- with omit $resources "defaultHeapMemory" "coreInstances" "guestMemoryMode" }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -313,11 +313,11 @@ runtime:
   # host: size `limits.memory` for your expected per-host workload density, or
   # remove it to leave host memory uncapped.
   #
-  # `defaultHeapMemory` and `coreInstances` are wasmtime knobs rather than
-  # Kubernetes resource fields; the chart strips them out of the container's
-  # `resources` block and sets them as `WASH_DEFAULT_HEAP_MEMORY` /
-  # `WASH_CORE_INSTANCES` for the host.
-  # Leaving both empty uses the default wasmtime values.
+  # `defaultHeapMemory`, `coreInstances` and `guestMemoryMode` are host knobs
+  # rather than Kubernetes resource fields; the chart strips them out of the
+  # container's `resources` block and sets them as `WASH_DEFAULT_HEAP_MEMORY` /
+  # `WASH_CORE_INSTANCES` / `WASH_GUEST_MEMORY_MODE` for the host.
+  # Leaving them empty uses the host's own defaults.
   #
   # The simplest way to change host sizing for the whole release:
   #   --set runtime.resources.limits.memory=2Gi
@@ -334,6 +334,23 @@ runtime:
     # -- Instance slots the pooling allocator keeps. Empty leaves wasmtime's
     # default of 1000.
     coreInstances: ""
+    # -- Whether `limits.memory` is enforced against total guest memory or only
+    # counted: `count` (the default) charges every guest `memory.grow` to the
+    # budget and reports what it would have refused, but allows it; `enforce`
+    # refuses growth past the budget, which the guest sees as `memory.grow`
+    # returning -1. Guest memory has never been bounded in aggregate, so run in
+    # `count` and watch the host's reported high-water mark before switching.
+    #
+    # Before setting `enforce`, note that the chart passes `limits.memory`
+    # through as the guest budget unchanged — 100% of the pod. Guests are not
+    # all a host pod holds: wasmtime itself, compiled module images, NATS, OCI
+    # pulls and HTTP buffers come out of the same limit, and none of them is
+    # charged to this budget. A host left to derive its own budget keeps a
+    # quarter back for them. So an enforced budget equal to `limits.memory` can
+    # still be OOM-killed before it ever refuses a guest; give the host its
+    # headroom by setting `limits.memory` above the guest budget you want, or
+    # by overriding `WASH_HOST_MAX_GUEST_MEMORY` below it via `runtime.env`.
+    guestMemoryMode: ""
   # -- Additional environment variables applied to every host group container,
   # appended after the chart-managed vars and before any per-host-group `env`.
   # Standard Kubernetes env shape (supports `valueFrom`).
@@ -635,6 +652,7 @@ runtime:
       #     memory: "2Gi"
       #   defaultHeapMemory: "512MiB"
       #   coreInstances: "200"
+      #   guestMemoryMode: "enforce"
       # -- Extra CA bundles trusted when this group pulls images, added to the
       # chart-wide `runtime.ociCaPaths` rather than replacing it:
       # ociCaPaths:

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -158,6 +158,10 @@ wasi-webgpu-wasmtime = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+# `testing` brings in `InMemoryMetricExporter`, which is how the guest memory
+# budget's OTel instruments are asserted against a real collection rather than
+# by calling their getters.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # `stream` (bytes_stream / Body::wrap_stream) is used by the blobstore

--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -84,6 +84,11 @@ pub struct SharedCtx {
     /// reported by [`crate::observability::ExecutionTimeMeter`]. Read its docs
     /// before reading the number: it is a floor, not a total.
     pub executed: Arc<crate::engine::abandon::GuestExecution>,
+    /// This store's share of the host's guest memory budget, installed on the
+    /// store by [`crate::engine::guest_memory::install_memory_limiter`]. Living
+    /// here is what makes the release exact: dropping the store drops this and
+    /// hands the bytes back.
+    pub memory_limiter: crate::engine::guest_memory::StoreMemoryLimiter,
 }
 
 /// The identity of whoever is invoking a host component plugin, used to
@@ -110,6 +115,7 @@ impl SharedCtx {
             resource_registry: None,
             abandoned: Arc::default(),
             executed: Arc::default(),
+            memory_limiter: Default::default(),
         }
     }
 
@@ -117,6 +123,16 @@ impl SharedCtx {
     /// real resources alive as it hands proxies across the bridge.
     pub fn with_resource_registry(mut self) -> Self {
         self.resource_registry = Some(Default::default());
+        self
+    }
+
+    /// Draws this store's linear memory from `budget`. Without this the store
+    /// is neither charged nor limited.
+    pub fn with_guest_memory(
+        mut self,
+        budget: &Arc<crate::engine::guest_memory::GuestMemoryBudget>,
+    ) -> Self {
+        self.memory_limiter = budget.limiter();
         self
     }
 

--- a/crates/wash-runtime/src/engine/guest_memory.rs
+++ b/crates/wash-runtime/src/engine/guest_memory.rs
@@ -58,9 +58,19 @@
 //! told about — so the growth that gets charged is the growth that happens.
 //!
 //! What is left over is the host genuinely running out: an `mmap` that fails
-//! under real memory pressure. That charge is held until the store is dropped,
-//! which makes the budget refuse sooner than it strictly must — the safe
+//! after the growth was approved. That charge is held until the store is
+//! dropped, so the budget refuses sooner than it strictly must — the safe
 //! direction, and a host in that state has larger problems.
+//!
+//! A guest that *retries* such a growth is charged again each time, because
+//! wasmtime reports the memory at its old size and there is nothing in the
+//! call to say it is the same request. `ResourceLimiter` identifies no memory,
+//! so charging it once would mean conflating two memories that happen to grow
+//! to the same size — which is what every linked component does at
+//! instantiation. Refunding from `memory_grow_failed` is worse still, for the
+//! reason above. Bounding this properly needs a memory identity the trait does
+//! not provide; until then a guest retrying into a failing `mmap` inflates the
+//! figure, and it is the host's own memory exhaustion that put it there.
 //!
 //! # A plugin draws on the same budget as the workloads that call it
 //!
@@ -326,8 +336,8 @@ impl GuestMemoryBudget {
         let would_refuse = self.would_refuse();
         let refusals = refused.saturating_add(would_refuse);
         let new_refusals = refusals > self.reported_refusals.swap(refusals, Ordering::Relaxed);
-        // Saturating, so a `u64::MAX` cap (the unmetered default) cannot
-        // overflow its way under the threshold.
+        // Divided before it is multiplied, so a `u64::MAX` cap — the unmetered
+        // default — cannot overflow its way under the threshold.
         let pressured = in_use >= self.cap / PRESSURE_DENOMINATOR * PRESSURE_NUMERATOR;
 
         if !pressured && !new_refusals {
@@ -340,6 +350,23 @@ impl GuestMemoryBudget {
             );
             return;
         }
+        // Said separately because they are different states, and one message
+        // for both would misdescribe whichever it was not: a host can be
+        // refusing nothing right now and still have refused since the last
+        // report, and calling that "close to its budget" once `in_use` has
+        // fallen back is the opposite of the live reading this is keyed on.
+        if pressured {
+            tracing::info!(
+                mode = self.mode.as_str(),
+                in_use = %render_bytes(in_use),
+                high_water = %render_bytes(self.high_water()),
+                max_guest_memory = %render_bytes(self.cap),
+                refused,
+                would_refuse,
+                "guest memory is close to this host's budget"
+            );
+            return;
+        }
         tracing::info!(
             mode = self.mode.as_str(),
             in_use = %render_bytes(in_use),
@@ -347,7 +374,7 @@ impl GuestMemoryBudget {
             max_guest_memory = %render_bytes(self.cap),
             refused,
             would_refuse,
-            "guest memory is close to this host's budget"
+            "guest memory growth has been refused since the last report"
         );
     }
 

--- a/crates/wash-runtime/src/engine/guest_memory.rs
+++ b/crates/wash-runtime/src/engine/guest_memory.rs
@@ -1,0 +1,965 @@
+//! What enforces [`HostMemoryBudgets::max_guest_memory`].
+//!
+//! The budget names a total; wasmtime's own knobs bound a *single* linear
+//! memory ([`HostMemoryBudgets::default_heap_memory`]) and a *count* of pool
+//! slots ([`HostMemoryBudgets::core_instances`]). Neither adds up to the total:
+//! `core_instances x default_heap_memory` bounds address space, which the
+//! kernel does not back until it is written to. The case nothing covers is
+//! aggregate creep — N guests each under its own ceiling, together over the
+//! pod's — and the first notification is the OOM killer taking every workload
+//! on the host with it.
+//!
+//! This module closes that. A [`GuestMemoryBudget`] is one counter of guest
+//! bytes for the whole host. Every store carries a [`StoreMemoryLimiter`]
+//! installed through [`wasmtime::Store::limiter`], which sees each
+//! `memory.grow` before it happens, charges the growth to the shared counter,
+//! and can refuse it.
+//!
+//! # Count before Enforce
+//!
+//! [`GuestMemoryMode::Count`] is the default and is a no-op by construction: it
+//! charges and reports, and allows the growth regardless. This matters because
+//! `max_guest_memory` is always *derived* when unset — never absent — so a host
+//! that switched straight to enforcement would gain a ceiling it has never had,
+//! on upgrade, with nobody having asked for one. Count preserves
+//! [`crate::engine::host_memory`]'s property that nothing changes when the
+//! flags are unset, while still producing the number no host has today: a
+//! high-water mark for aggregate guest memory, which is what answers "one
+//! runaway component, or aggregate creep?".
+//!
+//! Same shape as [`crate::sockets::policy::EgressMode`], for the same reason.
+//!
+//! # What a refusal looks like to a guest
+//!
+//! Returning `Ok(false)` from [`wasmtime::ResourceLimiter::memory_growing`]
+//! makes `memory.grow` return `-1`. That is an ordinary WebAssembly outcome an
+//! allocator is written to handle, not a trap, and it is already what a guest
+//! sees on hitting `default_heap_memory`. The exception is a memory's *initial*
+//! size, requested during instantiation: wasmtime has no `-1` to return there,
+//! so a refusal surfaces as an instantiation error.
+//!
+//! # This is growth, not RSS
+//!
+//! The limiter sees requested growth. The pooling allocator commits lazily, so
+//! a guest that grows its heap and touches none of it is charged for pages the
+//! kernel has not backed. That overcounts against RSS, which is the safe
+//! direction for a budget, but it means this number is an upper bound on
+//! resident guest memory rather than a measurement of it.
+//!
+//! # A charge is taken before the growth is known to have succeeded
+//!
+//! [`wasmtime::ResourceLimiter`] offers no callback that says "the growth you
+//! permitted went through". `memory_grow_failed` looks like one and is not: it
+//! also fires for growth the limiter was never consulted about, so refunding
+//! against it would let a guest alternate a real growth with an oversized one
+//! and have its own charges written off. Instead every ceiling wasmtime is
+//! going to apply is checked *here* first — see
+//! [`GuestMemoryBudget::with_heap_ceiling`] for the one the limiter is not
+//! told about — so the growth that gets charged is the growth that happens.
+//!
+//! What is left over is the host genuinely running out: an `mmap` that fails
+//! under real memory pressure. That charge is held until the store is dropped,
+//! which makes the budget refuse sooner than it strictly must — the safe
+//! direction, and a host in that state has larger problems.
+//!
+//! # A plugin draws on the same budget as the workloads that call it
+//!
+//! A host component plugin's store is long-lived and shared by every workload
+//! importing its capability, and it is charged here like any other guest. So
+//! under [`GuestMemoryMode::Enforce`] workloads can fill the budget and leave
+//! the plugin unable to grow — and a Rust guest that cannot allocate aborts,
+//! which takes the capability away from every workload using it, not just the
+//! one that filled the budget. Reserving a plugin's share is the same missing
+//! piece as a per-workload sub-budget.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use super::host_memory::{HostMemoryBudgets, render_bytes};
+
+/// Share of the budget in use past which the periodic report is worth an
+/// operator's attention rather than a debug line.
+const PRESSURE_NUMERATOR: u64 = 3;
+const PRESSURE_DENOMINATOR: u64 = 4;
+
+/// How strictly the guest memory budget is applied.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum GuestMemoryMode {
+    /// Charge the growth, record that the budget would have refused it, and
+    /// allow it anyway. The default, so upgrading a host does not hand every
+    /// guest a ceiling nobody asked for.
+    #[default]
+    Count,
+    /// Refuse growth past the budget.
+    Enforce,
+}
+
+impl GuestMemoryMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Count => "count",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+/// One counter of guest linear-memory bytes, shared by every store on a host.
+///
+/// Held by the [`Engine`] and cloned into each store's
+/// [`StoreMemoryLimiter`]. Charges accumulate as guests grow their heaps and
+/// are returned when the store that made them is dropped.
+///
+/// [`Engine`]: crate::engine::Engine
+#[derive(Debug)]
+pub struct GuestMemoryBudget {
+    cap: u64,
+    mode: GuestMemoryMode,
+    /// The pooling allocator's per-slot ceiling, when one is installed.
+    ///
+    /// Not a budget knob — a correction. wasmtime hands the limiter the
+    /// *memory type's* maximum, which for a Rust component that declares none
+    /// is 4 GiB; the pool's own per-slot ceiling is applied later, and a
+    /// growth past it fails after the limiter already said yes. Charging that
+    /// growth would hold bytes the guest never got for the life of the store,
+    /// so the ceiling has to be known here to refuse it first.
+    heap_ceiling: Option<u64>,
+    in_use: AtomicU64,
+    high_water: AtomicU64,
+    refused: AtomicU64,
+    would_refuse: AtomicU64,
+    /// Whether the cap has ever been crossed, so the first crossing can be
+    /// reported loudly and the rest quietly. A host that has crept past its
+    /// budget is worth one warning, not one per `memory.grow`.
+    crossed: AtomicBool,
+    /// Refusals as of the last [`Self::report`], so a report can say whether
+    /// anything has been refused *since* rather than ever.
+    reported_refusals: AtomicU64,
+}
+
+impl Default for GuestMemoryBudget {
+    /// An unmetered budget: accounted but never crossed. What a store built
+    /// without an engine's budget gets, so a limiter is always installable.
+    fn default() -> Self {
+        Self::new(u64::MAX, GuestMemoryMode::Count)
+    }
+}
+
+impl GuestMemoryBudget {
+    pub fn new(cap: u64, mode: GuestMemoryMode) -> Self {
+        Self {
+            cap,
+            mode,
+            heap_ceiling: None,
+            in_use: AtomicU64::new(0),
+            high_water: AtomicU64::new(0),
+            refused: AtomicU64::new(0),
+            would_refuse: AtomicU64::new(0),
+            crossed: AtomicBool::new(false),
+            reported_refusals: AtomicU64::new(0),
+        }
+    }
+
+    /// Tell the budget the per-slot ceiling the pooling allocator was actually
+    /// built with, so growth the pool will refuse is never charged.
+    ///
+    /// Read back from the installed pool rather than from the resolved knobs:
+    /// an environment override or a caller-supplied pooling config both move
+    /// it, and a ceiling that is too high here reintroduces the overcharge.
+    #[must_use]
+    pub fn with_heap_ceiling(mut self, heap_ceiling: u64) -> Self {
+        self.heap_ceiling = Some(heap_ceiling);
+        self
+    }
+
+    /// The budget a host's resolved knobs describe.
+    pub fn from_budgets(budgets: &HostMemoryBudgets, mode: GuestMemoryMode) -> Self {
+        Self::new(budgets.max_guest_memory, mode)
+    }
+
+    /// A limiter drawing on this budget, to be installed on one store.
+    pub fn limiter(self: &Arc<Self>) -> StoreMemoryLimiter {
+        StoreMemoryLimiter {
+            budget: Some(Arc::clone(self)),
+            charged: 0,
+        }
+    }
+
+    pub fn cap(&self) -> u64 {
+        self.cap
+    }
+
+    pub fn mode(&self) -> GuestMemoryMode {
+        self.mode
+    }
+
+    /// Guest bytes currently charged.
+    pub fn in_use(&self) -> u64 {
+        self.in_use.load(Ordering::Relaxed)
+    }
+
+    /// The most that has ever been charged at once — the figure that says
+    /// whether this host is near its budget, and the whole point of running in
+    /// [`GuestMemoryMode::Count`].
+    pub fn high_water(&self) -> u64 {
+        self.high_water.load(Ordering::Relaxed)
+    }
+
+    /// Growths refused under [`GuestMemoryMode::Enforce`].
+    pub fn refused(&self) -> u64 {
+        self.refused.load(Ordering::Relaxed)
+    }
+
+    /// Growths [`GuestMemoryMode::Enforce`] would have refused, counted while
+    /// running in [`GuestMemoryMode::Count`].
+    pub fn would_refuse(&self) -> u64 {
+        self.would_refuse.load(Ordering::Relaxed)
+    }
+
+    /// Publish this budget as OpenTelemetry metrics.
+    ///
+    /// *Observable* instruments: the exporter calls back on its own schedule
+    /// and reads the atomics this budget already keeps, so nothing is recorded
+    /// on the `memory.grow` path and the cost of being watched is zero.
+    ///
+    /// Not gated behind `--enable-meters`, unlike
+    /// [`crate::observability::FuelConsumptionMeter`]. That flag exists because
+    /// fuel metering makes the guest measurably slower; this does not, and the
+    /// high-water figure is the one an operator is told to watch before turning
+    /// enforcement on — putting it behind an opt-in would hide the number the
+    /// rollout depends on. With no OTel exporter configured the global meter is
+    /// a no-op and none of these callbacks are ever invoked.
+    fn register_metrics(self: &Arc<Self>, meter: &opentelemetry::metrics::Meter) {
+        let mode = [opentelemetry::KeyValue::new("mode", self.mode.as_str())];
+
+        // Weak, so a dropped engine's budget is not kept alive by the meter
+        // provider — the same reason the epoch ticker holds a weak engine. A
+        // callback that cannot upgrade reports nothing and the series ends.
+        macro_rules! observe {
+            ($build:ident, $name:literal, $unit:literal, $doc:literal, $read:expr) => {{
+                let budget = Arc::downgrade(self);
+                let mode = mode.clone();
+                // The returned handle carries no state: the callback is
+                // registered on the pipeline, so dropping it changes nothing.
+                let _ = meter
+                    .$build($name)
+                    .with_description($doc)
+                    .with_unit($unit)
+                    .with_callback(move |observer| {
+                        if let Some(budget) = budget.upgrade() {
+                            #[allow(clippy::redundant_closure_call)]
+                            observer.observe($read(&budget), &mode);
+                        }
+                    })
+                    .build();
+            }};
+        }
+
+        observe!(
+            u64_observable_gauge,
+            "guest_memory.in_use",
+            "By",
+            "Guest linear memory currently charged to this host's budget",
+            |b: &Arc<Self>| b.in_use()
+        );
+        // Kept rather than left to `max_over_time(in_use)` in the query layer:
+        // the exporter samples, and a burst that begins and ends between two
+        // samples is invisible to the gauge but is exactly what precedes an
+        // unexplained OOM.
+        observe!(
+            u64_observable_gauge,
+            "guest_memory.high_water",
+            "By",
+            "Most guest linear memory charged at once since this host started",
+            |b: &Arc<Self>| b.high_water()
+        );
+        // Exported so a dashboard can plot utilisation without the budget being
+        // hardcoded in the query.
+        observe!(
+            u64_observable_gauge,
+            "guest_memory.limit",
+            "By",
+            "This host's max-guest-memory budget",
+            |b: &Arc<Self>| b.cap()
+        );
+        observe!(
+            u64_observable_counter,
+            "guest_memory.refused",
+            "{growth}",
+            "Guest memory growths refused for crossing this host's budget",
+            |b: &Arc<Self>| b.refused()
+        );
+        observe!(
+            u64_observable_counter,
+            "guest_memory.would_refuse",
+            "{growth}",
+            "Guest memory growths that crossed this host's budget and were \
+             allowed because it is only being counted",
+            |b: &Arc<Self>| b.would_refuse()
+        );
+    }
+
+    /// The budget, published as metrics on the process-wide meter.
+    ///
+    /// Registration needs an [`Arc`] — the callbacks hold a
+    /// [`std::sync::Weak`] back to it — so this is the one place the two are
+    /// wired together.
+    pub fn into_metered(self) -> Arc<Self> {
+        let budget = Arc::new(self);
+        budget.register_metrics(&opentelemetry::global::meter("wash-runtime"));
+        budget
+    }
+
+    /// Report where the host stands, for the periodic host status line.
+    ///
+    /// At `info` while the host is *currently* under memory pressure, or when
+    /// growth has been refused since the last report. That is the figure an
+    /// operator is told to watch before turning enforcement on, and a host
+    /// does not run at `debug`.
+    ///
+    /// Keyed on live pressure rather than on the high-water mark, which only
+    /// ever rises: a host that crossed its budget once during a burst at
+    /// minute three would otherwise say so on every heartbeat for the rest of
+    /// its life, and a line that never stops carries nothing.
+    pub fn report(&self) {
+        let in_use = self.in_use();
+        let refused = self.refused();
+        let would_refuse = self.would_refuse();
+        let refusals = refused.saturating_add(would_refuse);
+        let new_refusals = refusals > self.reported_refusals.swap(refusals, Ordering::Relaxed);
+        // Saturating, so a `u64::MAX` cap (the unmetered default) cannot
+        // overflow its way under the threshold.
+        let pressured = in_use >= self.cap / PRESSURE_DENOMINATOR * PRESSURE_NUMERATOR;
+
+        if !pressured && !new_refusals {
+            tracing::debug!(
+                mode = self.mode.as_str(),
+                in_use = %render_bytes(in_use),
+                high_water = %render_bytes(self.high_water()),
+                max_guest_memory = %render_bytes(self.cap),
+                "guest memory budget"
+            );
+            return;
+        }
+        tracing::info!(
+            mode = self.mode.as_str(),
+            in_use = %render_bytes(in_use),
+            high_water = %render_bytes(self.high_water()),
+            max_guest_memory = %render_bytes(self.cap),
+            refused,
+            would_refuse,
+            "guest memory is close to this host's budget"
+        );
+    }
+
+    /// Charge `bytes` and report whether the growth may proceed.
+    ///
+    /// Under [`GuestMemoryMode::Count`] the charge is taken whether or not it
+    /// fits, so the high-water figure describes what the host actually did
+    /// rather than what it would have permitted.
+    fn charge(&self, bytes: u64) -> bool {
+        match self.mode {
+            GuestMemoryMode::Enforce => {
+                let taken =
+                    self.in_use
+                        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |in_use| {
+                            let next = in_use.saturating_add(bytes);
+                            (next <= self.cap).then_some(next)
+                        });
+                match taken {
+                    Ok(previous) => {
+                        self.high_water
+                            .fetch_max(previous.saturating_add(bytes), Ordering::Relaxed);
+                        true
+                    }
+                    Err(in_use) => {
+                        self.refused.fetch_add(1, Ordering::Relaxed);
+                        self.report_refusal(bytes, in_use);
+                        false
+                    }
+                }
+            }
+            GuestMemoryMode::Count => {
+                // Saturating rather than `fetch_add`: this branch takes the
+                // charge whether or not it fits, so nothing else stops the
+                // counter wrapping past `u64::MAX` and reading as near-empty.
+                let in_use = self
+                    .in_use
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |in_use| {
+                        Some(in_use.saturating_add(bytes))
+                    })
+                    // Both variants carry the previous value; the closure
+                    // never declines, so `Err` is unreachable — but reading a
+                    // zero out of it would report a host holding gigabytes as
+                    // holding one growth, which is the one number this mode
+                    // exists to produce.
+                    .unwrap_or_else(|previous| previous)
+                    .saturating_add(bytes);
+                self.high_water.fetch_max(in_use, Ordering::Relaxed);
+                if in_use > self.cap {
+                    self.would_refuse.fetch_add(1, Ordering::Relaxed);
+                    self.report_crossing(bytes, in_use);
+                }
+                true
+            }
+        }
+    }
+
+    /// Say that a growth was refused: loudly the first time, quietly after
+    /// that, since a host doing this is doing it on every `memory.grow`.
+    ///
+    /// The first one is a `warn` because of what a refusal does to the guest
+    /// that gets it. `-1` is a well-formed answer, but a Rust guest's
+    /// allocator turns it into `handle_alloc_error` and aborts — so this is
+    /// often the only record connecting a workload that died, or a host
+    /// component plugin that took its capability down with it, to the budget
+    /// that caused it.
+    fn report_refusal(&self, bytes: u64, in_use: u64) {
+        if self.crossed.swap(true, Ordering::Relaxed) {
+            tracing::debug!(
+                requested = %render_bytes(bytes),
+                in_use = %render_bytes(in_use),
+                max_guest_memory = %render_bytes(self.cap),
+                "refusing guest memory growth past this host's budget"
+            );
+            return;
+        }
+        tracing::warn!(
+            requested = %render_bytes(bytes),
+            in_use = %render_bytes(in_use),
+            max_guest_memory = %render_bytes(self.cap),
+            "refusing guest memory growth past this host's budget. The guest sees memory.grow \
+             return -1; a guest that cannot handle that will abort. Raise --max-guest-memory, \
+             give this host fewer workloads, or run with --guest-memory-mode count while \
+             sizing it"
+        );
+    }
+
+    /// Say that the budget has been crossed: loudly the first time, quietly
+    /// after that. A host doing this is doing it on every `memory.grow`.
+    fn report_crossing(&self, bytes: u64, in_use: u64) {
+        if self.crossed.swap(true, Ordering::Relaxed) {
+            tracing::debug!(
+                requested = %render_bytes(bytes),
+                in_use = %render_bytes(in_use),
+                max_guest_memory = %render_bytes(self.cap),
+                "guest memory growth is past this host's budget; allowing it because the host \
+                 is in count mode"
+            );
+            return;
+        }
+        tracing::warn!(
+            requested = %render_bytes(bytes),
+            in_use = %render_bytes(in_use),
+            max_guest_memory = %render_bytes(self.cap),
+            "guest memory has crossed this host's budget; allowing it because the host is in \
+             count mode. Nothing bounds guest memory until this host runs with \
+             --guest-memory-mode enforce, and the kernel's own correction is an OOM kill that \
+             takes every workload on this host with it"
+        );
+    }
+
+    /// Return bytes a store is no longer holding.
+    fn release(&self, bytes: u64) {
+        // Saturating rather than `fetch_sub`, which would wrap an unbalanced
+        // release into an enormous `in_use` and refuse everything thereafter.
+        let _ = self
+            .in_use
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |in_use| {
+                Some(in_use.saturating_sub(bytes))
+            });
+    }
+}
+
+/// One store's share of a [`GuestMemoryBudget`].
+///
+/// Lives inside the store's own [`SharedCtx`], which is what makes the release
+/// exact: a store that is dropped — cleanly, or with a call still in flight —
+/// drops this too, and [`Drop`] hands back everything the store was charged.
+/// Nothing outside has to notice the store is gone.
+///
+/// [`SharedCtx`]: crate::engine::ctx::SharedCtx
+#[derive(Debug, Default)]
+pub struct StoreMemoryLimiter {
+    /// `None` on a store built without a budget — an embedder's, or a test's.
+    /// Such a store is neither charged nor limited.
+    budget: Option<Arc<GuestMemoryBudget>>,
+    /// What this store has taken from the budget and owes back on drop.
+    charged: u64,
+}
+
+impl StoreMemoryLimiter {
+    /// What this store is currently charged.
+    pub fn charged(&self) -> u64 {
+        self.charged
+    }
+}
+
+impl wasmtime::ResourceLimiter for StoreMemoryLimiter {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        let Some(budget) = &self.budget else {
+            return Ok(true);
+        };
+        // Growth wasmtime is going to refuse on its own account is refused here
+        // first, uncharged. There is no callback saying a permitted growth then
+        // failed that can be trusted — `memory_grow_failed` also fires for
+        // growth the limiter was never asked about — so a charge taken for
+        // bytes the guest never receives is held until the store is dropped.
+        //
+        // Two ceilings, and the limiter is told about only one of them:
+        // `maximum` is the memory *type's* limit, while the pooling allocator's
+        // per-slot ceiling is applied after this returns.
+        let refused_by_wasmtime = maximum.is_some_and(|maximum| desired > maximum)
+            || budget
+                .heap_ceiling
+                .is_some_and(|ceiling| desired as u64 > ceiling);
+        if refused_by_wasmtime {
+            return Ok(false);
+        }
+        // `desired` is the memory's new total, not a delta, and wasmtime
+        // guarantees it is the larger of the two.
+        let growth = (desired as u64).saturating_sub(current as u64);
+        if !budget.charge(growth) {
+            return Ok(false);
+        }
+        self.charged = self.charged.saturating_add(growth);
+        Ok(true)
+    }
+
+    /// Tables are not charged against the guest memory budget. The budget is
+    /// denominated in linear-memory bytes — the thing `default_heap_memory`
+    /// bounds one of — and a table is counted in elements, whose byte cost is
+    /// wasmtime's business. What still bounds a table is its own declared
+    /// maximum and the pooling allocator's `table_elements`; there is no
+    /// store-level element ceiling here, and `ResourceLimiter` does not
+    /// provide one (its `tables()` default is a count of tables, not of
+    /// elements).
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        Ok(true)
+    }
+}
+
+impl Drop for StoreMemoryLimiter {
+    fn drop(&mut self) {
+        if let Some(budget) = &self.budget
+            && self.charged > 0
+        {
+            budget.release(self.charged);
+        }
+    }
+}
+
+/// Point `store` at its own [`StoreMemoryLimiter`].
+///
+/// Required at every store creation rather than optional: a store whose
+/// limiter is never installed grows its linear memories without the budget
+/// ever seeing them, and the aggregate stops being an aggregate.
+pub fn install_memory_limiter(store: &mut wasmtime::Store<crate::engine::ctx::SharedCtx>) {
+    store.limiter(|ctx| &mut ctx.memory_limiter);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use wasmtime::ResourceLimiter as _;
+
+    use super::*;
+
+    const MIB: u64 = 1024 * 1024;
+
+    fn budget(cap: u64, mode: GuestMemoryMode) -> Arc<GuestMemoryBudget> {
+        Arc::new(GuestMemoryBudget::new(cap, mode))
+    }
+
+    /// `memory_growing` takes totals, not deltas, so a limiter has to subtract.
+    /// Charging `desired` would count a memory's whole size again on every
+    /// grow and exhaust the budget in a handful of pages.
+    #[test]
+    fn a_grow_is_charged_for_its_growth_not_the_new_total() {
+        let budget = budget(100 * MIB, GuestMemoryMode::Enforce);
+        let mut limiter = budget.limiter();
+
+        assert!(limiter.memory_growing(0, 10 * MIB as usize, None).unwrap());
+        assert_eq!(budget.in_use(), 10 * MIB);
+        assert!(
+            limiter
+                .memory_growing(10 * MIB as usize, 30 * MIB as usize, None)
+                .unwrap()
+        );
+        assert_eq!(budget.in_use(), 30 * MIB, "charged the 20MiB of growth");
+        assert_eq!(limiter.charged(), 30 * MIB);
+    }
+
+    #[test]
+    fn enforce_refuses_the_growth_that_crosses_the_budget() {
+        let budget = budget(100 * MIB, GuestMemoryMode::Enforce);
+        let mut a = budget.limiter();
+        let mut b = budget.limiter();
+
+        assert!(a.memory_growing(0, 60 * MIB as usize, None).unwrap());
+        assert!(
+            !b.memory_growing(0, 60 * MIB as usize, None).unwrap(),
+            "the second guest is refused: together they would be over"
+        );
+        assert_eq!(budget.in_use(), 60 * MIB, "a refused growth is not charged");
+        assert_eq!(budget.refused(), 1);
+        assert_eq!(b.charged(), 0);
+
+        // The budget refuses what does not fit, not everything thereafter.
+        assert!(b.memory_growing(0, 30 * MIB as usize, None).unwrap());
+        assert_eq!(budget.in_use(), 90 * MIB);
+    }
+
+    /// The upgrade-safety guarantee: a host that gains a derived budget it
+    /// never asked for must behave exactly as it did before.
+    #[test]
+    fn count_allows_everything_and_still_reports_it() {
+        let budget = budget(100 * MIB, GuestMemoryMode::Count);
+        let mut a = budget.limiter();
+        let mut b = budget.limiter();
+
+        assert!(a.memory_growing(0, 80 * MIB as usize, None).unwrap());
+        assert!(
+            b.memory_growing(0, 80 * MIB as usize, None).unwrap(),
+            "count mode never refuses"
+        );
+        assert_eq!(
+            budget.in_use(),
+            160 * MIB,
+            "and still charges, so the high-water figure is true"
+        );
+        assert_eq!(budget.high_water(), 160 * MIB);
+        assert_eq!(budget.would_refuse(), 1);
+        assert_eq!(budget.refused(), 0, "nothing was actually refused");
+    }
+
+    /// The failure the budget exists to catch: guests individually under the
+    /// per-memory ceiling, collectively over the host's.
+    #[test]
+    fn aggregate_creep_is_caught_where_a_per_memory_ceiling_would_not_be() {
+        let heap_ceiling = 1024 * MIB;
+        let budget = budget(4608 * MIB, GuestMemoryMode::Enforce);
+        let mut guests: Vec<_> = (0..5).map(|_| budget.limiter()).collect();
+
+        let mut admitted = 0;
+        for guest in &mut guests {
+            // Every one of these is legal against `default_heap_memory`.
+            if guest
+                .memory_growing(0, heap_ceiling as usize, Some(heap_ceiling as usize))
+                .unwrap()
+            {
+                admitted += 1;
+            }
+        }
+        assert_eq!(
+            admitted, 4,
+            "the fifth is what would have OOM-killed the pod"
+        );
+        assert_eq!(budget.refused(), 1);
+    }
+
+    #[test]
+    fn a_dropped_store_gives_its_bytes_back() {
+        let budget = budget(100 * MIB, GuestMemoryMode::Enforce);
+        let mut resident = budget.limiter();
+        assert!(resident.memory_growing(0, 40 * MIB as usize, None).unwrap());
+
+        {
+            let mut transient = budget.limiter();
+            assert!(
+                transient
+                    .memory_growing(0, 50 * MIB as usize, None)
+                    .unwrap()
+            );
+            assert_eq!(budget.in_use(), 90 * MIB);
+        }
+
+        assert_eq!(
+            budget.in_use(),
+            40 * MIB,
+            "the dropped store's charge is returned, the survivor's is not"
+        );
+        // The bytes are genuinely available again, not merely uncounted.
+        let mut next = budget.limiter();
+        assert!(next.memory_growing(0, 60 * MIB as usize, None).unwrap());
+    }
+
+    /// A store that dies mid-call is the case that would ratchet the budget
+    /// down until the host refused everything, so it is pinned separately from
+    /// the orderly drop above.
+    #[test]
+    fn a_store_dropped_mid_growth_still_gives_its_bytes_back() {
+        let budget = budget(100 * MIB, GuestMemoryMode::Enforce);
+        let mut limiter = budget.limiter();
+        assert!(limiter.memory_growing(0, 90 * MIB as usize, None).unwrap());
+        // Refused, so nothing more is owed — and then the store goes away
+        // without anyone unwinding the charge it did make.
+        assert!(!limiter.memory_growing(0, 90 * MIB as usize, None).unwrap());
+        drop(limiter);
+
+        assert_eq!(budget.in_use(), 0);
+        assert_eq!(budget.high_water(), 90 * MIB, "the high-water mark stands");
+    }
+
+    /// The charge has to be exact under concurrency: a lost update leaks bytes
+    /// the budget never gets back, and an over-release lets it admit more than
+    /// its cap.
+    #[test]
+    fn concurrent_growth_across_threads_balances_exactly() {
+        let budget = budget(u64::MAX, GuestMemoryMode::Enforce);
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let budget = Arc::clone(&budget);
+                std::thread::spawn(move || {
+                    for _ in 0..200 {
+                        let mut limiter = budget.limiter();
+                        assert!(limiter.memory_growing(0, MIB as usize, None).unwrap());
+                        assert!(
+                            limiter
+                                .memory_growing(MIB as usize, 2 * MIB as usize, None)
+                                .unwrap()
+                        );
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().expect("no thread should panic");
+        }
+
+        assert_eq!(
+            budget.in_use(),
+            0,
+            "every store was dropped, so every byte came back"
+        );
+        assert!(budget.high_water() >= 2 * MIB);
+    }
+
+    /// The pooling allocator's per-slot ceiling is applied *after* the limiter
+    /// and is not what `maximum` reports — that is the memory type's limit,
+    /// 4GiB for a Rust component that declares none. Charging against the
+    /// wrong one leaks: a guest looping `memory.grow` past
+    /// `default-heap-memory` is charged every time, wasmtime refuses every
+    /// time, and the budget walks to its cap and starts refusing every other
+    /// workload on the host.
+    #[test]
+    fn growth_past_the_pools_slot_ceiling_is_not_charged() {
+        let heap_ceiling = 512 * MIB;
+        let budget = Arc::new(
+            GuestMemoryBudget::new(8192 * MIB, GuestMemoryMode::Enforce)
+                .with_heap_ceiling(heap_ceiling),
+        );
+        let mut limiter = budget.limiter();
+
+        // Up to the ceiling is fine.
+        assert!(
+            limiter
+                .memory_growing(0, heap_ceiling as usize, Some(4096 * MIB as usize))
+                .unwrap()
+        );
+        assert_eq!(budget.in_use(), heap_ceiling);
+
+        // Past it, wasmtime refuses regardless — the type max says 4GiB, so
+        // nothing else here would have caught this.
+        for _ in 0..100 {
+            assert!(
+                !limiter
+                    .memory_growing(
+                        heap_ceiling as usize,
+                        (heap_ceiling + MIB) as usize,
+                        Some(4096 * MIB as usize),
+                    )
+                    .unwrap()
+            );
+        }
+        assert_eq!(
+            budget.in_use(),
+            heap_ceiling,
+            "a hundred refused growths must not have moved the budget"
+        );
+        assert_eq!(limiter.charged(), heap_ceiling);
+    }
+
+    /// Charging for growth wasmtime is about to refuse anyway would leave the
+    /// budget holding bytes no guest ever received, for the life of the store.
+    #[test]
+    fn growth_past_the_memorys_own_maximum_is_not_charged() {
+        let budget = budget(u64::MAX, GuestMemoryMode::Enforce);
+        let mut limiter = budget.limiter();
+
+        assert!(
+            !limiter
+                .memory_growing(0, 20 * MIB as usize, Some(10 * MIB as usize))
+                .unwrap()
+        );
+        assert_eq!(budget.in_use(), 0);
+        assert_eq!(limiter.charged(), 0);
+        assert_eq!(
+            budget.refused(),
+            0,
+            "wasmtime's own ceiling refused this, not the budget"
+        );
+    }
+
+    #[test]
+    fn a_store_without_a_budget_is_neither_charged_nor_limited() {
+        let mut limiter = StoreMemoryLimiter::default();
+        assert!(limiter.memory_growing(0, usize::MAX / 2, None).unwrap());
+        assert_eq!(limiter.charged(), 0);
+    }
+
+    #[test]
+    fn tables_are_not_charged_against_the_memory_budget() {
+        let budget = budget(MIB, GuestMemoryMode::Enforce);
+        let mut limiter = budget.limiter();
+        assert!(limiter.table_growing(0, 1_000_000, None).unwrap());
+        assert_eq!(budget.in_use(), 0);
+    }
+
+    #[test]
+    fn the_budget_takes_its_cap_from_the_resolved_knobs() {
+        let budgets = HostMemoryBudgets::resolve(Some(8 * 1024 * MIB), None, None).unwrap();
+        let budget = GuestMemoryBudget::from_budgets(&budgets, GuestMemoryMode::Enforce);
+        assert_eq!(budget.cap(), 8 * 1024 * MIB);
+        assert_eq!(budget.mode(), GuestMemoryMode::Enforce);
+    }
+
+    /// Collect every `u64` metric the budget publishes, through a real SDK
+    /// pipeline. A reader of its own rather than the process-wide meter, so
+    /// the assertions do not depend on what another test installed globally.
+    fn collect_metrics(budget: &Arc<GuestMemoryBudget>) -> BTreeMap<String, u64> {
+        use opentelemetry::metrics::MeterProvider as _;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+            data::{AggregatedMetrics, MetricData},
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .build();
+        budget.register_metrics(&provider.meter("test"));
+        provider.force_flush().expect("flush");
+
+        let mut seen = BTreeMap::new();
+        for resource in exporter.get_finished_metrics().expect("finished metrics") {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    let AggregatedMetrics::U64(data) = metric.data() else {
+                        continue;
+                    };
+                    let value = match data {
+                        MetricData::Gauge(gauge) => gauge.data_points().map(|p| p.value()).next(),
+                        MetricData::Sum(sum) => sum.data_points().map(|p| p.value()).next(),
+                        _ => None,
+                    };
+                    if let Some(value) = value {
+                        seen.insert(metric.name().to_string(), value);
+                    }
+                }
+            }
+        }
+        seen
+    }
+
+    /// The figures reach a metrics pipeline, which is how an operator watches
+    /// the high-water mark before turning enforcement on. Collected rather than
+    /// read off the getters, so this covers the part that can silently not
+    /// work: the callbacks being registered, and reporting what the budget
+    /// actually holds.
+    #[test]
+    fn the_budget_is_exported_as_metrics() {
+        let budget = Arc::new(GuestMemoryBudget::new(100 * MIB, GuestMemoryMode::Enforce));
+        let mut limiter = budget.limiter();
+        assert!(limiter.memory_growing(0, 40 * MIB as usize, None).unwrap());
+        assert!(
+            !limiter
+                .memory_growing(40 * MIB as usize, 200 * MIB as usize, None)
+                .unwrap()
+        );
+
+        let seen = collect_metrics(&budget);
+        assert_eq!(seen.get("guest_memory.in_use"), Some(&(40 * MIB)));
+        assert_eq!(seen.get("guest_memory.high_water"), Some(&(40 * MIB)));
+        assert_eq!(
+            seen.get("guest_memory.limit"),
+            Some(&(100 * MIB)),
+            "the cap is exported so a dashboard need not hardcode it"
+        );
+        assert_eq!(
+            seen.get("guest_memory.refused"),
+            Some(&1),
+            "the refusal must reach the pipeline: {seen:?}"
+        );
+        assert_eq!(seen.get("guest_memory.would_refuse"), Some(&0));
+    }
+
+    /// The high-water mark is exported rather than left to
+    /// `max_over_time(in_use)` in the query layer, because the exporter samples:
+    /// a burst that begins and ends between two collections is invisible to the
+    /// gauge but is exactly what precedes an unexplained OOM.
+    #[test]
+    fn a_burst_between_collections_survives_in_the_high_water_mark() {
+        let budget = Arc::new(GuestMemoryBudget::new(100 * MIB, GuestMemoryMode::Enforce));
+        {
+            let mut spike = budget.limiter();
+            assert!(spike.memory_growing(0, 80 * MIB as usize, None).unwrap());
+        }
+        // The store is gone before anything collected, so `in_use` never
+        // witnessed it.
+        let seen = collect_metrics(&budget);
+        assert_eq!(seen.get("guest_memory.in_use"), Some(&0));
+        assert_eq!(seen.get("guest_memory.high_water"), Some(&(80 * MIB)));
+    }
+
+    /// The callbacks must not keep a dropped engine's budget alive: a process
+    /// building many engines would otherwise accumulate one live budget per
+    /// engine for as long as the meter provider lives.
+    #[test]
+    fn a_dropped_budget_is_not_held_alive_by_the_meter() {
+        use opentelemetry::metrics::MeterProvider as _;
+        use opentelemetry_sdk::metrics::{
+            InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        };
+
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter).build())
+            .build();
+
+        let weak = {
+            let budget = Arc::new(GuestMemoryBudget::new(MIB, GuestMemoryMode::Count));
+            budget.register_metrics(&provider.meter("test"));
+            Arc::downgrade(&budget)
+        };
+        assert!(
+            weak.upgrade().is_none(),
+            "the meter provider must not hold the budget alive"
+        );
+        // Collecting against a dead budget observes nothing rather than panicking.
+        provider.force_flush().expect("flush");
+    }
+
+    #[test]
+    fn the_default_budget_is_accounted_but_never_crossed() {
+        let budget = Arc::new(GuestMemoryBudget::default());
+        let mut limiter = budget.limiter();
+        assert!(
+            limiter
+                .memory_growing(0, 4096 * MIB as usize, None)
+                .unwrap()
+        );
+        assert_eq!(budget.in_use(), 4096 * MIB);
+        assert_eq!(budget.would_refuse(), 0);
+    }
+}

--- a/crates/wash-runtime/src/engine/host_memory.rs
+++ b/crates/wash-runtime/src/engine/host_memory.rs
@@ -12,11 +12,13 @@
 //!
 //! **Nothing here changes behaviour when the flags are unset.** Both pool knobs
 //! fall through to exactly the values wasmtime has always used, and the budget
-//! is used to *check* the other two rather than to gate anything. That is
-//! deliberate: this is the vocabulary a memory-aware host needs, landed on its
-//! own so the enforcement built on top of it can be reviewed separately.
+//! only *checks* the other two unless a host opts into enforcing it. What
+//! enforces it is [`crate::engine::guest_memory`], which counts rather than
+//! refuses by default — for the same reason: an unset budget is derived, never
+//! absent, so enforcing it out of the box would hand every host a ceiling
+//! nobody chose.
 //!
-//! # Why the budget is worth having before anything enforces it
+//! # Why the budget is worth naming apart from enforcing it
 //!
 //! `default_heap_memory × core_instances` is what the pooling allocator
 //! reserves — every slot is sized for the largest memory it might hold, whether
@@ -346,7 +348,47 @@ impl HostMemoryBudgets {
         }
         None
     }
+
+    /// What to say about enforcing this budget on this machine, if anything.
+    ///
+    /// Separate from [`Self::advisory`] because it is only worth saying when
+    /// the budget is a real ceiling: in count mode a budget larger than the
+    /// machine costs nothing, because nothing is refused.
+    ///
+    /// The check is against the limit that would actually OOM-kill this
+    /// process, not against the budget's own derivation, so it catches the
+    /// misconfiguration however it arrived — a flag, an environment variable,
+    /// or a Helm chart passing `resources.limits.memory` straight through.
+    /// A *derived* budget is three quarters of that limit and never trips it.
+    pub fn enforcement_advisory(&self) -> Option<String> {
+        let limit = detected_memory_limit()?;
+        if self.max_guest_memory.saturating_mul(100)
+            <= limit.saturating_mul(MAX_ENFORCED_SHARE_PERCENT)
+        {
+            return None;
+        }
+        Some(format!(
+            "max-guest-memory {} is {}% of the {} this process is actually limited to, and \
+             guest memory is being enforced. Everything a guest is not — wasmtime itself, \
+             compiled module images, NATS, OCI pulls, host buffers — comes out of the same \
+             limit and is not charged to this budget, so the kernel is likely to OOM-kill \
+             this host before the budget ever refuses a guest. An unset budget reserves a \
+             quarter of the limit for them; set max-guest-memory below the container limit, \
+             or raise the limit.",
+            render_bytes(self.max_guest_memory),
+            self.max_guest_memory.saturating_mul(100) / limit.max(1),
+            render_bytes(limit),
+        ))
+    }
 }
+
+/// Share of the real memory limit an *enforced* guest budget may claim before
+/// the host says the number leaves it no room to be a host.
+///
+/// Above the derived 75%, so a host that named no budget never trips it, and
+/// below 100%, which is the value a chart passing `limits.memory` through
+/// produces.
+const MAX_ENFORCED_SHARE_PERCENT: u64 = 90;
 
 /// What `is_pooling_allocator_supported` probes for at startup, and therefore
 /// the most address space the pool can be assumed to get.
@@ -643,6 +685,52 @@ mod tests {
             advisory.contains("default-heap-memory") && advisory.contains("core-instances"),
             "names both knobs so it is actionable: {advisory}"
         );
+    }
+
+    /// The chart passes `resources.limits.memory` through as the guest budget
+    /// verbatim, so an operator turning enforcement on gets a ceiling equal to
+    /// 100% of the pod — and the host's own overhead, which this budget does
+    /// not charge, then OOM-kills the pod before the budget refuses anything.
+    #[test]
+    fn enforcing_a_budget_that_leaves_the_host_no_room_is_called_out() {
+        let limit = detected_memory_limit().expect("a test machine has a readable memory limit");
+
+        // The whole limit: what the chart renders today.
+        let whole = HostMemoryBudgets::resolve(Some(limit), None, None).unwrap();
+        let advisory = whole
+            .enforcement_advisory()
+            .expect("a budget equal to the real limit leaves the host nothing");
+        assert!(
+            advisory.contains("max-guest-memory") && advisory.contains("OOM"),
+            "the advisory must name the knob and the consequence: {advisory}"
+        );
+
+        // Half of it: room to spare, nothing to say.
+        let modest = HostMemoryBudgets::resolve(Some(limit / 2), None, None).unwrap();
+        assert_eq!(modest.enforcement_advisory(), None);
+    }
+
+    /// The derived budget is three quarters of the limit, so a host that named
+    /// no budget must never trip the advisory — otherwise every host that
+    /// turned enforcement on would be warned about a number it did not choose.
+    #[test]
+    fn a_derived_budget_is_never_warned_about() {
+        let derived = HostMemoryBudgets::resolve(None, None, None).unwrap();
+        // Only meaningful where the derivation was not clamped: the 256MiB
+        // floor can legitimately exceed a tiny container's limit, and being
+        // told so is correct.
+        let limit = detected_memory_limit().expect("a test machine has a readable memory limit");
+        if derived.max_guest_memory > MIN_DERIVED_MAX_GUEST_MEMORY
+            && derived.max_guest_memory < MAX_DERIVED_MAX_GUEST_MEMORY
+        {
+            assert_eq!(
+                derived.enforcement_advisory(),
+                None,
+                "a derived budget is {} of a {} limit and reserves its own headroom",
+                render_bytes(derived.max_guest_memory),
+                render_bytes(limit),
+            );
+        }
     }
 
     #[test]

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -77,6 +77,8 @@ pub(crate) struct ComponentCtxTemplate {
     /// `allowedHostLoopbackPorts`) comes from `local_resources` and is layered over
     /// this when the check is built.
     socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
+    /// The host-wide guest memory budget this component's stores draw on.
+    guest_memory: Arc<crate::engine::guest_memory::GuestMemoryBudget>,
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
 }
@@ -91,6 +93,7 @@ impl ComponentCtxTemplate {
             plugins: metadata.plugins.clone(),
             loopback: metadata.loopback.clone(),
             socket_policy: metadata.socket_policy.clone(),
+            guest_memory: metadata.guest_memory.clone(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: None,
         }
@@ -336,7 +339,7 @@ pub(crate) async fn new_store_from_templates(
         is_service,
     )
     .await?;
-    let mut shared_ctx = SharedCtx::new(active_ctx);
+    let mut shared_ctx = SharedCtx::new(active_ctx).with_guest_memory(&active.guest_memory);
 
     for linked in linked {
         let linked_ctx = build_ctx_from_template(
@@ -356,6 +359,7 @@ pub(crate) async fn new_store_from_templates(
     // Trap for every store built here, services included: trapping a service
     // means a supervisor restart, which beats carrying a wedged call forever.
     arm_epoch_deadline(&mut store, AbandonedCallPolicy::Trap);
+    crate::engine::guest_memory::install_memory_limiter(&mut store);
 
     let active_id = active.component_id.clone();
     for (linked_id, linked_pre) in linked_instances {

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -1377,6 +1377,14 @@ where
     Some(value)
 }
 
+/// [`pooling_env_override`] for the knobs that are plain instance counts.
+///
+/// All of them default to the same resolved `--core-instances` and all of them
+/// mean "this host runs nothing" at zero, so all of them want the same guard.
+fn pooling_env_instances(key: &str, resolved: u32) -> u32 {
+    pooling_env_override(key, resolved, |v| v.to_string()).unwrap_or(resolved)
+}
+
 fn new_pooling_config(instances: u32, default_heap_memory: u64) -> PoolingAllocationConfig {
     let mut config = PoolingAllocationConfig::default();
     if let Some(v) = getenv("WASMTIME_POOLING_MAX_UNUSED_WASM_SLOTS") {
@@ -1394,11 +1402,10 @@ fn new_pooling_config(instances: u32, default_heap_memory: u64) -> PoolingAlloca
     if let Some(v) = getenv("WASMTIME_POOLING_TABLE_KEEP_RESIDENT") {
         config.table_keep_resident(v);
     }
-    if let Some(v) = getenv("WASMTIME_POOLING_TOTAL_COMPONENT_INSTANCES") {
-        config.total_component_instances(v);
-    } else {
-        config.total_component_instances(instances);
-    }
+    config.total_component_instances(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_COMPONENT_INSTANCES",
+        instances,
+    ));
     if let Some(v) = getenv("WASMTIME_POOLING_MAX_COMPONENT_INSTANCE_SIZE") {
         config.max_component_instance_size(v);
     }
@@ -1411,29 +1418,24 @@ fn new_pooling_config(instances: u32, default_heap_memory: u64) -> PoolingAlloca
     if let Some(v) = getenv("WASMTIME_POOLING_MAX_TABLES_PER_COMPONENT") {
         config.max_tables_per_component(v);
     }
-    if let Some(v) = getenv("WASMTIME_POOLING_TOTAL_MEMORIES") {
-        config.total_memories(v);
-    } else {
-        config.total_memories(instances);
-    }
-    if let Some(v) = getenv("WASMTIME_POOLING_TOTAL_TABLES") {
-        config.total_tables(v);
-    } else {
-        config.total_tables(instances);
-    }
-    if let Some(v) = getenv("WASMTIME_POOLING_TOTAL_STACKS") {
-        config.total_stacks(v);
-    } else {
-        config.total_stacks(instances);
-    }
+    config.total_memories(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_MEMORIES",
+        instances,
+    ));
+    config.total_tables(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_TABLES",
+        instances,
+    ));
+    config.total_stacks(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_STACKS",
+        instances,
+    ));
     // `--core-instances` is what `host memory resolved` reports, and this is
     // what actually sizes the pool.
-    config.total_core_instances(
-        pooling_env_override("WASMTIME_POOLING_TOTAL_CORE_INSTANCES", instances, |v| {
-            v.to_string()
-        })
-        .unwrap_or(instances),
-    );
+    config.total_core_instances(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_CORE_INSTANCES",
+        instances,
+    ));
     if let Some(v) = getenv("WASMTIME_POOLING_MAX_CORE_INSTANCE_SIZE") {
         config.max_core_instance_size(v);
     }
@@ -1461,11 +1463,10 @@ fn new_pooling_config(instances: u32, default_heap_memory: u64) -> PoolingAlloca
         .unwrap_or(resolved_heap),
     );
     #[cfg(not(windows))]
-    if let Some(v) = getenv("WASMTIME_POOLING_TOTAL_GC_HEAPS") {
-        config.total_gc_heaps(v);
-    } else {
-        config.total_gc_heaps(instances);
-    }
+    config.total_gc_heaps(pooling_env_instances(
+        "WASMTIME_POOLING_TOTAL_GC_HEAPS",
+        instances,
+    ));
     config
 }
 

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -219,6 +219,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 
 pub mod abandon;
 pub mod ctx;
+pub mod guest_memory;
 pub(crate) mod instance_driver;
 pub(crate) mod instance_pool;
 pub use instance_pool::InstancePolicy;
@@ -299,6 +300,10 @@ pub struct Engine {
     /// (`allowedHosts`, `allowedHostLoopbackPorts`) is layered over it per component.
     pub(crate) socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
     pub(crate) host_memory: host_memory::HostMemoryBudgets,
+    /// The host-wide counter of guest linear-memory bytes that
+    /// [`host_memory::HostMemoryBudgets::max_guest_memory`] is the cap on.
+    /// Every store this engine builds carries a limiter drawing on it.
+    pub(crate) guest_memory: Arc<guest_memory::GuestMemoryBudget>,
     /// TLS provider override for `wasi:tls` client connections.
     #[cfg(feature = "wasi-tls")]
     pub(crate) tls_provider: Option<SharedTlsProvider>,
@@ -432,6 +437,12 @@ impl Engine {
     /// installed — including an embedder's `max_instances` winning over the flag-driven count.
     pub fn host_memory(&self) -> host_memory::HostMemoryBudgets {
         self.host_memory
+    }
+
+    /// The host-wide guest memory budget, for reporting what guests are
+    /// holding and what the budget has refused.
+    pub fn guest_memory(&self) -> &Arc<guest_memory::GuestMemoryBudget> {
+        &self.guest_memory
     }
 
     /// Core instances the pooling allocator was configured to admit, captured
@@ -639,6 +650,7 @@ impl Engine {
             loopback,
         );
         service.metadata.socket_policy = Arc::clone(&self.socket_policy);
+        service.metadata.guest_memory = Arc::clone(&self.guest_memory);
 
         let world = service.world();
 
@@ -764,6 +776,7 @@ impl Engine {
             instances,
         );
         workload_component.metadata.socket_policy = Arc::clone(&self.socket_policy);
+        workload_component.metadata.guest_memory = Arc::clone(&self.guest_memory);
         Ok(workload_component)
     }
 
@@ -948,6 +961,7 @@ pub struct EngineBuilder {
     fuel_consumption: Option<bool>,
     socket_policy: Option<Arc<crate::sockets::policy::SocketPolicy>>,
     host_memory: Option<host_memory::HostMemoryBudgets>,
+    guest_memory_mode: guest_memory::GuestMemoryMode,
     /// Optional TLS provider override for wasi:tls client connections.
     #[cfg(feature = "wasi-tls")]
     tls_provider: Option<SharedTlsProvider>,
@@ -970,6 +984,19 @@ impl EngineBuilder {
     /// Unset, the engine uses wasmtime's default memory limits.
     pub fn with_host_memory(mut self, host_memory: host_memory::HostMemoryBudgets) -> Self {
         self.host_memory = Some(host_memory);
+        self
+    }
+
+    /// Whether `max_guest_memory` is enforced or only accounted.
+    ///
+    /// Unset, it is [`guest_memory::GuestMemoryMode::Count`]: the budget is
+    /// charged and reported but never refuses a growth. That is deliberate —
+    /// `max_guest_memory` is derived when an operator sets nothing, so
+    /// enforcing by default would give every host a ceiling on upgrade that
+    /// nobody chose.
+    #[must_use]
+    pub fn with_guest_memory_mode(mut self, mode: guest_memory::GuestMemoryMode) -> Self {
+        self.guest_memory_mode = mode;
         self
     }
 
@@ -1125,6 +1152,13 @@ impl EngineBuilder {
         if let Some(advisory) = host_memory.advisory() {
             tracing::warn!("{advisory}");
         }
+        // Only when the budget is a real ceiling: an over-large budget the host
+        // merely counts against costs nothing.
+        if self.guest_memory_mode == guest_memory::GuestMemoryMode::Enforce
+            && let Some(advisory) = host_memory.enforcement_advisory()
+        {
+            tracing::warn!("{advisory}");
+        }
 
         // The pooling allocator can be more efficient for workloads with many short-lived instances.
         // Read back from the installed pool: the environment and a
@@ -1155,6 +1189,7 @@ impl EngineBuilder {
         match installed_pool {
             Some(pool) => tracing::info!(
                 max_guest_memory = %host_memory::render_bytes(host_memory.max_guest_memory),
+                guest_memory_mode = self.guest_memory_mode.as_str(),
                 default_heap_memory = %host_memory::render_bytes(pool.max_memory_size),
                 core_instances = pool.core_instances,
                 memories = pool.memories,
@@ -1164,6 +1199,7 @@ impl EngineBuilder {
             // No pool, so no reservation and no installed ceiling to name.
             None => tracing::info!(
                 max_guest_memory = %host_memory::render_bytes(host_memory.max_guest_memory),
+                guest_memory_mode = self.guest_memory_mode.as_str(),
                 pooling = false,
                 "host memory resolved"
             ),
@@ -1215,6 +1251,21 @@ impl EngineBuilder {
             cache,
             socket_policy: self.socket_policy.unwrap_or_default(),
             host_memory,
+            guest_memory: {
+                let budget = guest_memory::GuestMemoryBudget::from_budgets(
+                    &host_memory,
+                    self.guest_memory_mode,
+                );
+                // The ceiling the pool actually installed, not the knob that
+                // asked for it: the budget must not charge for growth the pool
+                // is going to refuse. The same figure `explain_compile_failure`
+                // measures against, so they cannot drift apart.
+                match installed_heap_memory {
+                    Some(ceiling) => budget.with_heap_ceiling(ceiling),
+                    None => budget,
+                }
+                .into_metered()
+            },
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
             total_core_instances,

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -1341,10 +1341,15 @@ where
 
 /// Reports a `WASMTIME_POOLING_*` value that overrides a resolved flag.
 ///
-/// `host memory resolved` is the line an operator reads to confirm what the
-/// host is running, and every sizing rule is derived against it. These envs are
-/// applied *after* it, so when one is set the line is quietly wrong — it names
-/// the flag, not the number in force. This says so, once, next to it.
+/// The flags are what an operator set and what every sizing rule is derived
+/// against; these envs are applied on top of them, here. Where the two differ
+/// the host runs on the env, and an operator reading back the flag they set
+/// has no way to tell — so this says which one won, once, at startup.
+///
+/// It does not say `host memory resolved` is wrong. That line is read back
+/// from the pool that was actually built ([`InstalledPool`]), so for the three
+/// knobs it names it already prints the overridden number; the other four it
+/// does not mention at all.
 ///
 /// Also refuses a zero. Every one of these knobs means "this host runs
 /// nothing" at zero, which is never what an operator meant, and the flags they
@@ -1364,14 +1369,14 @@ where
         return None;
     }
     if value != resolved {
-        // Rendered, not raw: `host memory resolved` prints this knob through
-        // `render_bytes`, and an operator cannot compare 4294967296 to 256MiB.
+        // Rendered, not raw: the byte-sized knobs go through `render_bytes`,
+        // and an operator cannot compare 4294967296 to 256MiB.
         let (resolved, value) = (render(resolved), render(value));
         warn!(
             resolved = %resolved,
             override_value = %value,
-            "`{key}` overrides the resolved host memory budget: this host runs with \
-             {value}, not the {resolved} reported by `host memory resolved`"
+            "`{key}` overrides the flag it shadows: this host runs with {value}, not the \
+             {resolved} it was configured with"
         );
     }
     Some(value)

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -116,6 +116,11 @@ pub struct WorkloadMetadata {
     /// from [`crate::engine::Engine`]'s configuration; the workload-level half
     /// (`allowedHosts`, `allowedHostLoopbackPorts`) comes from `local_resources`.
     pub(crate) socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
+    /// The host-wide guest memory budget every store built for this component
+    /// draws on. Installed by the engine alongside `socket_policy`; the
+    /// [`Default`] here is an unmetered budget, so a metadata built outside an
+    /// engine is neither charged nor limited.
+    pub(crate) guest_memory: Arc<crate::engine::guest_memory::GuestMemoryBudget>,
     /// Linked component ids
     linked_components: HashSet<Arc<str>>,
 }
@@ -340,6 +345,7 @@ impl WorkloadService {
                 plugins: None,
                 loopback,
                 socket_policy: Arc::default(),
+                guest_memory: Arc::default(),
                 linked_components: Default::default(),
             },
             handle: None,
@@ -435,6 +441,7 @@ impl WorkloadComponent {
                 plugins: None,
                 loopback,
                 socket_policy: Arc::default(),
+                guest_memory: Arc::default(),
                 linked_components: Default::default(),
             },
             name: component_name.into(),

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -841,6 +841,10 @@ impl HostApi for Host {
             monitor.refresh();
             monitor.report_usage();
         }
+        // Reported beside the machine's own usage, because the two answer
+        // different questions: the monitor says how much memory this process
+        // holds, the budget says how much of it guests asked for.
+        self.engine.guest_memory().report();
 
         let (os_arch, os_name, os_kernel) = self.get_system_info().await;
         let (system_memory_total, system_memory_free) = self

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -1852,7 +1852,14 @@ fn build_plugin_store(
     let ctx = ctx_builder.build();
     // The registry marks this as the plugin (real) side of the resource bridge
     // and keeps the resources it hands out across the boundary alive.
-    let mut store = Store::new(engine.inner(), SharedCtx::new(ctx).with_resource_registry());
+    // A host component plugin is a guest too: its linear memory is charged to
+    // the same host-wide budget the workloads on this engine draw on.
+    let mut store = Store::new(
+        engine.inner(),
+        SharedCtx::new(ctx)
+            .with_resource_registry()
+            .with_guest_memory(engine.guest_memory()),
+    );
     // Required, not optional: the engine enables `epoch_interruption`, and a
     // store that never sets a deadline traps the moment it runs any guest code.
     // `WarnThenTrap` because this one store serves every workload that imports
@@ -1862,6 +1869,7 @@ fn build_plugin_store(
         &mut store,
         crate::engine::abandon::AbandonedCallPolicy::WarnThenTrap,
     );
+    crate::engine::guest_memory::install_memory_limiter(&mut store);
     store
 }
 

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -401,6 +401,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-memory-grow"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "http-sleeper"
 version = "0.0.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "postgres-implements",
     # P3 fixtures (wasm32-wasip1 + reactor adapter)
     "http-handler-p3",
+    "http-memory-grow",
     "http-ip-name-lookup-p3",
     "http-blobstore-p3",
     "cli-service-p3",

--- a/crates/wash-runtime/tests/fixtures/http-memory-grow/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/http-memory-grow/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/http_memory_grow.wasm

--- a/crates/wash-runtime/tests/fixtures/http-memory-grow/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/http-memory-grow/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "http-memory-grow"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/http-memory-grow/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-memory-grow/src/lib.rs
@@ -1,0 +1,136 @@
+//! A p3 HTTP handler that grows its own linear memory and reports what it got.
+//!
+//! `GET /grow?mib=N` grows the memory by N MiB and answers
+//! `{"granted_mib":G,"refused":B}`. The growth goes through
+//! `core::arch::wasm32::memory_grow` rather than through an allocation, so a
+//! refusal is *observable*: the intrinsic hands back `usize::MAX` where a Rust
+//! allocation would call `handle_alloc_error` and abort, turning the host's
+//! deliberate `-1` into a trap and hiding the very thing under test.
+//!
+//! Each page grown is written to, so the pages the host is charged for are
+//! pages the kernel really backs — otherwise a lazily committing allocator
+//! makes the fixture prove nothing about residency.
+//!
+//! The memory is never given back: a wasm linear memory cannot shrink. That is
+//! the point — what releases it is the store being dropped.
+
+mod bindings {
+    wit_bindgen::generate!({
+        generate_all,
+    });
+}
+
+use bindings::exports::wasi::http::handler::Guest as Handler;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+/// The WebAssembly page size.
+const PAGE: usize = 64 * 1024;
+const PAGES_PER_MIB: usize = (1024 * 1024) / PAGE;
+
+/// Held across the grow loop so the reply can be built after the host has
+/// stopped handing out memory. Several pages, so it survives however the
+/// allocator chooses to carve it up.
+const RESERVE_BYTES: usize = 8 * PAGE;
+
+struct Component;
+
+impl Handler for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let path = request.get_path_with_query().unwrap_or_default();
+        let mib = query_usize(&path, "mib=").unwrap_or(1);
+
+        // Bought before the loop and handed back after it, so building the
+        // reply is served from the allocator's free list rather than from a
+        // fresh `memory.grow`.
+        //
+        // This is load-bearing: the loop runs until the host refuses, leaving
+        // the budget with under a page to spare, and a Rust guest whose
+        // allocation fails calls `handle_alloc_error` and aborts. Without the
+        // reserve, the graceful -1 under test would surface as a trap — the
+        // one outcome the test asserts against.
+        //
+        // Written to and passed through `black_box`, because a buffer that is
+        // only allocated and dropped is an allocation the optimiser is free to
+        // delete outright, and this fixture is built `--release`.
+        let mut reserve: Vec<u8> = vec![0; RESERVE_BYTES];
+        std::hint::black_box(&mut reserve);
+
+        let mut granted_pages = 0;
+        let mut refused = false;
+        // One page at a time so the reply can say exactly where the budget cut
+        // in, rather than only that the whole request failed.
+        for _ in 0..(mib * PAGES_PER_MIB) {
+            match grow_one_page() {
+                Some(base) => {
+                    touch(base);
+                    granted_pages += 1;
+                }
+                None => {
+                    refused = true;
+                    break;
+                }
+            }
+        }
+
+        // Everything below here allocates — the body, the header fields, the
+        // stream and future pair, the spawned task. This is what pays for it.
+        std::hint::black_box(&reserve);
+        drop(reserve);
+
+        let body = format!(
+            "{{\"granted_mib\":{},\"refused\":{refused}}}",
+            granted_pages / PAGES_PER_MIB
+        );
+        Ok(make_response(body.into_bytes()))
+    }
+}
+
+/// Grow the default memory by one page, returning the byte offset of the new
+/// page, or `None` when the host refused.
+#[cfg(target_arch = "wasm32")]
+fn grow_one_page() -> Option<usize> {
+    let previous_pages = core::arch::wasm32::memory_grow::<0>(1);
+    // `memory.grow` answers `-1` on failure, which the intrinsic surfaces as
+    // `usize::MAX`. Every other value is the page count from before the grow.
+    (previous_pages != usize::MAX).then(|| previous_pages * PAGE)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn grow_one_page() -> Option<usize> {
+    unreachable!("this fixture only builds for wasm32")
+}
+
+/// Write to the page at `base` so the host is charged for memory something
+/// actually resides in.
+fn touch(base: usize) {
+    // Safety: `base` is the first byte of a page `memory.grow` just returned,
+    // so the whole page is addressable and owned by nothing else.
+    unsafe {
+        core::ptr::write_volatile(base as *mut u8, 0xAB);
+        core::ptr::write_volatile((base + PAGE - 1) as *mut u8, 0xAB);
+    }
+}
+
+/// The digits following `key` in `path`, if it carries that key.
+fn query_usize(path: &str, key: &str) -> Option<usize> {
+    let (_, rest) = path.split_once(key)?;
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+fn make_response(body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(200);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/http-memory-grow/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/http-memory-grow/wit/world.wit
@@ -1,0 +1,7 @@
+package wasmcloud:memory-grow@0.1.0;
+
+world http-memory-grow {
+    import wasi:http/types@0.3.0;
+
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/http-memory-grow/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/http-memory-grow/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }

--- a/crates/wash-runtime/tests/integration_guest_memory_budget.rs
+++ b/crates/wash-runtime/tests/integration_guest_memory_budget.rs
@@ -1,0 +1,308 @@
+//! The host-wide guest memory budget, driven by a p3 guest that really grows.
+//!
+//! The `http-memory-grow` fixture grows its own linear memory a page at a time
+//! through `memory.grow` and reports how much it got and whether it was
+//! refused. That is what makes the two modes distinguishable end to end: in
+//! `Count` the guest always gets everything it asked for, in `Enforce` it stops
+//! at the budget and *says so* instead of trapping.
+//!
+//! What the unit tests in `engine::guest_memory` cannot cover is whether the
+//! limiter is installed on the stores the host actually builds. These tests are
+//! that check: they never touch the budget directly, only the guest's own
+//! report of what the host let it have.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::{
+        Engine,
+        guest_memory::{GuestMemoryBudget, GuestMemoryMode},
+        host_memory::HostMemoryBudgets,
+    },
+    host::{
+        HostApi, HostBuilder,
+        http::{DynamicRouter, Ingress},
+    },
+    plugin::{wasi_config::DynamicConfig, wasi_logging::TracingLogger},
+    types::{Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest},
+    wit::WitInterface,
+};
+
+const HTTP_MEMORY_GROW_WASM: &[u8] = include_bytes!("wasm/http_memory_grow.wasm");
+
+const MIB: u64 = 1024 * 1024;
+
+/// The budget these tests run under. Small enough that one fixture request can
+/// cross it, and well under `default_heap_memory` so it is the *aggregate*
+/// ceiling under test rather than wasmtime's per-memory one.
+const BUDGET_MIB: u64 = 48;
+
+/// What the guest asks for in a single request. Two of these cross
+/// [`BUDGET_MIB`]; one does not.
+const REQUEST_MIB: u64 = 32;
+
+/// What the guest reported about one `/grow` request.
+#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+struct GrowReport {
+    granted_mib: u64,
+    refused: bool,
+}
+
+async fn start_host(
+    mode: GuestMemoryMode,
+) -> Result<(std::net::SocketAddr, impl HostApi, Arc<GuestMemoryBudget>)> {
+    let engine = Engine::builder()
+        .with_host_memory(HostMemoryBudgets::resolve(Some(BUDGET_MIB * MIB), None, None).unwrap())
+        .with_guest_memory_mode(mode)
+        .build()?;
+    let budget = Arc::clone(engine.guest_memory());
+    let ingress = Ingress::new(DynamicRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let bound_addr = ingress.addr();
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(ingress))
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+    Ok((bound_addr, host, budget))
+}
+
+/// A workload serving `http-memory-grow` under `name` as its HTTP host header.
+///
+/// `pool_size: 1` keeps one warm store per workload, so a workload's grown
+/// pages stay resident between requests — which is what lets these tests
+/// accumulate toward the budget instead of having every request start over.
+fn grow_workload(name: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: name.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "http-memory-grow.wasm".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(HTTP_MEMORY_GROW_WASM),
+                local_resources: LocalResources {
+                    memory_limit_mb: 128,
+                    cpu_limit: 1,
+                    config: HashMap::new(),
+                    environment: HashMap::new(),
+                    volume_mounts: vec![],
+                    allowed_hosts: Default::default(),
+                    allowed_ip_name_lookups: Default::default(),
+                    allowed_host_loopback_ports: Default::default(),
+                },
+                pool_size: 1,
+                max_invocations: 100,
+                max_concurrency: 1,
+            }],
+            host_interfaces: vec![WitInterface {
+                namespace: "wasi".to_string(),
+                package: "http".to_string(),
+                interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+                version: Some(semver::Version::parse("0.2.2").unwrap()),
+                config: HashMap::from([("host".to_string(), name.to_string())]),
+                name: None,
+            }],
+            volumes: vec![],
+        },
+    }
+}
+
+async fn grow(
+    client: &reqwest::Client,
+    addr: std::net::SocketAddr,
+    host_header: &str,
+    mib: u64,
+) -> Result<GrowReport> {
+    let response = timeout(
+        Duration::from_secs(30),
+        client
+            .get(format!("http://{addr}/grow?mib={mib}"))
+            .header("HOST", host_header)
+            .send(),
+    )
+    .await
+    .context("grow request timed out")?
+    .context("grow request failed")?;
+    assert_eq!(
+        response.status().as_u16(),
+        200,
+        "a refusal must reach the guest as -1, never as a trap"
+    );
+
+    let body = response.text().await.context("failed to read grow body")?;
+    serde_json::from_str(&body).with_context(|| format!("unparseable grow reply: {body}"))
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+/// The upgrade-safety guarantee, end to end: a host that gains a budget it
+/// never asked for must serve exactly what it served before. Every guest gets
+/// everything it asks for, past the budget included — and the host still
+/// counts it, which is the number no host has today.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn count_mode_allows_growth_past_the_budget_and_still_accounts_for_it() -> Result<()> {
+    init_tracing();
+    let (addr, host, budget) = start_host(GuestMemoryMode::Count).await?;
+    let client = reqwest::Client::new();
+
+    for name in ["grow-a", "grow-b"] {
+        host.workload_start(grow_workload(name))
+            .await
+            .with_context(|| format!("failed to start {name}"))?;
+    }
+
+    for name in ["grow-a", "grow-b"] {
+        let report = grow(&client, addr, name, REQUEST_MIB).await?;
+        assert_eq!(
+            report,
+            GrowReport {
+                granted_mib: REQUEST_MIB,
+                refused: false
+            },
+            "{name} must get everything it asked for in count mode"
+        );
+    }
+
+    // Together the two are past a 48MiB budget, which is the whole point: the
+    // host has to *notice* aggregate creep it is not stopping.
+    assert!(
+        budget.high_water() >= 2 * REQUEST_MIB * MIB,
+        "the high-water mark must cover both guests: {}",
+        budget.high_water()
+    );
+    assert!(
+        budget.would_refuse() > 0,
+        "count mode must record what enforcement would have refused"
+    );
+    assert_eq!(budget.refused(), 0, "count mode refuses nothing");
+
+    Ok(())
+}
+
+/// Aggregate creep, caught: two workloads each well under `default_heap_memory`
+/// and each individually affordable, together past the host's budget. The
+/// second is cut off partway through — and it finds out by `memory.grow`
+/// returning -1, not by trapping.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn enforce_mode_refuses_the_growth_that_crosses_the_budget() -> Result<()> {
+    init_tracing();
+    let (addr, host, budget) = start_host(GuestMemoryMode::Enforce).await?;
+    let client = reqwest::Client::new();
+
+    for name in ["grow-a", "grow-b"] {
+        host.workload_start(grow_workload(name))
+            .await
+            .with_context(|| format!("failed to start {name}"))?;
+    }
+
+    let first = grow(&client, addr, "grow-a", REQUEST_MIB).await?;
+    assert_eq!(
+        first,
+        GrowReport {
+            granted_mib: REQUEST_MIB,
+            refused: false
+        },
+        "the first guest is comfortably inside the budget"
+    );
+
+    let second = grow(&client, addr, "grow-b", REQUEST_MIB).await?;
+    assert!(
+        second.refused,
+        "the second guest must be cut off at the budget, got {second:?}"
+    );
+    assert!(
+        second.granted_mib < REQUEST_MIB,
+        "it must be cut off partway, not merely fail: {second:?}"
+    );
+
+    assert!(budget.refused() > 0, "the budget must record the refusal");
+    assert_eq!(
+        budget.would_refuse(),
+        0,
+        "enforce mode refuses rather than counting"
+    );
+    assert!(
+        budget.in_use() <= budget.cap(),
+        "the budget must never admit past its cap: {} > {}",
+        budget.in_use(),
+        budget.cap()
+    );
+
+    Ok(())
+}
+
+/// The leak the release-on-drop path exists to prevent. A workload that has
+/// filled the budget and is then stopped must give every byte back — otherwise
+/// the budget ratchets down until the host refuses everything, which is a worse
+/// failure than the one it was built to prevent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_stopped_workload_returns_its_memory_to_the_budget() -> Result<()> {
+    init_tracing();
+    let (addr, host, budget) = start_host(GuestMemoryMode::Enforce).await?;
+    let client = reqwest::Client::new();
+
+    let hog = grow_workload("grow-hog");
+    let hog_id = hog.workload_id.clone();
+    host.workload_start(hog)
+        .await
+        .context("failed to start hog")?;
+    host.workload_start(grow_workload("grow-after"))
+        .await
+        .context("failed to start the second workload")?;
+
+    let filled = grow(&client, addr, "grow-hog", REQUEST_MIB).await?;
+    assert_eq!(filled.granted_mib, REQUEST_MIB);
+    // Captured rather than compared against a threshold: the hog holds its
+    // grown pages *plus* an instantiation baseline, so "below 32MiB" would be
+    // satisfied by returning 3MiB and leaking the rest.
+    let held = budget.in_use();
+    assert!(held >= REQUEST_MIB * MIB);
+
+    host.workload_stop(WorkloadStopRequest {
+        workload_id: hog_id,
+    })
+    .await
+    .context("failed to stop the hog")?;
+
+    // The stop tears the workload's stores down asynchronously; the bytes come
+    // back as each one drops.
+    let released = |budget: &GuestMemoryBudget| held.saturating_sub(budget.in_use());
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while released(&budget) < REQUEST_MIB * MIB && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        released(&budget) >= REQUEST_MIB * MIB,
+        "a stopped workload must return everything it grew: held {held}, now {}, released {}",
+        budget.in_use(),
+        released(&budget),
+    );
+
+    // And the returned bytes are genuinely spendable again, not merely
+    // uncounted: the next guest gets the full ask.
+    let after = grow(&client, addr, "grow-after", REQUEST_MIB).await?;
+    assert_eq!(
+        after,
+        GrowReport {
+            granted_mib: REQUEST_MIB,
+            refused: false
+        },
+        "the freed budget must be usable by the next workload"
+    );
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_guest_memory_metrics.rs
+++ b/crates/wash-runtime/tests/integration_guest_memory_metrics.rs
@@ -1,0 +1,155 @@
+//! The metrics contract for the guest memory budget.
+//!
+//! Two things nothing else covers.
+//!
+//! **That a real [`Engine`] publishes at all.** The unit tests in
+//! `engine::guest_memory` call `register_metrics` directly with a meter of
+//! their own, so they would still pass if `Engine::build` stopped registering
+//! the budget it just built. Only building an engine the way a host does
+//! catches that.
+//!
+//! **That the names, units and instrument kinds do not move.** These are a
+//! public interface: an operator's dashboard queries them by name and a panel
+//! divides `in_use` by `limit`. Renaming one, or turning a gauge into a
+//! counter, breaks every dashboard silently and at a distance — nothing in the
+//! runtime fails. So they are pinned here as a spec, and changing one should
+//! mean deliberately editing this list.
+//!
+//! # Why this is a file of its own
+//!
+//! It installs the *process-wide* meter provider, which is what `Engine::build`
+//! reads. Cargo gives each `tests/*.rs` its own binary and therefore its own
+//! process, so doing that here cannot disturb another test's metrics — but any
+//! test added to this file shares that provider, and will see this engine's
+//! instruments too.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+    data::{AggregatedMetrics, MetricData},
+};
+use wash_runtime::engine::{Engine, guest_memory::GuestMemoryMode, host_memory::HostMemoryBudgets};
+
+const MIB: u64 = 1024 * 1024;
+const BUDGET: u64 = 512 * MIB;
+
+/// One exported instrument, reduced to the parts a dashboard depends on.
+#[derive(Debug, PartialEq, Eq)]
+struct Exported {
+    kind: &'static str,
+    unit: String,
+    value: u64,
+}
+
+#[test]
+fn a_built_engine_publishes_its_guest_memory_budget() {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    // Before the engine is built: `Engine::build` resolves its meter from
+    // whatever the global provider is at that moment, so a provider installed
+    // afterwards would leave the instruments bound to the no-op one.
+    opentelemetry::global::set_meter_provider(provider.clone());
+
+    // Held, not dropped: the callbacks hold a weak reference to the budget, so
+    // an engine that went away before the flush would export nothing and this
+    // test would pass for the wrong reason.
+    let engine = Engine::builder()
+        .with_host_memory(HostMemoryBudgets::resolve(Some(BUDGET), None, None).unwrap())
+        .with_guest_memory_mode(GuestMemoryMode::Enforce)
+        .build()
+        .expect("engine builds");
+
+    provider.force_flush().expect("flush");
+    let exported = collect(&exporter);
+
+    let names: BTreeSet<&str> = exported.keys().map(String::as_str).collect();
+    assert_eq!(
+        names,
+        BTreeSet::from([
+            "guest_memory.high_water",
+            "guest_memory.in_use",
+            "guest_memory.limit",
+            "guest_memory.refused",
+            "guest_memory.would_refuse",
+        ]),
+        "the exported metric names are a dashboard's interface; changing this \
+         set means editing dashboards too"
+    );
+
+    // A fresh engine has run no guest, so every figure but the cap is zero —
+    // and the cap proves these are *this* engine's instruments rather than
+    // some default.
+    assert_eq!(
+        exported.get("guest_memory.limit"),
+        Some(&Exported {
+            kind: "gauge",
+            unit: "By".to_string(),
+            value: BUDGET,
+        }),
+    );
+    for name in ["guest_memory.in_use", "guest_memory.high_water"] {
+        assert_eq!(
+            exported.get(name),
+            Some(&Exported {
+                kind: "gauge",
+                unit: "By".to_string(),
+                value: 0,
+            }),
+            "{name} must be a byte gauge, at zero on a host that has run nothing"
+        );
+    }
+    for name in ["guest_memory.refused", "guest_memory.would_refuse"] {
+        assert_eq!(
+            exported.get(name),
+            Some(&Exported {
+                kind: "sum",
+                unit: "{growth}".to_string(),
+                value: 0,
+            }),
+            "{name} counts events and must be a monotonic sum, not a gauge"
+        );
+    }
+
+    drop(engine);
+}
+
+fn collect(exporter: &InMemoryMetricExporter) -> BTreeMap<String, Exported> {
+    let mut exported = BTreeMap::new();
+    for resource in exporter.get_finished_metrics().expect("finished metrics") {
+        for scope in resource.scope_metrics() {
+            for metric in scope.metrics() {
+                if !metric.name().starts_with("guest_memory.") {
+                    continue;
+                }
+                // An unexpected representation is recorded rather than
+                // rejected here, so it fails the assertions below naming the
+                // metric and what it turned into — a bare panic from inside
+                // the collector would say only that something was wrong.
+                let (kind, value) = match metric.data() {
+                    AggregatedMetrics::U64(MetricData::Gauge(gauge)) => {
+                        ("gauge", gauge.data_points().map(|p| p.value()).next())
+                    }
+                    AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                        ("sum", sum.data_points().map(|p| p.value()).next())
+                    }
+                    AggregatedMetrics::U64(_) => ("neither a gauge nor a sum", None),
+                    _ => ("not a u64 metric", None),
+                };
+                exported.insert(
+                    metric.name().to_string(),
+                    Exported {
+                        kind,
+                        unit: metric.unit().to_string(),
+                        value: value.unwrap_or_default(),
+                    },
+                );
+            }
+        }
+    }
+    exported
+}

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -209,15 +209,48 @@ pub struct HostCommand {
     /// where there is no cgroup, clamped to 256 MiB..1 TiB. An unset flag means
     /// the derived number, never "unbounded".
     ///
-    /// Nothing is gated on this yet — it is reported at startup and checked
-    /// against the two pool knobs below, so a host says whether the pool it is
-    /// about to build is one the machine could back.
+    /// What this bounds is the *total* of every guest's linear memory, which
+    /// no other knob does: `--default-heap-memory` bounds one memory and
+    /// `--core-instances` bounds a count of slots. Whether it is enforced or
+    /// only accounted is `--guest-memory-mode`, which counts by default.
     //
     // Deliberately no `default_value_t`: a parse-time default is
     // indistinguishable downstream from an operator typing the same number, and
     // the derivation has to tell them apart.
     #[arg(long = "max-guest-memory", env = "WASH_HOST_MAX_GUEST_MEMORY")]
     pub max_guest_memory: Option<String>,
+
+    /// How `--max-guest-memory` is applied.
+    ///
+    /// `count` (the default) charges every guest `memory.grow` to the budget
+    /// and records what it would have refused, but allows the growth anyway.
+    /// Guest memory was never bounded in aggregate and the budget is derived
+    /// when unset, so enforcing on upgrade would hand every host a ceiling
+    /// nobody chose; run in `count` first, watch the reported high-water mark
+    /// and `would_refuse` count, then switch to `enforce`.
+    ///
+    /// Under `enforce`, a growth past the budget makes the guest's
+    /// `memory.grow` return -1 — the same failure it already sees on hitting
+    /// `--default-heap-memory` — rather than trapping it.
+    ///
+    /// `enforce` makes `--max-guest-memory` a real ceiling, so it has to leave
+    /// the host room to be a host: wasmtime, compiled module images, NATS, OCI
+    /// pulls and HTTP buffers are not charged to this budget but do come out
+    /// of the same container limit. An unset budget already reserves a quarter
+    /// of the detected limit for them; a budget set to the whole container
+    /// limit can be OOM-killed before it ever refuses a guest.
+    //
+    // Parsed through `parse_guest_memory_mode` rather than plain `value_enum`
+    // so a blank value counts as unset, matching the sibling size knobs: a
+    // ConfigMap key or `value: ""` reaches clap as `Some("")`, and failing to
+    // parse that would refuse to start the host over a variable nobody set.
+    #[arg(
+        long = "guest-memory-mode",
+        env = "WASH_GUEST_MEMORY_MODE",
+        value_parser = parse_guest_memory_mode,
+        default_value = "count"
+    )]
+    pub guest_memory_mode: GuestMemoryMode,
 
     /// Ceiling on how large any single guest linear memory may grow
     /// (e.g. `512MiB`).
@@ -592,6 +625,7 @@ impl CliCommand for HostCommand {
         });
         engine_builder = engine_builder.with_socket_policy(Arc::clone(&socket_policy));
         engine_builder = engine_builder.with_host_memory(host_memory);
+        engine_builder = engine_builder.with_guest_memory_mode(self.guest_memory_mode.into());
 
         let engine = engine_builder.build()?;
 
@@ -1057,6 +1091,41 @@ impl From<NatsWorkloadConfig> for wash_runtime::plugin::wasmcloud_nats::Workload
         match mode {
             NatsWorkloadConfig::Deny => Self::Deny,
             NatsWorkloadConfig::Allow => Self::Allow,
+        }
+    }
+}
+
+/// CLI spelling of [`wash_runtime::engine::guest_memory::GuestMemoryMode`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum GuestMemoryMode {
+    /// Charge and report guest memory growth; allow it either way.
+    #[default]
+    Count,
+    /// Refuse guest memory growth past `--max-guest-memory`.
+    Enforce,
+}
+
+/// [`GuestMemoryMode`] from a flag or environment value, reading a blank one
+/// as unset.
+fn parse_guest_memory_mode(raw: &str) -> Result<GuestMemoryMode, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(GuestMemoryMode::default());
+    }
+    match raw.to_ascii_lowercase().as_str() {
+        "count" => Ok(GuestMemoryMode::Count),
+        "enforce" => Ok(GuestMemoryMode::Enforce),
+        _ => Err(format!(
+            "invalid guest-memory-mode {raw:?}; expected 'count' or 'enforce'"
+        )),
+    }
+}
+
+impl From<GuestMemoryMode> for wash_runtime::engine::guest_memory::GuestMemoryMode {
+    fn from(mode: GuestMemoryMode) -> Self {
+        match mode {
+            GuestMemoryMode::Count => Self::Count,
+            GuestMemoryMode::Enforce => Self::Enforce,
         }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,6 +108,7 @@ const P3_FIXTURES: &[&str] = &[
     "nats-implements-p3",
     "messaging-dual-handler",
     "http-handler-p3",
+    "http-memory-grow",
     "http-ip-name-lookup-p3",
     "http-blobstore-p3",
     "cli-service-p3",


### PR DESCRIPTION
We added a new knob `max_guest_memory` but we weren't enforcing it.

A `GuestMemoryBudget` is one counter of guest bytes for the whole host and every store carries a `StoreMemoryLimiter` installed through `Store::limiter`, which sees each `memory.grow` and may refuse it. A refusal reaches the guest as `memory.grow` returning -1. This is already what happens when the limit for `default_heap_memory` is hit.

`--guest-memory-mode` defaults to `count`: report but allow anyway. `max_guest_memory` is *derived* when unset rather than absent, so enforcing by default would give every host a new ceiling. 

Five OpenTelemetry observable instruments (`guest_memory.in_use`, `.high_water`, `.limit`, `.refused`, `.would_refuse`). 

- `--guest-memory-mode` / `WASH_GUEST_MEMORY_MODE`, plus `runtime.resources.guestMemoryMode` in the chart.
- `enforcement_advisory`: warns at startup when an enforced budget claims >90% of the limit that would actually OOM-kill the process.
- All seven `WASMTIME_POOLING_*` instance counts now go through `pooling_env_override`, so a zero is refused and an override is reported. Previously only two did, and `TOTAL_MEMORIES=0` silently sized part of the pool to nothing.

Locally measured this change where I saw 6.3ns per `memory.grow` uncontended, 14.8ns to install a limiter on a store,
265ns per growth with eight threads contending the counter.

This does not yet cover per-workload sub-budgets nor does it cover component plugin reservations.