### PR TITLE
Run NATS core and KV NATS deliveries on the instance pool

### DIFF
--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -43,6 +43,8 @@
 //! with it, so every call in flight on that instance fails rather than just
 //! one. That is bounded by `max_concurrency`, and by `1/pool_size` of the pool.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -79,6 +81,101 @@ pub(crate) enum InstanceJob {
     Http(Box<ServiceHttpJob>),
     /// A call from another component in the workload.
     Linked(Box<LinkedJob>),
+    /// A call a host plugin supplies, made on a pooled instance.
+    ///
+    /// The engine routes it like any other job and never looks inside: the
+    /// plugin keeps its own payload and makes its own typed call. That is what
+    /// lets a delivery carry, say, a NATS message's bytes rather than the one
+    /// 48-byte [`Val`] per byte a store-independent lowering would cost.
+    Plugin(Box<dyn PluginJob>),
+}
+
+/// A call a plugin hands to the pool, run on whichever instance is free.
+///
+/// Implemented by the plugin so the engine needs none of its types. The
+/// plugin's own bindgen call takes an [`Accessor`] rather than a `&mut Store`,
+/// so it runs inside the driver's long-lived `run_concurrent` exactly as a
+/// linked call does — several at a time on one instance, up to
+/// `max_concurrency`.
+pub(crate) trait PluginJob: Send + 'static {
+    /// Names this job in a driver log line.
+    fn describe(&self) -> &str;
+
+    /// Runs the call. Owns replying to whoever is waiting for it, and may
+    /// retire the instance through `slot` when it ends leaving guest state
+    /// indeterminate — the same contract [`LinkedTask`] follows.
+    fn run<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: Instance,
+        slot: Option<PoolSlot>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
+/// Measures the guest execution one pooled call adds, and records it when
+/// dropped.
+///
+/// Every pooled call is metered, not just the ones a plugin remembered to wrap:
+/// `guest.execution.time` is the only signal an operator has for what a warm
+/// instance is spending, and a histogram whose population depends on which
+/// call site opted in cannot be read as a distribution.
+///
+/// Recording on drop is what makes it cover a call that ends by trapping or
+/// timing out — the two an operator most wants in the histogram, and the two an
+/// early return would otherwise skip.
+///
+/// Started once the export has resolved, not before: a call that never reached
+/// guest code has no execution to report, and recording it anyway would put a
+/// 0ms observation in the same bucket as a genuinely fast call.
+///
+/// A plugin serving a call from a store of its own — because the component
+/// declared no pool, or because every instance was busy — starts one of these
+/// too, so a component's measurements do not depend on whether it opted into
+/// pooling.
+pub(crate) struct ExecutionSample {
+    executed: Arc<crate::engine::abandon::GuestExecution>,
+    before: u64,
+    attributes: Vec<opentelemetry::KeyValue>,
+}
+
+impl ExecutionSample {
+    pub(crate) fn start(
+        accessor: &Accessor<SharedCtx>,
+        attributes: Vec<opentelemetry::KeyValue>,
+    ) -> Self {
+        let executed = accessor.with(|mut access| Arc::clone(&access.get().executed));
+        let before = executed.millis();
+        Self {
+            executed,
+            before,
+            attributes,
+        }
+    }
+}
+
+impl Drop for ExecutionSample {
+    fn drop(&mut self) {
+        if let Some(meter) = crate::observability::execution_time_meter() {
+            meter.record(
+                &self.attributes,
+                self.executed.millis().saturating_sub(self.before),
+            );
+        }
+    }
+}
+
+/// Drives one [`PluginJob`] as an ordinary pooled task.
+struct PluginTask {
+    instance: Instance,
+    job: Box<dyn PluginJob>,
+    slot: PoolSlot,
+}
+
+impl AccessorTask<SharedCtx> for PluginTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        self.job.run(accessor, self.instance, Some(self.slot)).await;
+        Ok(())
+    }
 }
 
 /// What an instance's driver handle and the calls running on it share: how many
@@ -164,7 +261,6 @@ impl AccessorTask<SharedCtx> for LinkedTask {
             crate::engine::abandon::rearm_for_call(&mut access);
             Arc::clone(&access.get().abandoned)
         });
