### PR TITLE
Use component's name for wasmcloud:nats component scoping

### DIFF
--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
@@ -49,6 +49,10 @@ pub struct ComponentData {
     /// the next component of the same workload can tell whether it is about to
     /// pick up the same ones — see [`WasmcloudNats::on_workload_item_bind`].
     pub(super) untargeted_specs: Vec<String>,
+    /// The manifest's `components[].name`. The tracker keys components by the
+    /// runtime id, which is a fresh UUID per start, so the name is kept here to
+    /// name a component in an error the manifest's author can act on.
+    pub(super) name: String,
     pub(super) cancel_token: tokio_util::sync::CancellationToken,
 }
 /// `wasmcloud:nats` host plugin — NATS-native capabilities split by interface.
@@ -943,10 +947,14 @@ impl HostPlugin for WasmcloudNats {
                     .iter()
                     .find(|spec| other.untargeted_specs.contains(spec))
                 {
+                    // Both by manifest name, because that is what the advice
+                    // asks for: the ids here are per-start UUIDs, so naming
+                    // those would point at nothing the author can edit.
+                    let other_name = &other.name;
                     anyhow::bail!(
                         "workload `{workload_id}` declares {spec} without naming a component, so \
-                         it attaches to both `{other_id}` and `{component_id}` and every message \
-                         would be handled twice. Add `component: <name>` to each \
+                         it attaches to both `{other_name}` and `{component_name}` and every \
+                         message would be handled twice. Add `component: <name>` to each \
                          subscription-bearing wasmcloud:nats entry"
                     )
                 }
@@ -961,6 +969,7 @@ impl HostPlugin for WasmcloudNats {
                 core_subs,
                 kv_watches,
                 untargeted_specs,
+                name: component_name,
             },
         );
 

--- a/crates/wash-runtime/tests/integration_nats_plugin.rs
+++ b/crates/wash-runtime/tests/integration_nats_plugin.rs
@@ -228,6 +228,17 @@ fn workload_request_with_limits(
     }
 }
 
+/// The same request with a second component, so a subscription that names no
+/// component has two handlers to attach to. Both run the same guest — what
+/// matters is that the workload holds two components exporting the handler.
+fn two_component_request(workload_id: &str, interface: WitInterface) -> WorkloadStartRequest {
+    let mut request = workload_request(workload_id, interface);
+    let mut second = request.workload.components[0].clone();
+    second.name = "nats-handler-2".to_string();
+    request.workload.components.push(second);
+    request
+}
+
 async fn start_host() -> Result<impl HostApi> {
     // `allow`, the `wash dev` posture: these fixtures describe their own
     // bindings, which is what a project manifest does. The tests that declare
@@ -1825,6 +1836,39 @@ async fn an_ephemeral_component_starts_fresh_every_delivery() -> Result<()> {
         got,
         vec!["warm:a:1", "warm:b:1"],
         "an ephemeral component must never see a previous delivery's memory"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn an_unscoped_subscription_names_the_components_it_collided_between() -> Result<()> {
+    let h = start_nats().await?;
+    let host = start_host().await?;
+
+    // Both components export the core handler and the entry names neither, so
+    // the subscription attaches to both and every message would be handled
+    // twice. The refusal has to name them the way the manifest does: the
+    // runtime ids are a fresh UUID per workload start, so an author told to
+    // add `component: <name>` cannot act on an id.
+    let message = expect_refused(
+        &host,
+        two_component_request(
+            "wl-unscoped",
+            nats_async_interface(&[
+                ("servers", &h.nats_url),
+                ("subject-allow", "test.>"),
+                ("core-subscriptions", "test.orders"),
+            ]),
+        ),
+    )
+    .await?;
+
+    // Backtick-quoted, because `nats-handler-2` contains `nats-handler`: a
+    // bare substring check passes on the second name alone.
+    assert!(
+        message.contains("`nats-handler`") && message.contains("`nats-handler-2`"),
+        "expected the refusal to name both components, got {message}"
     );
     Ok(())
 }


### PR DESCRIPTION
**Holding off till host plugin config is merged**

- uses the components name for scoping instead of id, since the id is generated by the operator (and is a UUID)

This is needed since you don't know the ID to define what the contract in the config.

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