-
         let func = accessor.with(|mut access| {
             instance
                 .get_func(&mut access, func_idx)
@@ -338,6 +434,14 @@ impl InstanceDriver {
                                 })
                             }
                             InstanceJob::Linked(job) => accessor.spawn(LinkedTask {
+                                instance,
+                                job,
+                                slot: PoolSlot {
+                                    state: Arc::clone(&task_state),
+                                    _in_flight: guard,
+                                },
+                            }),
+                            InstanceJob::Plugin(job) => accessor.spawn(PluginTask {
                                 instance,
                                 job,
                                 slot: PoolSlot {

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -2011,9 +2011,16 @@ async fn invoke_component_handler(
                 Err(InstanceJob::Http(job)) => job.req,
                 // A job comes back as the variant it went in as, so this is
                 // unreachable — but not worth a panic on a request path.
-                Err(InstanceJob::Linked(_)) => {
-                    debug_assert!(false, "an HTTP job cannot come back as a linked one");
-                    anyhow::bail!("instance pool returned a linked job for an HTTP request");
+                Err(other) => {
+                    debug_assert!(false, "an HTTP job cannot come back as another kind");
+                    anyhow::bail!(
+                        "instance pool returned a {} job for an HTTP request",
+                        match other {
+                            InstanceJob::Linked(_) => "linked",
+                            InstanceJob::Plugin(_) => "plugin",
+                            InstanceJob::Http(_) => "http",
+                        }
+                    );
                 }
             }
         } else {

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -161,13 +161,41 @@ pub struct Meters {
     pub meters: HashMap<String, Arc<dyn Any + Send + Sync + 'static>>,
 }
 
+/// The execution-time histogram, reachable without a `Meters` in hand.
+///
+/// A pooled call runs inside the driver's `run_concurrent`, several layers
+/// below anything holding a `Meters`, and carrying one down to every driver
+/// would thread a metric through the engine's whole dispatch path. The
+/// histogram is a handle rather than host state — OTel's own meter registry is
+/// process-global for the same reason — so it is published here once and read
+/// where a call actually ends.
+static EXECUTION_TIME: std::sync::OnceLock<ExecutionTimeMeter> = std::sync::OnceLock::new();
+
+/// The execution-time meter, once a host has built its [`Meters`].
+///
+/// `None` before that, and on a host that did not enable metering the meter
+/// itself is inert, so a caller never has to ask which.
+pub fn execution_time_meter() -> Option<&'static ExecutionTimeMeter> {
+    EXECUTION_TIME.get()
+}
+
 impl Meters {
     pub fn new(enabled: bool) -> Self {
-        Self {
+        let meters = Self {
             fuel_consumption: FuelConsumptionMeter::new(enabled),
             execution_time: ExecutionTimeMeter::new(enabled),
             meters: Default::default(),
+        };
+        // First host with metering on wins. A second one in the same process
+        // (tests, an embedder running two) records into the first's histogram,
+        // which is the same instrument OTel would have handed it anyway.
+        // Skipping the disabled ones matters: a host built with metering off
+        // would otherwise claim the slot and silence every pooled call after
+        // it, including calls on a later host that did ask for metrics.
+        if enabled {
+            let _ = EXECUTION_TIME.set(meters.execution_time.clone());
         }
+        meters
     }
 }
 
@@ -247,6 +275,22 @@ impl ExecutionTimeMeter {
                 .build()
         });
         Self { hist }
+    }
+
+    /// Records the guest execution one call added, measured by the caller.
+    ///
+    /// The store-taking [`Self::observe`] cannot be used from inside a pooled
+    /// call: the driver owns the store for the instance's whole life and calls
+    /// arrive as tasks on it, so nobody down there has a `&mut Store`. Read
+    /// `SharedCtx::executed` through the accessor either side of the call and
+    /// hand the delta here instead. Same counter, same caveats — read
+    /// [`crate::engine::abandon::GuestExecution`] before reading the number,
+    /// and note that on an instance serving several calls at once the delta
+    /// includes its neighbours'.
+    pub fn record(&self, attributes: &[KeyValue], millis: u64) {
+        if let Some(hist) = &self.hist {
+            hist.record(millis, attributes);
+        }
     }
 
     pub async fn observe<F, R>(

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
@@ -546,11 +546,9 @@ impl WasmcloudNats {
                 handle.clone(),
                 core_subs,
                 cancel_token.clone(),
-                execution_meter.clone(),
                 failure_sink.clone(),
                 workload_id,
                 self.host_backlog.clone(),
-                warm_sets.clone(),
             )
             .await?;
         }
@@ -561,10 +559,8 @@ impl WasmcloudNats {
                 handle,
                 kv_watches,
                 cancel_token,
-                execution_meter,
                 failure_sink,
                 workload_id,
-                warm_sets,
             )
             .await?;
         }

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -10,13 +10,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use anyhow::Context as _;
 use async_nats::jetstream;
 use futures::StreamExt;
-use opentelemetry::KeyValue;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, warn};
 
+use crate::engine::instance_driver::InstanceJob;
+use crate::engine::instance_pool::{ComponentInstance, Dispatch};
 use crate::engine::workload::ResolvedWorkload;
 use crate::observability::ExecutionTimeMeter;
-use crate::wasmtime::component::Resource;
+use crate::wasmtime::component::{Accessor, InstancePre, Resource};
+use opentelemetry::KeyValue;
 
 use super::config::{AckMode, CoreSubscriptionConfig, JetStreamSubscriptionConfig, KvWatchConfig};
 use super::conn::ConnHandle;
@@ -69,18 +71,6 @@ handler_pre!(
     jetstream_bindings::JsProcessorPre<SharedCtx>,
     jetstream_bindings::JsProcessor
 );
-handler_pre!(
-    CoreHandlerPre,
-    CoreProxy,
-    core_bindings::SubscriberPre<SharedCtx>,
-    core_bindings::Subscriber
-);
-handler_pre!(
-    KvHandlerPre,
-    KvProxy,
-    kv_bindings::KvWatcherPre<SharedCtx>,
-    kv_bindings::KvWatcher
-);
 
 impl JsProxy {
     async fn call(
@@ -99,54 +89,361 @@ impl JsProxy {
     }
 }
 
-impl CoreProxy {
-    async fn call(
-        &self,
-        store: &mut crate::wasmtime::Store<SharedCtx>,
-        raw: &async_nats::Message,
-    ) -> wasmtime::Result<Result<(), String>> {
-        let msg = core_bindings::wasmcloud::nats::types::NatsMessage {
-            subject: raw.subject.to_string(),
-            reply_to: raw.reply.as_ref().map(|r| r.to_string()),
-            body: raw.payload.to_vec(),
-            headers: raw.headers.as_ref().map(nats_headers_to_core_wit),
-        };
-        let p = &self.0;
-        store
-            .run_concurrent(async move |accessor| {
-                p.wasmcloud_nats_core_handler()
-                    .call_handle_message(accessor, msg)
-                    .await
-            })
-            .await?
+fn nats_headers_to_core_wit(
+    headers: &async_nats::HeaderMap,
+) -> Vec<core_bindings::wasmcloud::nats::types::HeaderEntry> {
+    let mut out = Vec::new();
+    for (name, values) in headers.iter() {
+        for value in values {
+            out.push(core_bindings::wasmcloud::nats::types::HeaderEntry {
+                name: name.to_string(),
+                value: value.as_str().to_string(),
+            });
+        }
+    }
+    out
+}
+
+fn kv_entry_to_kv_handler_wit(e: &jetstream::kv::Entry) -> kv_bindings::wasmcloud::nats::kv::Entry {
+    let operation = match e.operation {
+        jetstream::kv::Operation::Put => kv_bindings::wasmcloud::nats::kv::KvOperation::Put,
+        jetstream::kv::Operation::Delete => kv_bindings::wasmcloud::nats::kv::KvOperation::Delete,
+        jetstream::kv::Operation::Purge => kv_bindings::wasmcloud::nats::kv::KvOperation::Purge,
+    };
+
+    kv_bindings::wasmcloud::nats::kv::Entry {
+        key: e.key.clone(),
+        value: e.value.to_vec(),
+        revision: e.revision,
+        created_at_unix_nanos: e.created.unix_timestamp_nanos().max(0) as u64,
+        operation,
     }
 }
 
-impl KvProxy {
-    async fn call(
-        &self,
-        store: &mut crate::wasmtime::Store<SharedCtx>,
-        bucket: &str,
-        entry: &jetstream::kv::Entry,
-    ) -> wasmtime::Result<Result<(), String>> {
-        let (bucket, entry) = (bucket.to_string(), kv_entry_to_kv_handler_wit(entry));
-        let p = &self.0;
-        store
-            .run_concurrent(async move |accessor| {
-                p.wasmcloud_nats_kv_handler()
-                    .call_handle_event(accessor, bucket, entry)
-                    .await
-            })
-            .await?
+/// What a core or KV delivery needs to reach its handler, resolved once per
+/// subscription rather than once per message.
+#[derive(Clone)]
+struct HandlerTarget {
+    component_id: Arc<str>,
+    pre: InstancePre<SharedCtx>,
+}
+
+/// The outcome channel every delivery job replies on: the handler's own
+/// `result<_, string>`, or a host failure that kept it from being reached.
+type DeliveryReply = tokio::sync::oneshot::Sender<anyhow::Result<Result<(), String>>>;
+
+/// Re-arms this call's epoch deadline and hands back the store's abandon set,
+/// the way [`LinkedTask`] does — a pooled store is reused, so the countdown has
+/// to measure this call rather than the instance's whole life.
+fn call_guard(accessor: &Accessor<SharedCtx>) -> Arc<crate::engine::abandon::AbandonedCalls> {
+    accessor.with(|mut access| {
+        crate::engine::abandon::rearm_for_call(&mut access);
+        Arc::clone(&access.get().abandoned)
+    })
+}
+
+/// How each delivery flavour names itself in a driver log line.
+const CORE_OPERATION: &str = "wasmcloud:nats/core-handler#handle-message";
+const KV_OPERATION: &str = "wasmcloud:nats/kv-handler#handle-event";
+
+/// One core NATS delivery, run on whichever instance the pool picks.
+///
+/// The payload stays a `Vec<u8>` inside the generated `NatsMessage`. Lowering
+/// it to a store-independent `Val` instead would cost one 48-byte `Val` per
+/// byte, which on the payload sizes core NATS carries is the memory blow-up
+/// `subscription-capacity-bytes` exists to prevent.
+struct CoreDeliveryJob {
+    msg: core_bindings::wasmcloud::nats::types::NatsMessage,
+    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+    reply: DeliveryReply,
+    attributes: Vec<opentelemetry::KeyValue>,
+}
+
+impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
+    fn describe(&self) -> &str {
+        CORE_OPERATION
     }
+
+    fn run<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: crate::wasmtime::component::Instance,
+        slot: Option<crate::engine::instance_driver::PoolSlot>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let Self {
+                msg,
+                abandoned,
+                reply,
+                attributes,
+            } = *self;
+            let calls = call_guard(accessor);
+            let proxy = accessor.with(|mut access| {
+                core_bindings::Subscriber::new(&mut access, &instance).map_err(|e| {
+                    anyhow::anyhow!(
+                        "pooled instance does not export wasmcloud:nats/core-handler: {e:#}"
+                    )
+                })
+            });
+            let proxy = match proxy {
+                Ok(p) => p,
+                Err(e) => {
+                    let _ = reply.send(Err(e));
+                    return;
+                }
+            };
+            // Bounds this task, which the dispatcher's own deadline cannot: a
+            // guest subtask is not cancellable from the host, so a delivery
+            // that never returns would hold its in-flight slot for the life of
+            // the workload. Retiring is what ends it — the driver stops
+            // admitting, drains, and the store's teardown takes the stalled
+            // work with it. The same contract [`LinkedTask`] follows.
+            let _sample =
+                crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
+            let outcome = tokio::time::timeout(
+                crate::timeouts::ephemeral_call(),
+                crate::engine::abandon::watch_until_abandoned(
+                    &calls,
+                    abandoned,
+                    proxy
+                        .wasmcloud_nats_core_handler()
+                        .call_handle_message(accessor, msg),
+                ),
+            )
+            .await;
+            let _ = reply.send(match outcome {
+                Ok(Ok(inner)) => Ok(inner),
+                // A host failure mid-call leaves guest state indeterminate.
+                Ok(Err(e)) => {
+                    if let Some(slot) = slot {
+                        slot.retire_instance();
+                    }
+                    Err(anyhow::anyhow!("{e:#}"))
+                }
+                Err(e) => {
+                    if let Some(slot) = slot {
+                        slot.retire_instance();
+                    }
+                    Err(anyhow::anyhow!("delivery timed out: {e}"))
+                }
+            });
+        })
+    }
+}
+
+/// One KV watch event. Same shape and the same reason as [`CoreDeliveryJob`]:
+/// a KV value is bytes too.
+struct KvDeliveryJob {
+    bucket: String,
+    entry: kv_bindings::wasmcloud::nats::kv::Entry,
+    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+    reply: DeliveryReply,
+    attributes: Vec<opentelemetry::KeyValue>,
+}
+
+impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
+    fn describe(&self) -> &str {
+        KV_OPERATION
+    }
+
+    fn run<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: crate::wasmtime::component::Instance,
+        slot: Option<crate::engine::instance_driver::PoolSlot>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let Self {
+                bucket,
+                entry,
+                abandoned,
+                reply,
+                attributes,
+            } = *self;
+            let calls = call_guard(accessor);
+            let proxy = accessor.with(|mut access| {
+                kv_bindings::KvWatcher::new(&mut access, &instance).map_err(|e| {
+                    anyhow::anyhow!(
+                        "pooled instance does not export wasmcloud:nats/kv-handler: {e:#}"
+                    )
+                })
+            });
+            let proxy = match proxy {
+                Ok(p) => p,
+                Err(e) => {
+                    let _ = reply.send(Err(e));
+                    return;
+                }
+            };
+            // Bounds this task, which the dispatcher's own deadline cannot: a
+            // guest subtask is not cancellable from the host, so a delivery
+            // that never returns would hold its in-flight slot for the life of
+            // the workload. Retiring is what ends it — the driver stops
+            // admitting, drains, and the store's teardown takes the stalled
+            // work with it. The same contract [`LinkedTask`] follows.
+            let _sample =
+                crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
+            let outcome = tokio::time::timeout(
+                crate::timeouts::ephemeral_call(),
+                crate::engine::abandon::watch_until_abandoned(
+                    &calls,
+                    abandoned,
+                    proxy
+                        .wasmcloud_nats_kv_handler()
+                        .call_handle_event(accessor, bucket, entry),
+                ),
+            )
+            .await;
+            let _ = reply.send(match outcome {
+                Ok(Ok(inner)) => Ok(inner),
+                // A host failure mid-call leaves guest state indeterminate.
+                Ok(Err(e)) => {
+                    if let Some(slot) = slot {
+                        slot.retire_instance();
+                    }
+                    Err(anyhow::anyhow!("{e:#}"))
+                }
+                Err(e) => {
+                    if let Some(slot) = slot {
+                        slot.retire_instance();
+                    }
+                    Err(anyhow::anyhow!("delivery timed out: {e}"))
+                }
+            });
+        })
+    }
+}
+
+/// Builds a store and instantiates the handler into it, giving up if the
+/// workload is torn down first.
+///
+/// `Ok(None)` means cancelled: the delivery is abandoned, which is not a
+/// failure worth logging — the subscription it arrived on is going away too.
+async fn build_instance(
+    workload: &ResolvedWorkload,
+    target: &HandlerTarget,
+    component_id: &str,
+    cancel_token: &CancellationToken,
+) -> anyhow::Result<
+    Option<(
+        crate::wasmtime::Store<SharedCtx>,
+        crate::wasmtime::component::Instance,
+    )>,
+> {
+    let mut store = tokio::select! {
+        created = workload.new_store(component_id) => created?,
+        _ = cancel_token.cancelled() => return Ok(None),
+    };
+    waive_fuel_limit(&mut store);
+    let instance = tokio::select! {
+        instantiated = target.pre.instantiate_async(&mut store) => {
+            instantiated.map_err(|e| anyhow::anyhow!("{e:#}"))?
+        }
+        _ = cancel_token.cancelled() => return Ok(None),
+    };
+    Ok(Some((store, instance)))
+}
+
+/// Runs one delivery: through the workload's instance pool when the component
+/// opted into pooling, and in a store of its own otherwise.
+///
+/// The job crosses as [`InstanceJob::Plugin`], so a core or KV delivery takes
+/// the same path as inbound HTTP and linked calls and honours the same
+/// `poolSize`, `maxInvocations` and `maxConcurrency` the component declared —
+/// including several deliveries in flight on one instance, which the plugin's
+/// own warm set can never do because its call holds the store for the length
+/// of the call.
+///
+/// The same job runs either way: a delivery the pool declines is not rebuilt,
+/// it is handed back and run in a fresh store, so a large payload is never
+/// copied to pay for the attempt.
+///
+/// JetStream stays on the warm set. Its call carries a `message-handle`
+/// resource — an index into one store's table — so its argument cannot exist
+/// before the store is chosen, and a job the pool hands back would already
+/// hold an index into a table it no longer belongs to.
+///
+/// `cancel_token` ends the delivery at the two awaits that can block on a
+/// workload being torn down: building a store and instantiating into it is work
+/// nobody will see the result of, and an instance built for the pool could
+/// otherwise be installed after the pool was cleared.
+async fn run_delivery(
+    workload: &ResolvedWorkload,
+    target: &HandlerTarget,
+    job: Box<dyn crate::engine::instance_driver::PluginJob>,
+    reply_rx: tokio::sync::oneshot::Receiver<anyhow::Result<Result<(), String>>>,
+    call: crate::engine::abandon::DispatchedCall,
+    cancel_token: &CancellationToken,
+) -> anyhow::Result<Result<(), String>> {
+    let component_id = target.component_id.as_ref();
+    let mut job = job;
+
+    if let Some(pool) = workload.instance_pool_for_component(component_id).await {
+        let outcome = match pool.offer(InstanceJob::Plugin(job)) {
+            Dispatch::Sent => Ok(()),
+            // Built out here, where awaiting is allowed and where a component
+            // that fails to instantiate reports it to this delivery rather
+            // than only to the log.
+            Dispatch::NeedsInstance(pending) => {
+                let Some((store, instance)) =
+                    build_instance(workload, target, component_id, cancel_token).await?
+                else {
+                    return Ok(Ok(()));
+                };
+                pool.install(ComponentInstance { store, instance }, pending)
+            }
+            Dispatch::Saturated(pending) => Err(pending),
+        };
+        match outcome {
+            Ok(()) => {
+                return call
+                    .await_reply(reply_rx)
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("pooled instance produced no reply in time"))?
+                    .map_err(|_| anyhow::anyhow!("pooled instance dropped the delivery"))?;
+            }
+            // Every instance was busy and the pool is full, so run the very
+            // same job in a store of its own.
+            Err(declined) => {
+                let InstanceJob::Plugin(returned) = declined else {
+                    return Err(anyhow::anyhow!("pool returned the wrong job kind"));
+                };
+                debug!(
+                    job = returned.describe(),
+                    "warm instances saturated; own store"
+                );
+                job = returned;
+            }
+        }
+    }
+
+    let Some((mut store, instance)) =
+        build_instance(workload, target, component_id, cancel_token).await?
+    else {
+        return Ok(Ok(()));
+    };
+    // Awaited through the same `DispatchedCall` the pooled path uses:
+    // `arm_after` runs inside `await_reply`, so a cold delivery that skipped it
+    // would be unbounded while looking bounded. Giving up here drops the
+    // future, and with it the store, which is what ends the guest's work.
+    call.await_reply(store.run_concurrent(async move |accessor| {
+        // No pool slot: nothing to retire, the store goes when this ends.
+        job.run(accessor, instance, None).await;
+    }))
+    .await
+    .ok_or_else(|| anyhow::anyhow!("delivery produced no reply in time"))?
+    .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    reply_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("delivery task dropped the reply"))?
 }
 
 /// The warm sets a component's handlers serve their deliveries from, built from
 /// the instance policy the component declared.
 ///
 /// The same `poolSize` / `maxInvocations` knobs that feed the engine's
-/// [`InstanceJob`] pool, honoured here because a NATS delivery cannot take
-/// that path — its call carries a typed resource that must live in the very
+/// [`InstanceJob`] pool, honoured here because a *JetStream* delivery cannot
+/// take that path — its call carries a typed resource that must live in the very
 /// store that runs it, and its ack ownership lives in the subscription loop.
 /// See [`super::warm`] for what is and is not honoured.
 ///
@@ -159,8 +456,6 @@ impl KvProxy {
 /// [`InstanceJob`]: crate::engine::instance_driver::InstanceJob
 pub(super) struct WarmSets {
     jetstream: Arc<super::warm::WarmSet<(crate::wasmtime::Store<SharedCtx>, JsProxy)>>,
-    core: Arc<super::warm::WarmSet<(crate::wasmtime::Store<SharedCtx>, CoreProxy)>>,
-    kv: Arc<super::warm::WarmSet<(crate::wasmtime::Store<SharedCtx>, KvProxy)>>,
 }
 
 impl WarmSets {
@@ -171,16 +466,15 @@ impl WarmSets {
         let policy = workload.warm_instance_policy(component_id).await;
         let sets = Self {
             jetstream: Arc::new(super::warm::WarmSet::new(policy)),
-            core: Arc::new(super::warm::WarmSet::new(policy)),
-            kv: Arc::new(super::warm::WarmSet::new(policy)),
         };
         if sets.jetstream.keeps_instances() {
             debug!(
                 component_id,
                 ?policy,
-                "wasmcloud:nats deliveries will reuse warm instances; note that \
-                 `maxConcurrency` above 1 is served by additional one-shot stores on this \
-                 path rather than by concurrent calls on one instance"
+                "wasmcloud:nats JetStream deliveries will reuse warm instances; note \
+                 that on this path `maxConcurrency` above 1 is served by additional \
+                 one-shot stores rather than by concurrent calls on one instance. Core \
+                 and KV deliveries go through the engine's pool and do honour it."
             );
         }
         Arc::new(sets)
@@ -430,37 +724,6 @@ fn short_hash(parts: &[&str]) -> String {
         hash = hash.wrapping_mul(PRIME);
     }
     format!("{hash:016x}")[..12].to_string()
-}
-
-fn nats_headers_to_core_wit(
-    headers: &async_nats::HeaderMap,
-) -> Vec<core_bindings::wasmcloud::nats::types::HeaderEntry> {
-    let mut out = Vec::new();
-    for (name, values) in headers.iter() {
-        for value in values {
-            out.push(core_bindings::wasmcloud::nats::types::HeaderEntry {
-                name: name.to_string(),
-                value: value.as_str().to_string(),
-            });
-        }
-    }
-    out
-}
-
-fn kv_entry_to_kv_handler_wit(e: &jetstream::kv::Entry) -> kv_bindings::wasmcloud::nats::kv::Entry {
-    let operation = match e.operation {
-        jetstream::kv::Operation::Put => kv_bindings::wasmcloud::nats::kv::KvOperation::Put,
-        jetstream::kv::Operation::Delete => kv_bindings::wasmcloud::nats::kv::KvOperation::Delete,
-        jetstream::kv::Operation::Purge => kv_bindings::wasmcloud::nats::kv::KvOperation::Purge,
-    };
-
-    kv_bindings::wasmcloud::nats::kv::Entry {
-        key: e.key.clone(),
-        value: e.value.to_vec(),
-        revision: e.revision,
-        created_at_unix_nanos: e.created.unix_timestamp_nanos().max(0) as u64,
-        operation,
-    }
 }
 
 /// Spawn a JetStream push subscription per entry. Each consumer uses explicit
@@ -1730,7 +1993,6 @@ pub(super) async fn spawn_core_subscriptions(
     conn: Arc<ConnHandle>,
     subs: Vec<CoreSubscriptionConfig>,
     cancel_token: CancellationToken,
-    execution_meter: ExecutionTimeMeter,
     failure_sink: Option<crate::plugin::WorkloadFailureSink>,
     workload_id: impl Into<String>,
     // The host-wide ceiling every core subscription on this host shares. The
@@ -1738,25 +2000,23 @@ pub(super) async fn spawn_core_subscriptions(
     // is the second one, and the only one that knows about the other
     // workloads. See `HostBacklogBudget`.
     host_budget: Arc<HostBacklogBudget>,
-    warm_sets: Arc<WarmSets>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
-    let pre = CoreHandlerPre::new(instance_pre)?;
-    let warm_set = warm_sets.core.clone();
+    let target = HandlerTarget {
+        component_id: Arc::from(component_id),
+        pre: instance_pre,
+    };
     let workload_id = workload_id.into();
 
     for sub in subs {
         let conn = conn.clone();
         let in_flight = Arc::new(tokio::sync::Semaphore::new(conn.limits.max_in_flight));
         let workload = workload.clone();
-        let component_id = component_id.to_string();
-        let pre = pre.clone();
+        let target = target.clone();
         let cancel_token = cancel_token.clone();
-        let execution_meter = execution_meter.clone();
         let failure_sink = failure_sink.clone();
         let workload_id = workload_id.clone();
         let host_budget = host_budget.clone();
-        let warm_set = warm_set.clone();
 
         // Subscribed *here*, not inside the task below. The bind hook awaits
         // this function, and the workload is reported ready once it returns,
@@ -1832,75 +2092,54 @@ pub(super) async fn spawn_core_subscriptions(
                         // the host-wide total too.
                         backlog.dequeue(raw.length);
 
-                        // Warm when the component opted in, cold otherwise —
-                        // see the JetStream loop for the shape.
-                        let mut warmed = match warm_set.checkout() {
-                            Some(mut warmed) => {
-                                crate::engine::abandon::rearm_for_call(&mut warmed.handler.0);
-                                warmed
-                            }
-                            None => {
-                                let mut store = tokio::select! {
-                                    created = workload.new_store(&component_id) => match created {
-                                        Err(e) => {
-                                            warn!("failed to create store for {component_id}: {e}");
-                                            continue;
-                                        }
-                                        Ok(s) => s,
-                                    },
-                                    // Instantiating into a workload that is being torn
-                                    // down is work nobody will see the result of.
-                                    _ = cancel_token.cancelled() => break,
-                                };
-                                let proxy = tokio::select! {
-                                    instantiated = pre.instantiate(&mut store) => match instantiated {
-                                        Err(e) => {
-                                            warn!("failed to instantiate {component_id}: {e}");
-                                            continue;
-                                        }
-                                        Ok(p) => p,
-                                    },
-                                    _ = cancel_token.cancelled() => break,
-                                };
-                                super::warm::Warmed::fresh((store, proxy))
-                            }
-                        };
-                        waive_fuel_limit(&mut warmed.handler.0);
-
-                        let subject_label = raw.subject.to_string();
-                        let span = tracing::span!(
-                            tracing::Level::INFO,
-                            "incoming_nats_core_message",
-                            subject = %subject_label,
-                        );
-
                         // A responder answers on the inbox the requester chose,
                         // which no sane grant covers. This is what authorizes
                         // that one reply, for this inbox only.
                         if let Some(reply) = raw.reply.as_deref() {
                             conn.grant_reply(reply);
                         }
-                        let execution_meter = execution_meter.clone();
-                        let warm_set = warm_set.clone();
-                        tokio::spawn(async move {
-                            let _permit = permit;
-                            let (store, proxy) = (&mut warmed.handler.0, &warmed.handler.1);
-                            let result = execution_meter.observe(
-                                &[
+
+                        let subject_label = raw.subject.to_string();
+                        let msg = core_bindings::wasmcloud::nats::types::NatsMessage {
+                            subject: subject_label.clone(),
+                            reply_to: raw.reply.as_ref().map(|r| r.to_string()),
+                            body: raw.payload.to_vec(),
+                            headers: raw.headers.as_ref().map(nats_headers_to_core_wit),
+                        };
+                        let (reply, reply_rx) = tokio::sync::oneshot::channel();
+                        // Enforced out here, outside the store the guest runs
+                        // in, so a guest that never yields cannot hold off its
+                        // own deadline.
+                        let call = crate::engine::abandon::DispatchedCall::new(
+                            "wasmcloud:nats core delivery",
+                            crate::timeouts::ephemeral_call(),
+                        );
+                        let job: Box<dyn crate::engine::instance_driver::PluginJob> =
+                            Box::new(CoreDeliveryJob {
+                                msg,
+                                abandoned: call.flag(),
+                                reply,
+                                attributes: vec![
                                     KeyValue::new("plugin", PLUGIN_NATS_ID),
                                     KeyValue::new("subject", subject_label.clone()),
                                 ],
-                                store,
-                                async move |store| {
-                                    proxy
-                                        .call(store, &raw)
-                                        .instrument(span)
-                                        .await
-                                        .map_err(Into::into)
-                                },
-                            ).await;
+                            });
+                        let span = tracing::span!(
+                            tracing::Level::INFO,
+                            "incoming_nats_core_message",
+                            subject = %subject_label,
+                        );
+                        let workload = workload.clone();
+                        let target = target.clone();
+                        let delivery_cancel = cancel_token.clone();
+                        tokio::spawn(async move {
+                            let _permit = permit;
+                            let result = run_delivery(&workload, &target, job, reply_rx, call, &delivery_cancel)
+                                .instrument(span)
+                                .await;
                             // The handler's own error is the useful one; the
-                            // outer result only carries traps.
+                            // outer result carries traps and the host failures
+                            // that kept the delivery from reaching the guest.
                             match &result {
                                 Ok(Err(handler_err)) => warn!(
                                     subject = %subject_label,
@@ -1908,15 +2147,9 @@ pub(super) async fn spawn_core_subscriptions(
                                 ),
                                 Err(e) => warn!(
                                     subject = %subject_label,
-                                    "core handler trapped: {e}"
+                                    "core delivery failed: {e:#}"
                                 ),
                                 Ok(Ok(())) => {}
-                            }
-                            // A trap poisons the store; anything else may
-                            // serve the next delivery warm.
-                            match &result {
-                                Err(_) => drop(warmed),
-                                Ok(_) => warm_set.park(warmed),
                             }
                         });
                     }
@@ -1963,24 +2196,21 @@ pub(super) async fn spawn_kv_watches(
     conn: Arc<ConnHandle>,
     watches: Vec<KvWatchConfig>,
     cancel_token: CancellationToken,
-    execution_meter: ExecutionTimeMeter,
     _failure_sink: Option<crate::plugin::WorkloadFailureSink>,
     _workload_id: impl Into<String>,
-    warm_sets: Arc<WarmSets>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
-    let pre = KvHandlerPre::new(instance_pre)?;
-    let warm_set = warm_sets.kv.clone();
+    let target = HandlerTarget {
+        component_id: Arc::from(component_id),
+        pre: instance_pre,
+    };
 
     for watch in watches {
         let conn = conn.clone();
         let in_flight = Arc::new(tokio::sync::Semaphore::new(conn.limits.max_in_flight));
         let workload = workload.clone();
-        let component_id = component_id.to_string();
-        let pre = pre.clone();
+        let target = target.clone();
         let cancel_token = cancel_token.clone();
-        let execution_meter = execution_meter.clone();
-        let warm_set = warm_set.clone();
 
         tokio::spawn(async move {
             // A KV watch is an ordered consumer underneath, which recovers
@@ -2156,79 +2386,43 @@ pub(super) async fn spawn_kv_watches(
                                 None => break,
                             };
 
-                            let bucket_name = watch.bucket.clone();
                             // Recorded before the entry moves into the handler
                             // task: this is where a rebuild resumes from.
                             last_revision = Some(entry.revision);
 
-                            // Warm when the component opted in, cold
-                            // otherwise — see the JetStream loop for the
-                            // shape.
-                            let mut warmed = match warm_set.checkout() {
-                                Some(mut warmed) => {
-                                    crate::engine::abandon::rearm_for_call(
-                                        &mut warmed.handler.0,
-                                    );
-                                    warmed
-                                }
-                                None => {
-                                    let mut store = tokio::select! {
-                                        created = workload.new_store(&component_id) => match created {
-                                            Err(e) => {
-                                                warn!("failed to create store for {component_id}: {e}");
-                                                continue;
-                                            }
-                                            Ok(s) => s,
-                                        },
-                                        // Instantiating into a workload that is being
-                                        // torn down is work nobody will see the result
-                                        // of.
-                                        _ = cancel_token.cancelled() => break 'watch,
-                                    };
-                                    let proxy = tokio::select! {
-                                        instantiated = pre.instantiate(&mut store) => match instantiated {
-                                            Err(e) => {
-                                                warn!("failed to instantiate {component_id}: {e}");
-                                                continue;
-                                            }
-                                            Ok(p) => p,
-                                        },
-                                        _ = cancel_token.cancelled() => break 'watch,
-                                    };
-                                    super::warm::Warmed::fresh((store, proxy))
-                                }
-                            };
-                            waive_fuel_limit(&mut warmed.handler.0);
-
+                            let bucket_for_label = watch.bucket.clone();
                             let key_label = entry.key.clone();
-                            let span = tracing::span!(
-                                tracing::Level::INFO,
-                                "incoming_nats_kv_event",
-                                bucket = %bucket_name,
-                                key = %key_label,
+                            let (reply, reply_rx) = tokio::sync::oneshot::channel();
+                            let call = crate::engine::abandon::DispatchedCall::new(
+                                "wasmcloud:nats kv delivery",
+                                crate::timeouts::ephemeral_call(),
                             );
-
-                            let execution_meter = execution_meter.clone();
-                            let warm_set = warm_set.clone();
-                            tokio::spawn(async move {
-                                let _permit = permit;
-                                let bucket_for_label = bucket_name.clone();
-                                let (store, proxy) =
-                                    (&mut warmed.handler.0, &warmed.handler.1);
-                                let result = execution_meter.observe(
-                                    &[
+                            let job: Box<dyn crate::engine::instance_driver::PluginJob> =
+                                Box::new(KvDeliveryJob {
+                                    bucket: bucket_for_label.clone(),
+                                    entry: kv_entry_to_kv_handler_wit(&entry),
+                                    abandoned: call.flag(),
+                                    reply,
+                                    attributes: vec![
                                         KeyValue::new("plugin", PLUGIN_NATS_ID),
                                         KeyValue::new("bucket", bucket_for_label.clone()),
                                     ],
-                                    store,
-                                    async move |store| {
-                                        proxy
-                                            .call(store, &bucket_name, &entry)
-                                            .instrument(span)
-                                            .await
-                                            .map_err(Into::into)
-                                    },
-                                ).await;
+                                });
+                            let span = tracing::span!(
+                                tracing::Level::INFO,
+                                "incoming_nats_kv_event",
+                                bucket = %bucket_for_label,
+                                key = %key_label,
+                            );
+                            let workload = workload.clone();
+                            let target = target.clone();
+                            let delivery_cancel = cancel_token.clone();
+                            tokio::spawn(async move {
+                                let _permit = permit;
+                                let result =
+                                    run_delivery(&workload, &target, job, reply_rx, call, &delivery_cancel)
+                                        .instrument(span)
+                                        .await;
                                 match &result {
                                     Ok(Err(handler_err)) => warn!(
                                         bucket = %bucket_for_label,
@@ -2238,15 +2432,9 @@ pub(super) async fn spawn_kv_watches(
                                     Err(e) => warn!(
                                         bucket = %bucket_for_label,
                                         key = %key_label,
-                                        "KV handler trapped: {e}"
+                                        "KV event delivery failed: {e:#}"
                                     ),
                                     Ok(Ok(())) => {}
-                                }
-                                // A trap poisons the store; anything else may
-                                // serve the next event warm.
-                                match &result {
-                                    Err(_) => drop(warmed),
-                                    Ok(_) => warm_set.park(warmed),
                                 }
                             });
                         }

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/warm.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/warm.rs
@@ -1,4 +1,4 @@
-//! Warm handler instances for the NATS delivery loops.
+//! Warm handler instances for the JetStream delivery loop.
 //!
 //! Every delivery loop in [`super::subscriber`] built, instantiated, invoked
 //! and dropped a store per message. That keeps guest state ephemeral — the
@@ -10,13 +10,17 @@
 //!
 //! The engine already has an opt-in for exactly this — `poolSize`,
 //! `maxInvocations`, `maxConcurrency` on the component, decoded once into
-//! [`InstancePolicy`] — but it fed only the [`InstanceJob`] paths (inbound
-//! HTTP and linked calls), so the three knobs silently did nothing for a NATS
-//! workload. A NATS delivery cannot become an [`InstanceJob`]: its call
-//! carries a typed resource (the JetStream message handle) that must be pushed
-//! into the very store that will run the call, and its settle-ack ownership
-//! and rebuild resume point live in the subscription loop. So the subscriber
-//! keeps a warm set of its own, honouring the same declaration:
+//! [`InstancePolicy`] — and core and KV deliveries take it: they cross as an
+//! [`InstanceJob::Plugin`] and the pool routes them like any other call.
+//! **JetStream
+//! cannot.** Its call carries a `message-handle` resource, which is an index
+//! into one store's resource table, so the argument cannot be built until the
+//! store is chosen — and a job the pool hands back has already been pushed
+//! into a table it no longer belongs to. Its settle-ack ownership and its
+//! rebuild resume point live in the subscription loop for the same reason.
+//!
+//! So the JetStream loop alone keeps a warm set, honouring the same
+//! declaration:
 //!
 //! * `pool_size` — instances parked between deliveries. A delivery finding
 //!   none idle builds a one-shot store exactly as before, so pooling never
@@ -27,9 +31,12 @@
 //!   has served that many, so guest state (and any message-handle resources a
 //!   guest leaked into the store's table) cannot accumulate forever.
 //! * `max_concurrency` — **not honoured per instance here.** These are
-//!   checkout instances: one call at a time each, which is `max_concurrency`'s
-//!   default. Deliveries beyond the idle set are served from one-shot stores,
-//!   so a value above 1 loses no throughput; it just does not multiply reuse.
+//!   checkout instances: the proxy call takes `&mut Store`, so one call at a
+//!   time each, which is `max_concurrency`'s default. Deliveries beyond the
+//!   idle set are served from one-shot stores, so a value above 1 loses no
+//!   throughput; it just does not multiply reuse. Core and KV deliveries do
+//!   honour it, because the driver holds the store in one long
+//!   `run_concurrent` and their calls arrive as tasks on it.
 //!
 //! A trapped store is poison — it can no longer enter any component instance —
 //! so a call that traps drops its store instead of parking it, and the next

--- a/crates/wash-runtime/tests/fixtures/nats-async-handler-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/nats-async-handler-p3/src/lib.rs
@@ -41,9 +41,25 @@ const PULL_TIMEOUT_MS: u32 = 1_000;
 /// reusing the instance (`poolSize`).
 const WARM_MARKER: &str = "warm:";
 
+/// Body prefix that reports the peak number of core deliveries this instance
+/// had in flight at once.
+///
+/// Peak rather than wall clock, for the reason `http-sleeper` gives: a delivery
+/// the warm set cannot take is served from a store of its own and runs in
+/// parallel anyway, so both configurations drain a burst in about the same
+/// time. What differs is *where* the calls ran. An instance serving one call at
+/// a time reports `1` however hard it is driven, so the signal does not depend
+/// on the burst actually overlapping.
+const CONC_MARKER: &str = "conc:";
+/// Long enough that a burst published back-to-back is still in flight when the
+/// next delivery arrives, short enough not to pace the test.
+const CONC_NANOS: u64 = 50_000_000; // 50ms
+
 /// Lives in this instance's linear memory and nowhere else: a fresh store per
 /// delivery reads 1 every time, a warm instance counts up.
 static WARM_DELIVERIES: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+static IN_FLIGHT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+static PEAK_IN_FLIGHT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
 struct Component;
 
@@ -240,6 +256,18 @@ impl CoreGuest for Component {
         if let Some(run) = body.strip_prefix(WARM_MARKER) {
             let seen = WARM_DELIVERIES.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
             return core::publish(message("test.results", format!("warm:{run}:{seen}")))
+                .await
+                .map_err(|e| label(&e));
+        }
+        if let Some(run) = body.strip_prefix(CONC_MARKER) {
+            let now = IN_FLIGHT.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            PEAK_IN_FLIGHT.fetch_max(now, std::sync::atomic::Ordering::SeqCst);
+            // Held open so a sibling delivery can overlap this one, if the
+            // instance is allowed to take a sibling at all.
+            monotonic_clock::wait_for(CONC_NANOS).await;
+            IN_FLIGHT.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            let peak = PEAK_IN_FLIGHT.load(std::sync::atomic::Ordering::SeqCst);
+            return core::publish(message("test.results", format!("conc:{run}:{peak}")))
                 .await
                 .map_err(|e| label(&e));
         }

--- a/crates/wash-runtime/tests/integration_nats_plugin.rs
+++ b/crates/wash-runtime/tests/integration_nats_plugin.rs
@@ -183,6 +183,17 @@ fn workload_request_with_pool(
     interface: WitInterface,
     pool_size: i32,
 ) -> WorkloadStartRequest {
+    workload_request_with_limits(workload_id, interface, pool_size, 4)
+}
+
+/// As [`workload_request_with_pool`], but with `max_concurrency` too — how many
+/// deliveries one warm instance may have in flight at once.
+fn workload_request_with_limits(
+    workload_id: &str,
+    interface: WitInterface,
+    pool_size: i32,
+    max_concurrency: i32,
+) -> WorkloadStartRequest {
     WorkloadStartRequest {
         workload_id: workload_id.to_string(),
         workload: Workload {
@@ -206,7 +217,7 @@ fn workload_request_with_pool(
                 },
                 pool_size,
                 max_invocations: 100,
-                max_concurrency: 4,
+                max_concurrency,
             }],
             host_interfaces: vec![interface],
             volumes: vec![],
@@ -1525,6 +1536,153 @@ async fn asking_for_an_undeclared_binding_fails_the_deployment() -> Result<()> {
     assert!(
         message.contains("leaf"),
         "expected the refusal to name the binding asked for, got {message}"
+    );
+    Ok(())
+}
+
+/// Publishes `runs` `conc:` triggers back to back on a core subject and returns
+/// the peak in-flight each delivery saw on its own instance.
+///
+/// Published without waiting between them, which is the point: the fixture
+/// holds each delivery open for 50ms, so a burst of four is still in flight
+/// when the last arrives — *if* an instance is allowed to take more than one.
+async fn conc_probe(h: &Harness, runs: usize) -> Result<Vec<u32>> {
+    let mut results = h.client.subscribe("test.results".to_string()).await?;
+
+    // Core NATS drops anything published before the workload's subscription has
+    // attached, and how long that takes depends on what else the machine is
+    // doing. Prove it is attached before sending the burst: a burst that landed
+    // on nothing is indistinguishable here from one the host refused to overlap.
+    //
+    // The ping takes the handler's echo branch, which leaves the in-flight
+    // counters alone, so warming the subscription cannot colour the result.
+    let mut attached = false;
+    for _ in 0..45 {
+        h.client
+            .publish("trigger.conc".to_string(), "ready".into())
+            .await
+            .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
+        h.client
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("flush failed: {e}"))?;
+        if matches!(
+            timeout(Duration::from_secs(1), results.next()).await,
+            Ok(Some(_))
+        ) {
+            attached = true;
+            break;
+        }
+    }
+    anyhow::ensure!(
+        attached,
+        "the workload's core subscription never attached to `trigger.conc`"
+    );
+
+    for run in 0..runs {
+        h.client
+            .publish("trigger.conc".to_string(), format!("conc:{run}").into())
+            .await
+            .map_err(|e| anyhow::anyhow!("publish failed: {e}"))?;
+    }
+    h.client
+        .flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("flush failed: {e}"))?;
+
+    let mut peaks = Vec::new();
+    while peaks.len() < runs {
+        let got = timeout(Duration::from_secs(20), results.next())
+            .await
+            .context("no result before the deadline")?
+            .context("results subscription ended")?;
+        let body = String::from_utf8_lossy(&got.payload).to_string();
+        // A retried readiness ping echoes on this subject too.
+        if !body.starts_with("conc:") {
+            continue;
+        }
+        let peak = body
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse::<u32>().ok())
+            .with_context(|| format!("unparseable result `{body}`"))?;
+        peaks.push(peak);
+    }
+    Ok(peaks)
+}
+
+/// A core subscription bound to the `conc:` trigger.
+///
+/// The async variant, because only it declares `core-handler`: a
+/// `core-subscriptions` key on a binding without that export subscribes nothing.
+fn conc_interface(h: &Harness) -> WitInterface {
+    nats_async_interface(&[
+        ("servers", &h.nats_url),
+        ("subject-allow", "trigger.>,test.>"),
+        ("core-subscriptions", "trigger.conc"),
+    ])
+}
+
+/// `maxConcurrency` reaches core deliveries: one warm instance takes several at
+/// once rather than serving them in turn while its siblings fall back to stores
+/// of their own.
+///
+/// The peak the fixture reports is the signal, not wall clock. A delivery the
+/// warm set cannot take is served from a store of its own and runs in parallel
+/// anyway, so both configurations drain the burst in about the same time — what
+/// differs is *where* the calls ran, and so how much per-instance state they
+/// could share.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn max_concurrency_overlaps_core_deliveries_on_one_instance() -> Result<()> {
+    let h = start_nats().await?;
+    let host = start_host().await?;
+
+    host.workload_start(workload_request_with_limits(
+        "wl-conc",
+        conc_interface(&h),
+        1,
+        4,
+    ))
+    .await
+    .context("failed to start the concurrent workload")?;
+
+    let peaks = conc_probe(&h, 4).await?;
+    assert!(
+        peaks.iter().any(|p| *p > 1),
+        "one instance should have taken more than one delivery at a time, saw {peaks:?}"
+    );
+    assert!(
+        peaks.iter().all(|p| *p <= 4),
+        "no instance may exceed max_concurrency of 4, saw {peaks:?}"
+    );
+    Ok(())
+}
+
+/// The control, and the default: `max_concurrency` of one means one call at a
+/// time on an instance however hard it is driven. A component that only asked
+/// for `poolSize` keeps the behaviour it had before this existed — which
+/// matters, because a guest driving its own executor cannot survive a second
+/// concurrent call entering it.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn without_max_concurrency_core_deliveries_do_not_overlap() -> Result<()> {
+    let h = start_nats().await?;
+    let host = start_host().await?;
+
+    host.workload_start(workload_request_with_limits(
+        "wl-serial",
+        conc_interface(&h),
+        1,
+        1,
+    ))
+    .await
+    .context("failed to start the serial workload")?;
+
+    let peaks = conc_probe(&h, 4).await?;
+    assert!(
+        peaks.iter().all(|p| *p == 1),
+        "no instance may serve two deliveries at once at max_concurrency 1, saw {peaks:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
`poolSize`, `maxInvocations` and `maxConcurrency` fed only the `InstanceJob` paths, so a NATS workload's declaration wasn't used. The plugin kept warm sets of its own to compensate, which could reuse an instance but never run two deliveries on one.

Core and KV deliveries now cross as `InstanceJob::Plugin` and take the same path as inbound HTTP and linked calls, honoring all three knobs. 

JetStream stays on a warm set: its call carries a `message-handle` resource, an index into one store's table, so its argument cannot exist before the store is chosen.