### PR TITLE
[FEAT] support concurrency for async wasmcloud:messaging

### DIFF
--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -9,13 +9,13 @@
 //! awaiting I/O is exactly the guest with that kind of state, so a pool has to
 //! be sized to peak *concurrency* to keep any of it, rather than to peak work.
 //!
-//! A driver removes that. Both an inbound HTTP request and a call from another
-//! component in the workload are [`InstanceJob`]s, so a component reached both
-//! ways shares one warm set rather than keeping two. It owns its store for good
-//! and runs one long-lived
-//! [`wasmtime::Store::run_concurrent`], taking calls off a channel and
-//! [`Accessor::spawn`]ing each as a concurrent task on the same instance. That
-//! is what the host already does for a service (see
+//! A driver removes that. An inbound HTTP request, an inbound message, a call
+//! from another component in the workload and a plugin's delivery are all
+//! [`InstanceJob`]s, so a component reached several ways shares one warm set
+//! rather than keeping one per trigger. It owns its store for good and runs one
+//! long-lived [`wasmtime::Store::run_concurrent`], taking calls off a channel
+//! and [`Accessor::spawn`]ing each as a concurrent task on the same instance.
+//! That is what the host already does for a service (see
 //! [`crate::host::trigger_service`]) — this is the same driver, one per warm
 //! instance rather than one per workload, with admission control in front.
 //!
@@ -72,15 +72,23 @@ pub(crate) struct LinkedJob {
     pub(crate) abandoned: Arc<crate::engine::abandon::AbandonFlag>,
 }
 
-/// Work an instance can be given. Both shapes run as concurrent tasks on the
-/// same instance, so a component reached both ways shares one warm set rather
-/// than keeping two.
+/// Work an instance can be given. Every shape runs as a concurrent task on the
+/// same instance, so a component reached several ways shares one warm set
+/// rather than keeping one per trigger.
 pub(crate) enum InstanceJob {
     /// An inbound HTTP request (`wasi:http/handler@0.3`). Boxed to keep the
     /// variants a similar size; a declined job carries the whole request back.
     Http(Box<ServiceHttpJob>),
     /// A call from another component in the workload.
     Linked(Box<LinkedJob>),
+    /// An inbound message (`wasmcloud:messaging/handler@0.3.0`), delivered by
+    /// whichever messaging backend the workload bound.
+    ///
+    /// Only the async `@0.3.0` handler reaches here. Its call takes an
+    /// [`Accessor`], so deliveries overlap on one instance up to
+    /// `max_concurrency`; the sync `@0.2.0` export holds `&mut Store` for the
+    /// length of its call and keeps its per-message store.
+    Messaging(Box<crate::host::trigger_service::MessagingJob>),
     /// A call a host plugin supplies, made on a pooled instance.
     ///
     /// The engine routes it like any other job and never looks inside: the
@@ -352,10 +360,67 @@ pub(crate) struct InstanceDriver {
     admitted: AtomicUsize,
     max_concurrency: usize,
     max_invocations: Option<usize>,
-    /// Whether this instance exports `wasi:http/handler`. A component reached
-    /// only by linked calls does not, which is not an error — but it cannot be
-    /// given HTTP work either.
-    serves_http: bool,
+    /// The triggered work this instance can take, so admission never gives it
+    /// a job it could only fail.
+    accepts: Accepts,
+}
+
+/// The typed handler views bound over one instance, built once when its driver
+/// starts and reused by every call on it.
+///
+/// Each is both the probe and the binding: `Service::new` and
+/// `AsyncMessaging::new` type-check their export against the live instance and
+/// hand back the view. A component reached only by linked calls has neither,
+/// which is not an error — it just cannot be given triggered work.
+///
+/// A set rather than a flag per trigger: the next host-invoked export is a
+/// field and a match arm, not a third bool and a third special case in
+/// admission.
+struct BoundExports {
+    http: Option<Arc<Service>>,
+    messaging: Option<Arc<crate::host::trigger_service::AsyncMessaging>>,
+}
+
+/// Which job kinds an instance will accept — the presence half of
+/// [`BoundExports`], split off so admission can answer without the views (and
+/// so a test can build one without a store).
+#[derive(Clone, Copy)]
+struct Accepts {
+    http: bool,
+    messaging: bool,
+}
+
+impl BoundExports {
+    fn bind(store: &mut wasmtime::Store<SharedCtx>, instance: &Instance) -> Self {
+        Self {
+            http: Service::new(&mut *store, instance).ok().map(Arc::new),
+            messaging: crate::host::trigger_service::AsyncMessaging::new(&mut *store, instance)
+                .ok()
+                .map(Arc::new),
+        }
+    }
+
+    fn accepts(&self) -> Accepts {
+        Accepts {
+            http: self.http.is_some(),
+            messaging: self.messaging.is_some(),
+        }
+    }
+}
+
+impl Accepts {
+    /// Whether this instance can be given `job` at all.
+    ///
+    /// A linked call names the export index it resolved against this very
+    /// component, and a plugin job binds its own view when it runs, so neither
+    /// is gated here.
+    fn takes(self, job: &InstanceJob) -> bool {
+        match job {
+            InstanceJob::Http(_) => self.http,
+            InstanceJob::Messaging(_) => self.messaging,
+            InstanceJob::Linked(_) | InstanceJob::Plugin(_) => true,
+        }
+    }
 }
 
 impl InstanceDriver {
@@ -380,11 +445,11 @@ impl InstanceDriver {
         });
         let task_state = Arc::clone(&state);
 
-        // Built before the run loop so admission knows whether this instance
-        // can take HTTP at all, rather than accepting a request it could only
-        // drop.
-        let service = Service::new(&mut store, &instance).ok().map(Arc::new);
-        let serves_http = service.is_some();
+        // Built before the run loop so admission knows what this instance can
+        // take at all, rather than accepting work it could only drop. The views
+        // move into the run loop; admission keeps only their presence.
+        let bound = BoundExports::bind(&mut store, &instance);
+        let accepts = bound.accepts();
 
         tokio::spawn(async move {
             // One `run_concurrent` for the life of the instance. Each call is
@@ -412,7 +477,7 @@ impl InstanceDriver {
                                     resp_tx,
                                     abandoned,
                                 } = *job;
-                                let Some(service) = service.as_ref().map(Arc::clone) else {
+                                let Some(service) = bound.http.as_ref().map(Arc::clone) else {
                                     // Admission declines HTTP for an instance
                                     // without the export, so this is not
                                     // normally reachable; answer the request
@@ -427,6 +492,36 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
+                                    pool_slot: Some(PoolSlot {
+                                        state: Arc::clone(&task_state),
+                                        _in_flight: guard,
+                                    }),
+                                })
+                            }
+                            InstanceJob::Messaging(job) => {
+                                let crate::host::trigger_service::MessagingJob {
+                                    msg,
+                                    result_tx,
+                                    abandoned,
+                                    attributes,
+                                } = *job;
+                                let Some(handler) = bound.messaging.as_ref().map(Arc::clone) else {
+                                    // As with HTTP: admission declines this for
+                                    // an instance without the export, so report
+                                    // it rather than dropping the delivery if
+                                    // it is ever reached.
+                                    let _ =
+                                        result_tx.send(Err("pooled instance does not export the \
+                                         @0.3.0 messaging handler"
+                                            .into()));
+                                    continue;
+                                };
+                                accessor.spawn(crate::host::trigger_service::MessagingTask {
+                                    handler,
+                                    msg,
+                                    result_tx,
+                                    abandoned,
+                                    attributes,
                                     pool_slot: Some(PoolSlot {
                                         state: Arc::clone(&task_state),
                                         _in_flight: guard,
@@ -470,7 +565,7 @@ impl InstanceDriver {
             admitted: AtomicUsize::new(0),
             max_concurrency,
             max_invocations,
-            serves_http,
+            accepts,
         }
     }
 
@@ -571,7 +666,10 @@ impl InstanceDriver {
                 admitted: AtomicUsize::new(0),
                 max_concurrency,
                 max_invocations,
-                serves_http: true,
+                accepts: Accepts {
+                    http: true,
+                    messaging: true,
+                },
             },
             rx,
         )
@@ -581,10 +679,10 @@ impl InstanceDriver {
     /// could not take it, so the caller can try elsewhere. Boxed because the
     /// refusal carries the whole request back.
     pub(crate) fn try_send(&self, job: InstanceJob) -> Result<(), InstanceJob> {
-        // An instance without the HTTP export can only fail such a call.
-        // Declining it sends the request to a store of its own, where the
-        // binding is built per request and its error reaches the client.
-        if !self.serves_http && matches!(job, InstanceJob::Http(_)) {
+        // An instance without the export a job needs can only fail it.
+        // Declining sends the job to a store of its own, where the binding is
+        // built per call and its error reaches whoever is waiting.
+        if !self.accepts.takes(&job) {
             return Err(job);
         }
         let Some(guard) = self.try_admit() else {

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -1297,6 +1297,20 @@ pub fn exports_messaging_handler(component: &Component) -> bool {
         .any(|(export, _item)| export.starts_with("wasmcloud:messaging/handler"))
 }
 
+/// Waive the fuel limit on a store whose guest execution is measured some other
+/// way.
+///
+/// A store on a fuel-enabled engine starts at **zero** and instantiation runs
+/// guest code, so without this the component traps on instantiate. Fuel is an
+/// engine-wide switch (`--enable-meters` turns it on for the paths that do
+/// measure by it), so a path measuring by the epoch callback instead — see
+/// [`crate::observability::ExecutionTimeMeter`] — has to waive it rather than
+/// assume it is off. Errors when fuel is off, which is the ordinary case and
+/// not a failure.
+pub(crate) fn waive_fuel_limit<T>(store: &mut crate::wasmtime::Store<T>) {
+    let _ = store.set_fuel(u64::MAX);
+}
+
 pub fn imports_wasi_http(component: &Component) -> bool {
     let ty: wasmtime::component::types::Component = component.component_type();
     let engine = component.engine();

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -797,11 +797,14 @@ pub trait HostHandler: Send + Sync + 'static {
         Ok(())
     }
     /// Deliver a message to a workload's registered messaging trigger service, returning
-    /// the handler's `result<_, string>`. Default: no messaging support.
+    /// the handler's `result<_, string>`. `attributes` is what the delivery is
+    /// measured under, built by the backend — the layer that knows which
+    /// messaging plugin drove it. Default: no messaging support.
     async fn deliver_trigger_service_message(
         &self,
         _workload_id: &str,
         _msg: BrokerMessage,
+        _attributes: Vec<opentelemetry::KeyValue>,
     ) -> anyhow::Result<Result<(), String>> {
         anyhow::bail!("this host does not support trigger service messaging delivery")
     }
@@ -1391,6 +1394,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         &self,
         workload_id: &str,
         msg: BrokerMessage,
+        attributes: Vec<opentelemetry::KeyValue>,
     ) -> anyhow::Result<Result<(), String>> {
         let sender = self
             .messaging_handlers
@@ -1412,6 +1416,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
                 msg,
                 result_tx: tx,
                 abandoned: call.flag(),
+                attributes,
             })
             .await
             .map_err(|_| anyhow::anyhow!("trigger service messaging instance is not running"))?;
@@ -2017,6 +2022,7 @@ async fn invoke_component_handler(
                         "instance pool returned a {} job for an HTTP request",
                         match other {
                             InstanceJob::Linked(_) => "linked",
+                            InstanceJob::Messaging(_) => "messaging",
                             InstanceJob::Plugin(_) => "plugin",
                             InstanceJob::Http(_) => "http",
                         }

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -1,15 +1,28 @@
-//! The [`Ingress::Messaging`] path: `wasmcloud:messaging/handler@0.3.0`
-//! invocations served on the shared service instance.
+//! `wasmcloud:messaging/handler@0.3.0` invocations, on a shared service
+//! instance or on a pooled one.
 //!
-//! Trigger services are p3-only, so this binds the async `@0.3.0` handler
-//! through generated typed bindings — `AsyncMessaging::new` over the live
-//! instance, the same shape `Service::new` gives the HTTP ingress — rather than
-//! the hand-rolled `Val` lowering the p2 handler once required. Typed bindings
-//! are also what make the `stream<u8>` message body workable: the delivered
-//! bytes are minted into a native stream per invocation, which `Val` has no
-//! ergonomic spelling for.
+//! Both shapes bind the async `@0.3.0` handler through generated typed
+//! bindings — `AsyncMessaging::new` over the live instance, the same shape
+//! `Service::new` gives the HTTP ingress — rather than the hand-rolled `Val`
+//! lowering the p2 handler once required. Typed bindings are also what make the
+//! `stream<u8>` message body workable: the delivered bytes are minted into a
+//! native stream per invocation, which `Val` has no ergonomic spelling for.
+//!
+//! [`MessagingJob`] serves both, exactly as [`ServiceHttpJob`] does for HTTP:
+//! the [`Ingress::Messaging`] path delivers to a service's singleton instance,
+//! and [`InstanceJob::Messaging`] delivers to whichever pooled instance is
+//! free. What separates them is [`MessagingTask::pool_slot`] — a service's
+//! instance is not the pool's to retire.
+//!
+//! Only `@0.3.0` reaches either. `handle-message` is an `async func` there, so
+//! its call takes an [`Accessor`] and several deliveries can share one instance
+//! up to `max_concurrency`. The sync `@0.2.0` export takes `&mut Store` for the
+//! length of its call, so it cannot share an instance at all and keeps its
+//! per-message store.
 //!
 //! [`Ingress::Messaging`]: super::Ingress::Messaging
+//! [`ServiceHttpJob`]: crate::host::http::ServiceHttpJob
+//! [`InstanceJob::Messaging`]: crate::engine::instance_driver::InstanceJob::Messaging
 
 use std::sync::Arc;
 
@@ -26,7 +39,7 @@ mod bindings {
     });
 }
 
-pub(super) use bindings::AsyncMessaging;
+pub(crate) use bindings::AsyncMessaging;
 use bindings::wasmcloud::messaging0_3_0::types::{
     BrokerMessage as WitBrokerMessage, HandleMessageError,
 };
@@ -51,10 +64,19 @@ pub struct BrokerMessage {
 /// outcome back to the host-side ingress (to ack/log, its disposition rendered
 /// to a string), and the abandonment flag of the dispatched call enforcing its
 /// deadline (see [`crate::engine::abandon`]).
+///
+/// Handle-free by construction — the body is bytes, and the `stream<u8>` the
+/// WIT carries is minted inside the invocation once the store is chosen — which
+/// is what lets the same job cross a channel to a service or go into the
+/// instance pool.
 pub struct MessagingJob {
     pub msg: BrokerMessage,
     pub result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
     pub abandoned: Arc<AbandonFlag>,
+    /// What this call is measured under. Built by the dispatcher, which is the
+    /// layer that knows the workload's manifest identity — see
+    /// [`crate::observability::WorkloadIdentity`].
+    pub attributes: Vec<opentelemetry::KeyValue>,
 }
 
 /// The messaging handler export a trigger service must provide.
@@ -109,20 +131,28 @@ pub(super) fn bind_handler(
     })
 }
 
-/// Handles one inbound message on the shared service instance by invoking the
-/// async `@0.3.0` `handle-message` export through its typed bindings, and
-/// reports its disposition.
+/// Handles one inbound message by invoking the async `@0.3.0` `handle-message`
+/// export through its typed bindings, and reports its disposition.
 ///
 /// A handler `err` is an ordinary application outcome, reported on `result_tx`
-/// only. A guest *trap*, however, leaves the shared instance unenterable for
-/// every later message, so after reporting it the task returns the error —
-/// faulting `run_concurrent` so the driver exits and the service supervisor
-/// restarts (and re-registers) a fresh instance.
-pub(super) struct MessagingTask {
-    pub(super) handler: std::sync::Arc<AsyncMessaging>,
-    pub(super) msg: BrokerMessage,
-    pub(super) result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
-    pub(super) abandoned: Arc<AbandonFlag>,
+/// only. A guest *trap*, however, leaves the instance unenterable for every
+/// later message, so after reporting it the task returns the error — faulting
+/// `run_concurrent` so the driver exits. A service's supervisor then restarts
+/// and re-registers a fresh instance; a pooled instance's handle is reaped by
+/// the next `offer`, and the delivery after it starts a new one.
+pub(crate) struct MessagingTask {
+    pub(crate) handler: std::sync::Arc<AsyncMessaging>,
+    pub(crate) msg: BrokerMessage,
+    pub(crate) result_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+    pub(crate) abandoned: Arc<AbandonFlag>,
+    /// What this call is measured under; see
+    /// [`crate::observability::WorkloadIdentity`].
+    pub(crate) attributes: Vec<opentelemetry::KeyValue>,
+    /// This delivery's tether to a pooled instance: holds its in-flight slot
+    /// and can retire the instance. `None` for the two shapes with no instance
+    /// to retire — a service, whose singleton is not the pool's, and a cold
+    /// store serving one delivery and being dropped.
+    pub(crate) pool_slot: Option<crate::engine::instance_driver::PoolSlot>,
 }
 
 impl AccessorTask<SharedCtx> for MessagingTask {
@@ -132,6 +162,8 @@ impl AccessorTask<SharedCtx> for MessagingTask {
             msg,
             result_tx,
             abandoned,
+            attributes,
+            pool_slot,
         } = self;
 
         // The epoch deadline measures this call's own execution, so re-arm it
@@ -140,6 +172,9 @@ impl AccessorTask<SharedCtx> for MessagingTask {
             crate::engine::abandon::rearm_for_call(&mut access);
             Arc::clone(&access.get().abandoned)
         });
+        // Both delivery shapes — a pooled instance and a long-lived service —
+        // land here, so one sample covers both.
+        let _sample = crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
 
         let deliver = async {
             // The `@0.3.0` body is a native `stream<u8>`; mint one carrying the
@@ -156,13 +191,44 @@ impl AccessorTask<SharedCtx> for MessagingTask {
                 .await
         };
 
-        // Unbounded from in here: the dispatcher enforces the deadline the
-        // caller waits out, and a handler that overruns it is slow rather than
-        // wedged. This bounds only how long an overrunning delivery stays
-        // visible to the epoch callback, whose trap would take the service
-        // singleton every other subject shares.
-        let outcome =
-            crate::engine::abandon::watch_until_abandoned(&calls, abandoned, deliver).await;
+        // `watch_until_abandoned` bounds only how long an overrunning delivery
+        // stays visible to the epoch callback, whose trap would take every
+        // other delivery sharing this instance. The deadline the *caller* waits
+        // out is enforced by its `DispatchedCall`, outside this store.
+        let watched = crate::engine::abandon::watch_until_abandoned(&calls, abandoned, deliver);
+
+        // On a *pooled* instance the delivery is additionally bounded here, for
+        // the guest work the host cannot cancel: once the dispatcher has given
+        // up, retirement is what ends it — stop admitting, drain, and let the
+        // store's teardown take the stalled work with it.
+        //
+        // Without a slot there is nothing to retire, so the arm is left
+        // unbounded. For a cold store the dispatcher dropping this future is
+        // already the remedy. For a service it is load-bearing: a wedged guest
+        // is ended by the epoch callback trapping the store, which faults
+        // `run_concurrent` and restarts the service, and reporting a timeout
+        // first would return `Ok` and keep the wedged delivery on the instance
+        // every other subject shares.
+        //
+        // TODO: both arms want per-task cancellation
+        // (bytecodealliance/wasmtime#11833).
+        let outcome = match pool_slot {
+            None => watched.await,
+            Some(slot) => {
+                match tokio::time::timeout(crate::timeouts::messaging_deliver(), watched).await {
+                    Ok(outcome) => outcome,
+                    Err(_) => {
+                        let _ = result_tx.send(Err("handle-message timed out".to_string()));
+                        slot.retire_instance();
+                        tracing::error!(
+                            "messaging delivery timed out; retiring its pooled instance to \
+                             end the stalled work"
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+        };
 
         match outcome {
             Ok(result) => {
@@ -171,7 +237,7 @@ impl AccessorTask<SharedCtx> for MessagingTask {
             }
             Err(e) => {
                 let _ = result_tx.send(Err(format!("handle-message trapped: {e:#}")));
-                Err(e.context("messaging handler trapped; restarting the trigger service"))
+                Err(e.context("messaging handler trapped; discarding its instance"))
             }
         }
     }

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -53,6 +53,8 @@ mod messaging;
 #[cfg(feature = "host-component-plugins")]
 pub use capability::{CapabilityCall, CapabilityFunc, CapabilityJob, LifecycleReplay};
 pub use messaging::{BrokerMessage, MessagingJob};
+// The pooled path binds and drives the same handler the service ingress does.
+pub(crate) use messaging::{AsyncMessaging, MessagingTask};
 
 #[cfg(feature = "host-component-plugins")]
 pub(crate) use capability::decode_bind_reply;
@@ -60,7 +62,6 @@ pub(crate) use capability::decode_bind_reply;
 #[cfg(feature = "host-component-plugins")]
 use capability::{admit_and_spawn_call, drain_plugin_resources, flush_pending_resource_drops};
 pub(crate) use http::HttpTask;
-use messaging::MessagingTask;
 
 /// A host-invoked handler export the TriggerService serves, carrying the receiver end
 /// of its delivery channel. The paired sender is handed to the host-side ingress
@@ -223,6 +224,7 @@ impl PreparedIngress {
                     msg,
                     result_tx,
                     abandoned,
+                    attributes,
                 }) = rx.recv().await
                 {
                     if let Err(e) = accessor.spawn(MessagingTask {
@@ -230,6 +232,8 @@ impl PreparedIngress {
                         msg,
                         result_tx,
                         abandoned,
+                        attributes,
+                        pool_slot: None,
                     }) {
                         tracing::error!(err = %e, "failed to spawn messaging invocation task");
                     }

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -634,7 +634,7 @@ impl HostPlugin for InMemoryMessaging {
         // instead. Only components get a `MessagingPre` for per-message work.
         let pre = match workload.instantiate_pre(component_id).await {
             Ok(instance_pre) => Some(
-                HandlerPre::new(instance_pre)
+                HandlerTarget::new(instance_pre)
                     .map_err(anyhow::Error::from)
                     .context("failed to instantiate messaging pre")?,
             ),
@@ -652,6 +652,12 @@ impl HostPlugin for InMemoryMessaging {
         // Spawn the message processing task
         let task_component_id = component_id.clone();
         let fuel_meter = self.meters.read().await.fuel_consumption.clone();
+        // As in the NATS backend: bounded labels only, so the subject stays
+        // on the span rather than minting a time series per value.
+        let attributes = vec![
+            KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
+            KeyValue::new("operation", super::MESSAGING_OPERATION),
+        ];
 
         let handle = tokio::spawn(async move {
             // Labelled so the inner drain below can end the whole task on
@@ -688,7 +694,11 @@ impl HostPlugin for InMemoryMessaging {
                             };
                             match workload
                                 .http_handler()
-                                .deliver_trigger_service_message(workload.id(), broker)
+                                .deliver_trigger_service_message(
+                                    workload.id(),
+                                    broker,
+                                    attributes.clone(),
+                                )
                                 .await
                             {
                                 Ok(Ok(())) => debug!(subject = %msg.subject, "trigger service handled message"),
@@ -711,9 +721,8 @@ impl HostPlugin for InMemoryMessaging {
                             continue;
                         };
 
-                        // Admission. Taken BEFORE the store and instance are
-                        // built and held until the handler returns, so permits
-                        // held and instances alive are the same number. Mirrors
+                        // Admission. Taken BEFORE any store or instance is
+                        // built and held until the handler returns. Mirrors
                         // the NATS backend exactly; see `Admission::acquire`
                         // for why the component level is taken before the host
                         // one, and `DEFAULT_ADMISSION_WAIT` for why the wait is
@@ -761,6 +770,52 @@ impl HostPlugin for InMemoryMessaging {
                             }
                         };
 
+                        let span = tracing::span!(
+                            tracing::Level::INFO,
+                            "incoming_wasmcloud_message_memory",
+                            subject = %msg.subject,
+                            reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"),
+                        );
+
+                        // As in the NATS backend: an async `@0.3.0` handler on
+                        // a component that opted into pooling is served on a
+                        // warm instance, honouring the limits it declared.
+                        // Everything else keeps a store per message.
+                        let pool = if pre.serves_async() {
+                            workload.instance_pool_for_component(&component_id).await
+                        } else {
+                            None
+                        };
+
+                        if let Some(pool) = pool {
+                            let broker = crate::host::trigger_service::BrokerMessage {
+                                subject: msg.subject,
+                                body: msg.body,
+                                reply_to: msg.reply_to,
+                            };
+                            let attributes = attributes.clone();
+                            let workload = workload.clone();
+                            let component_id = component_id.clone();
+                            let instance_pre = pre.instance_pre().clone();
+                            tokio::spawn(async move {
+                                // Released on completion, trap or not — which
+                                // is what frees the slot this message holds.
+                                let _permit = permit;
+                                let result = super::deliver_pooled(
+                                    &workload,
+                                    &component_id,
+                                    &instance_pre,
+                                    &pool,
+                                    broker,
+                                    attributes,
+                                )
+                                .instrument(span)
+                                .await;
+                                super::log_delivery(&result);
+                            });
+                            continue;
+                        }
+
                         let mut store = match workload.new_store(&component_id).await {
                             Err(e) => {
                                 warn!("failed to create store for component {component_id}: {e}");
@@ -776,13 +831,6 @@ impl HostPlugin for InMemoryMessaging {
                             }
                             Ok(p) => p,
                         };
-
-                        let span = tracing::span!(
-                            tracing::Level::INFO,
-                            "incoming_wasmcloud_message_memory",
-                            subject = %msg.subject,
-                            reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"),
-                        );
 
                         let fuel_meter = fuel_meter.clone();
 
@@ -816,14 +864,7 @@ impl HostPlugin for InMemoryMessaging {
                                 }
                             ).await;
 
-                            match result {
-                                Ok(_) => {
-                                    debug!("Message handled successfully");
-                                }
-                                Err(e) => {
-                                    warn!("Error handling message: {e}");
-                                }
-                            };
+                            super::log_delivery(&result);
                         });
                         }
                     }

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -22,6 +22,15 @@
 //!     admission_wait: "5m"     # this handler is slow on purpose
 //! ```
 //!
+//! # Instance limits
+//!
+//! A component exporting the async `wasmcloud:messaging/handler@0.3.0` serves
+//! its deliveries on the workload's instance pool, so the `poolSize`,
+//! `maxInvocations` and `maxConcurrency` it declares mean here what they mean
+//! for inbound HTTP and linked calls — see [`crate::engine::instance_driver`].
+//! A component exporting the sync `@0.2.0` handler cannot: its call holds the
+//! store for its whole length, so it keeps an instance per message.
+//!
 //! `max_in_flight` is a **per-component total**, unlike `max_concurrency`
 //! (per warm instance), and is separately bounded by the host-wide ceiling —
 //! see [`MessagingLimits`]. It is a total for the *component*, not for one
@@ -222,6 +231,143 @@ where
 /// this cap only stops runaway streams.
 const MAX_COLLECTED_BODY_BYTES: usize = 16 * 1024 * 1024;
 
+/// Report one delivery's outcome.
+///
+/// The handler's own error is the useful one; the outer result carries traps
+/// and the host failures that kept the delivery from reaching the guest. Both
+/// backends and both delivery shapes report through this, so a message that
+/// failed reads the same however it was served.
+pub(crate) fn log_delivery(result: &anyhow::Result<Result<(), String>>) {
+    match result {
+        Ok(Ok(())) => tracing::debug!("message handled successfully"),
+        Ok(Err(handler_err)) => {
+            tracing::warn!("messaging handler returned an error: {handler_err}")
+        }
+        Err(e) => tracing::warn!("message delivery failed: {e:#}"),
+    }
+}
+
+/// Runs one `@0.3.0` delivery: through the workload's instance pool when the
+/// component opted into pooling, and in a store of its own when every warm
+/// instance is busy.
+///
+/// The job crosses as [`InstanceJob::Messaging`], so a message takes the same
+/// path as inbound HTTP and linked calls and honours the same `poolSize`,
+/// `maxInvocations` and `maxConcurrency` the component declared — including
+/// several deliveries in flight on one instance, which per-message stores can
+/// never do.
+///
+/// The same job runs either way: a delivery the pool declines is not rebuilt,
+/// it is handed back and run in a fresh store, so a large payload is never
+/// copied to pay for the attempt.
+///
+/// Only `@0.3.0` reaches here. The sync `@0.2.0` handler takes `&mut Store` for
+/// the length of its call, so it cannot share an instance and keeps a store per
+/// message.
+pub(crate) async fn deliver_pooled(
+    workload: &crate::engine::workload::ResolvedWorkload,
+    component_id: &str,
+    pre: &wasmtime::component::InstancePre<crate::engine::ctx::SharedCtx>,
+    pool: &Arc<crate::engine::instance_pool::InstancePool>,
+    msg: crate::host::trigger_service::BrokerMessage,
+    attributes: Vec<KeyValue>,
+) -> anyhow::Result<Result<(), String>> {
+    use crate::engine::instance_driver::InstanceJob;
+    use crate::engine::instance_pool::{ComponentInstance, Dispatch};
+    use crate::host::trigger_service::{MessagingJob, MessagingTask};
+
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+    // Enforced out here, outside the store the guest runs in, so a guest that
+    // never yields cannot hold off its own deadline.
+    let call = crate::engine::abandon::DispatchedCall::new(
+        "messaging (pooled)",
+        crate::timeouts::messaging_deliver(),
+    );
+    let job = MessagingJob {
+        msg,
+        result_tx,
+        abandoned: call.flag(),
+        attributes,
+    };
+
+    let declined = match pool.try_dispatch(InstanceJob::Messaging(Box::new(job))) {
+        Dispatch::Sent => None,
+        // Built out here, where awaiting is allowed and where a component that
+        // fails to instantiate reports it to this delivery rather than only to
+        // the log.
+        Dispatch::NeedsInstance(job) => {
+            let mut store = workload.new_store(component_id).await?;
+            crate::engine::waive_fuel_limit(&mut store);
+            let instance = pre.instantiate_async(&mut store).await?;
+            pool.dispatch_on_new(ComponentInstance { store, instance }, job)
+                .err()
+        }
+        Dispatch::Saturated(job) => Some(job),
+    };
+
+    let Some(declined) = declined else {
+        return call
+            .await_reply(result_rx)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("pooled instance produced no message response in time"))?
+            .map_err(|_| anyhow::anyhow!("pooled instance dropped the message response"));
+    };
+
+    // Every instance was busy and the pool is full, so run the very same job in
+    // a store of its own.
+    let InstanceJob::Messaging(job) = declined else {
+        anyhow::bail!("instance pool returned the wrong job kind for a message");
+    };
+    tracing::debug!(component_id, "warm instances saturated; own store");
+
+    let mut store = workload.new_store(component_id).await?;
+    crate::engine::waive_fuel_limit(&mut store);
+    let instance = pre.instantiate_async(&mut store).await?;
+    let handler = Arc::new(
+        crate::host::trigger_service::AsyncMessaging::new(&mut store, &instance).map_err(|e| {
+            anyhow::anyhow!("component does not export wasmcloud:messaging/handler@0.3.0: {e:#}")
+        })?,
+    );
+    let MessagingJob {
+        msg,
+        result_tx,
+        abandoned,
+        attributes,
+    } = *job;
+    // Awaited through the same `DispatchedCall` the pooled path uses: `arm_after`
+    // runs inside `await_reply`, so a cold delivery that skipped it would be
+    // unbounded while looking bounded. No pool slot — the store goes when this
+    // future is dropped, which is what ends the guest's work.
+    let task = MessagingTask {
+        handler,
+        msg,
+        result_tx,
+        abandoned,
+        attributes,
+        pool_slot: None,
+    };
+    // Two unwraps, not one: the outer is `run_concurrent` faulting, the inner
+    // the task's own trap.
+    call.await_reply(store.run_concurrent(async move |accessor| {
+        wasmtime::component::AccessorTask::run(task, accessor).await
+    }))
+    .await
+    .ok_or_else(|| anyhow::anyhow!("delivery produced no message response in time"))?
+    .map_err(|e| anyhow::anyhow!("{e:#}"))?
+    .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    result_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("delivery task dropped the message response"))
+}
+
+/// The WIT export a delivery invokes, and what its measurements are grouped by.
+/// Bounded by the interface set, so it is safe as a metric attribute — unlike
+/// the concrete subject, which stays on the span and the logs.
+///
+/// One string for every backend and both delivery shapes, so a dashboard reads
+/// a service's deliveries and a pooled component's as the same operation.
+pub(crate) const MESSAGING_OPERATION: &str = "wasmcloud:messaging/handler#handle-message";
+
 /// Mint a `stream<u8>` carrying `bytes`, for handing a message body to a guest.
 pub(crate) fn mint_body<T, D>(
     accessor: &wasmtime::component::Accessor<T, D>,
@@ -247,6 +393,55 @@ where
 /// is written once here.
 macro_rules! messaging_handler_dispatch {
     (sync: $sync:ident, async: $async:ident $(,)?) => {
+        /// A component's messaging handler, resolved once where the
+        /// subscription is set up rather than once per message.
+        ///
+        /// Both halves come from the same `InstancePre`: `pre` is the
+        /// revision-typed view the per-message store path calls through, and
+        /// `instance_pre` is what the instance pool instantiates a warm
+        /// instance from — the pool binds its own typed view.
+        struct HandlerTarget {
+            handler: HandlerPre,
+            instance_pre: wasmtime::component::InstancePre<$crate::engine::ctx::SharedCtx>,
+        }
+
+        impl HandlerTarget {
+            fn new(
+                instance_pre: wasmtime::component::InstancePre<$crate::engine::ctx::SharedCtx>,
+            ) -> wasmtime::Result<Self> {
+                Ok(Self {
+                    handler: HandlerPre::new(instance_pre.clone())?,
+                    instance_pre,
+                })
+            }
+
+            /// Whether this component exports the async `@0.3.0` handler, the
+            /// only revision a pooled instance can serve: its call takes an
+            /// `Accessor`, so deliveries share one instance up to
+            /// `max_concurrency`. The sync `@0.2.0` export holds `&mut Store`
+            /// for the length of its call and keeps its per-message store.
+            fn serves_async(&self) -> bool {
+                matches!(self.handler, HandlerPre::V0_3(_))
+            }
+
+            /// What the instance pool instantiates a warm instance from. The
+            /// pool binds its own typed view over the result, so this is the
+            /// raw pre rather than the revision-typed one.
+            fn instance_pre(
+                &self,
+            ) -> &wasmtime::component::InstancePre<$crate::engine::ctx::SharedCtx> {
+                &self.instance_pre
+            }
+
+            /// Instantiate for one message, on the per-message store path.
+            async fn instantiate(
+                &self,
+                store: &mut wasmtime::Store<$crate::engine::ctx::SharedCtx>,
+            ) -> wasmtime::Result<HandlerProxy> {
+                self.handler.instantiate(store).await
+            }
+        }
+
         /// A pre-instantiated messaging handler component, at whichever revision
         /// of `wasmcloud:messaging/handler` it exports.
         enum HandlerPre {
@@ -367,10 +562,13 @@ pub(crate) use messaging_handler_dispatch;
 /// What an unset per-component ceiling resolves to **when pooling is
 /// disabled**: how many messages one component may process at once.
 ///
-/// A messaging-triggered component gets a fresh instance per message, so this
-/// is equally a ceiling on instances. 32 of a Componentize-Go component (the
-/// worst measured shape, at 5 core instances each) is 160 core instances —
-/// a bound on one workload's blast radius.
+/// A messaging-triggered component that declared no `poolSize` gets a fresh
+/// instance per message, so for those this is equally a ceiling on instances.
+/// 32 of a Componentize-Go component (the worst measured shape, at 5 core
+/// instances each) is 160 core instances — a bound on one workload's blast
+/// radius. A component that *did* declare `poolSize` is bounded by that
+/// instead: its deliveries run on warm instances, and only the ones arriving
+/// once every instance is busy build a store of their own.
 ///
 /// On a pooled host this constant does not apply: `per_component_ceiling`
 /// divides whatever host total is in force, so the number moves with the pool

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -508,9 +508,9 @@ impl HostPlugin for NatsMessaging {
         // pre-instantiate; its receive loop delivers to the running service
         // instead. Only components get a `MessagingPre` for per-message work.
         let pre = match workload.instantiate_pre(component_id).await {
-            Ok(instance_pre) => {
-                Some(HandlerPre::new(instance_pre).context("failed to instantiate messaging pre")?)
-            }
+            Ok(instance_pre) => Some(
+                HandlerTarget::new(instance_pre).context("failed to instantiate messaging pre")?,
+            ),
             Err(e) => {
                 trace!(component_id, error = %e, "no per-message instance (long-lived service); messages delivered to the service");
                 None
@@ -573,6 +573,13 @@ impl HostPlugin for NatsMessaging {
 
         let mut messages = futures::stream::select_all(subscriptions);
         let fuel_meter = self.meters.read().await.fuel_consumption.clone();
+        // What a pooled delivery is measured under, built once here rather
+        // than per message. Both are bounded by what is deployed; the subject a
+        // message carries is not, so it stays on the span and the log line.
+        let attributes = vec![
+            KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
+            KeyValue::new("operation", super::MESSAGING_OPERATION),
+        ];
 
         let span = tracing::Span::current();
         let handle = tokio::spawn(async move {
@@ -617,7 +624,11 @@ impl HostPlugin for NatsMessaging {
                             };
                             match workload
                                 .http_handler()
-                                .deliver_trigger_service_message(workload.id(), broker)
+                                .deliver_trigger_service_message(
+                                    workload.id(),
+                                    broker,
+                                    attributes.clone(),
+                                )
                                 .await
                             {
                                 Ok(Ok(())) => debug!(%subject, "trigger service handled message"),
@@ -640,10 +651,13 @@ impl HostPlugin for NatsMessaging {
                             continue;
                         };
 
-                        // Admission. Taken BEFORE the store and instance are
-                        // built and held until the handler returns, so permits
-                        // held and instances alive are the same number and the
-                        // ceiling is structural rather than advisory.
+                        // Admission. Taken BEFORE any store or instance is
+                        // built and held until the handler returns, so the
+                        // ceiling is structural rather than advisory. For a
+                        // component with no pool it is equally a ceiling on
+                        // instances, one per permit; for a pooled one the
+                        // instance count is bounded by `poolSize` and only the
+                        // deliveries past it build stores of their own.
                         //
                         // Waiting here stops us draining the subscription.
                         // That cannot back up the socket or endanger the shared
@@ -693,6 +707,55 @@ impl HostPlugin for NatsMessaging {
                             }
                         };
 
+                        let span = tracing::span!(
+                            tracing::Level::INFO,
+                            "incoming_wasmcloud_message",
+                            subject = %subject,
+                            reply_to = %reply_to.as_deref().unwrap_or("<none>"),
+                        );
+
+                        // An async `@0.3.0` handler on a component that opted
+                        // into pooling is served on a warm instance, honouring
+                        // the `poolSize`, `maxInvocations` and `maxConcurrency`
+                        // it declared. Everything else keeps a store per
+                        // message: without a pool there is nothing to reuse,
+                        // and the sync `@0.2.0` call holds `&mut Store` so it
+                        // could not share an instance anyway.
+                        let pool = if pre.serves_async() {
+                            workload.instance_pool_for_component(&component_id).await
+                        } else {
+                            None
+                        };
+
+                        if let Some(pool) = pool {
+                            let msg = crate::host::trigger_service::BrokerMessage {
+                                subject,
+                                body,
+                                reply_to,
+                            };
+                            let attributes = attributes.clone();
+                            let workload = workload.clone();
+                            let component_id = component_id.clone();
+                            let instance_pre = pre.instance_pre().clone();
+                            tokio::spawn(async move {
+                                // Released on completion, trap or not — which
+                                // is what frees the slot this message holds.
+                                let _permit = permit;
+                                let result = super::deliver_pooled(
+                                    &workload,
+                                    &component_id,
+                                    &instance_pre,
+                                    &pool,
+                                    msg,
+                                    attributes,
+                                )
+                                .instrument(span)
+                                .await;
+                                super::log_delivery(&result);
+                            });
+                            continue;
+                        }
+
                         let mut store = match workload.new_store(&component_id).await {
                             Err(e) => {
                                 warn!("failed to create store for component {component_id}: {e}");
@@ -712,13 +775,6 @@ impl HostPlugin for NatsMessaging {
                             reply_to,
                             body,
                         };
-
-                        let span = tracing::span!(
-                            tracing::Level::INFO,
-                            "incoming_wasmcloud_message",
-                            subject = %msg.subject,
-                            reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"),
-                        );
 
                         let fuel_meter = fuel_meter.clone();
 
@@ -755,14 +811,7 @@ impl HostPlugin for NatsMessaging {
                                 }
                             ).await;
 
-                            match result {
-                                Ok(_) => {
-                                    debug!("Message handled successfully");
-                                }
-                                Err(e) => {
-                                    warn!("Error handling message: {e}");
-                                }
-                            };
+                            super::log_delivery(&result);
                         });
                     }
                     _ = cancel_token.cancelled() => {

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -15,6 +15,7 @@ use tracing::{Instrument, debug, error, warn};
 
 use crate::engine::instance_driver::InstanceJob;
 use crate::engine::instance_pool::{ComponentInstance, Dispatch};
+use crate::engine::waive_fuel_limit;
 use crate::engine::workload::ResolvedWorkload;
 use crate::observability::ExecutionTimeMeter;
 use crate::wasmtime::component::{Accessor, InstancePre, Resource};
@@ -479,21 +480,6 @@ impl WarmSets {
         }
         Arc::new(sets)
     }
-}
-
-/// Waives the fuel limit on a fresh store, so nothing on this path is metered
-/// or bounded by fuel.
-///
-/// This plugin measures guest execution by sampling the epoch callback
-/// ([`crate::observability::ExecutionTimeMeter`]); it never reads a fuel
-/// counter and never bounds a call by one. The engine underneath it may still
-/// have fuel *enabled* — `--enable-meters` turns it on for the paths that do
-/// measure by it, and it is an engine-wide switch. A store on a fuel-enabled
-/// engine starts at **zero** and instantiation runs guest code, so without this
-/// the component traps on instantiate. Errors when fuel is off, which is the
-/// ordinary case and not a failure.
-fn waive_fuel_limit<T>(store: &mut crate::wasmtime::Store<T>) {
-    let _ = store.set_fuel(u64::MAX);
 }
 
 /// How long an unsettled sequence holds a rebuild back before the loop stops

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -611,6 +611,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "messaging-sleeper-p3"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "msg-counter"
 version = "0.0.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "nats-implements-p3",
     "messaging-echo",
     "messaging-echo-p3",
+    "messaging-sleeper-p3",
     "messaging-dual-handler",
     "inter-component-call-caller",
     "inter-component-call-callee",

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/messaging_sleeper_p3.wasm

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "messaging-sleeper-p3"
+edition = "2024"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/src/bindings.rs
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/src/bindings.rs
@@ -1,0 +1,2 @@
+#![allow(unsafe_code)]
+wit_bindgen::generate!({ world: "msg-sleeper-p3", generate_all });

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/src/lib.rs
@@ -1,0 +1,113 @@
+//! A `wasmcloud:messaging@0.3.0` handler that awaits instead of computing, with
+//! the cost split the way a real I/O-bound guest splits it.
+//!
+//! The messaging counterpart of the `http-sleeper` fixture, and the same
+//! reasoning applies. `SETUP_NANOS` is paid **once per instance**, standing in
+//! for what a guest builds on first use and then keeps: a connection pool, an
+//! authenticated session, a lazily built runtime. The per-delivery sleep — the
+//! milliseconds the message body names — stands in for the work itself. That
+//! split is what makes instance reuse measurable: a delivery the warm set
+//! cannot take is served from a store of its own and sleeps in parallel anyway,
+//! so wall clock says nothing, while a setup charged per instance says exactly
+//! what reuse saved.
+//!
+//! Three counters leave the guest through `wasi:http/handler`:
+//!
+//!   - `msg_peak`: the most deliveries this instance ever had in flight at
+//!     once. An instance serving one at a time reports 1 however hard it is
+//!     driven, so a value above 1 can only come from `maxConcurrency`.
+//!   - `msg_served`: how many deliveries this instance has handled. A fresh
+//!     instance starts over at zero, so a value that climbs is reuse.
+//!   - `served`: how many HTTP probes it has answered. A probe is a call on the
+//!     same pool and spends the same `maxInvocations` budget, so a count
+//!     restarting at one is a replacement instance.
+//!
+//! The HTTP handler neither sleeps nor touches the messaging counters, so
+//! reading them cannot perturb what it is reading.
+
+mod bindings;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::exports::wasmcloud::messaging::handler::Guest as MsgGuest;
+use bindings::wasi::clocks::monotonic_clock;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::wasmcloud::messaging::types::{BrokerMessage, HandleMessageError};
+
+/// Paid once per instance, on its first delivery: what a guest sets up and
+/// keeps.
+const SETUP_NANOS: u64 = 100_000_000; // 100ms
+/// What a delivery sleeps when its body names no duration.
+const DEFAULT_DELIVERY_NANOS: u64 = 5_000_000; // 5ms
+
+static SETUP_DONE: AtomicBool = AtomicBool::new(false);
+static MSG_IN_FLIGHT: AtomicU64 = AtomicU64::new(0);
+static MSG_PEAK_IN_FLIGHT: AtomicU64 = AtomicU64::new(0);
+static MSG_SERVED: AtomicU64 = AtomicU64::new(0);
+/// HTTP probes this instance has answered, this one included.
+static SERVED: AtomicU64 = AtomicU64::new(0);
+
+struct Component;
+
+impl MsgGuest for Component {
+    async fn handle_message(msg: BrokerMessage) -> Result<(), HandleMessageError> {
+        // Drain the body first: it names how long to sleep, and a reader left
+        // undrained holds the host's end of the stream open.
+        let body = msg.body.collect().await;
+        let sleep_nanos = match std::str::from_utf8(&body)
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+        {
+            Some(millis) => millis.saturating_mul(1_000_000),
+            None => DEFAULT_DELIVERY_NANOS,
+        };
+
+        MSG_SERVED.fetch_add(1, Ordering::SeqCst);
+        let now = MSG_IN_FLIGHT.fetch_add(1, Ordering::SeqCst) + 1;
+        MSG_PEAK_IN_FLIGHT.fetch_max(now, Ordering::SeqCst);
+
+        // First delivery on this instance pays to set up what the instance then
+        // keeps. A reused instance skips it; a fresh one never can.
+        if !SETUP_DONE.swap(true, Ordering::SeqCst) {
+            monotonic_clock::wait_for(SETUP_NANOS).await;
+        }
+
+        // Yield to the instance's executor. Anything else spawned on this
+        // instance runs while this delivery is parked here — which is the whole
+        // point of the exercise.
+        monotonic_clock::wait_for(sleep_nanos).await;
+
+        MSG_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let served = SERVED.fetch_add(1, Ordering::SeqCst) + 1;
+        let msg_peak = MSG_PEAK_IN_FLIGHT.load(Ordering::SeqCst);
+        let msg_served = MSG_SERVED.load(Ordering::SeqCst);
+        let body = format!(
+            "{{\"msg_peak\":{msg_peak},\"msg_served\":{msg_served},\"served\":{served}}}"
+        );
+        Ok(make_response(200, body.into_bytes()))
+    }
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(&"content-type".to_string(), &[b"application/json".to_vec()]);
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/wit/world.wit
@@ -1,0 +1,25 @@
+package wasmcloud:msg-sleeper-p3;
+
+/// The messaging counterpart of `http-sleeper`: a `wasmcloud:messaging@0.3.0`
+/// handler that *awaits* rather than computes, so per-instance concurrency is
+/// measurable. A handler that returned immediately would have nothing to
+/// overlap, and could not tell a concurrent instance from a serial one.
+///
+/// `wasi:http/handler` is how the counters leave the guest. It is a reporting
+/// surface only — it neither sleeps nor touches the messaging counters, so
+/// reading them cannot perturb them. It does count its own calls, because a
+/// probe is a call on the same pool and consumes the same `maxInvocations`
+/// budget; a test needs to see that.
+///
+/// Deliberately a fixture of its own rather than another export on
+/// `http-sleeper`: that one is started as a *service* by other tests, and a
+/// component exporting a messaging handler takes a different validation path
+/// there — it would be required to export `wasi:cli/run` as well.
+world msg-sleeper-p3 {
+    import wasi:http/types@0.3.0;
+    import wasi:clocks/types@0.3.0;
+    import wasi:clocks/monotonic-clock@0.3.0;
+
+    export wasi:http/handler@0.3.0;
+    export wasmcloud:messaging/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/messaging-sleeper-p3/wkg.toml
@@ -1,0 +1,8 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"wasmcloud:messaging" = { path = "../p3-wit-deps/wasmcloud-messaging-0.3.0" }

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -545,6 +545,7 @@ async fn deliver(
                 body: b"hi".to_vec(),
                 reply_to: None,
             },
+            Vec::new(),
         )
         .await
 }

--- a/crates/wash-runtime/tests/integration_messaging_concurrency.rs
+++ b/crates/wash-runtime/tests/integration_messaging_concurrency.rs
@@ -1,0 +1,354 @@
+//! A messaging-triggered component honours the instance limits it declares.
+//!
+//! `poolSize`, `maxConcurrency` and `maxInvocations` mean the same thing here
+//! as they do for inbound HTTP: deliveries run on warm instances, several at a
+//! time on one instance when the component asks for it, and an instance retires
+//! at its invocation budget. Every one of them defaults to the conservative
+//! value, so a limit that fails to reach the pool looks exactly like a limit
+//! that reached it and was honoured — which is what these pin down.
+//!
+//! These are the messaging counterparts of `integration_instance_concurrency`.
+//! The `messaging-sleeper-p3` fixture is that suite's `http-sleeper` with the
+//! trigger swapped: its `wasmcloud:messaging/handler@0.3.0` parks on the clock
+//! for the milliseconds the body names, and keeps `msg_peak` (the most
+//! deliveries this instance had in flight at once) and `msg_served` (how many
+//! it has handled) in its own linear memory. Both are reported over its HTTP
+//! handler, which is what makes them readable: a probe is a call on the same
+//! pool, so it lands on the instance the deliveries ran on — and a *fresh*
+//! instance reports zeroes, which is how reuse shows.
+//!
+//! Every case publishes, waits out the delivery, and only then probes. Polling
+//! while deliveries are in flight would be answered by whatever store the pool
+//! could spare rather than by the instance under test, so the counters would
+//! depend on timing rather than on the limits.
+//!
+//! Only `@0.3.0` is covered because only `@0.3.0` can be pooled: its
+//! `handle-message` is an `async func` taking an `Accessor`, so deliveries
+//! overlap on one instance. The sync `@0.2.0` export holds `&mut Store` for the
+//! length of its call and keeps its store per message.
+//!
+//! The in-memory backend is used, so these need no Docker and run in the
+//! default CI leg.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+use wash_runtime::engine::Engine;
+use wash_runtime::host::http::{DevRouter, Ingress};
+use wash_runtime::host::{HostApi, HostBuilder};
+use wash_runtime::plugin::wasmcloud_messaging::InMemoryMessaging;
+use wash_runtime::plugin::{
+    wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig, wasi_keyvalue::InMemoryKeyValue,
+    wasi_logging::TracingLogger,
+};
+use wash_runtime::types::{Component, LocalResources, Workload, WorkloadStartRequest};
+use wash_runtime::wit::WitInterface;
+
+mod common;
+use common::{http_only_host_interfaces, json_u64_field};
+
+const MSG_SLEEPER_WASM: &[u8] = include_bytes!("wasm/messaging_sleeper_p3.wasm");
+
+/// How long each delivery parks, in the body the fixture parses. Long enough
+/// that a burst is still in flight when the last of it arrives, short enough
+/// not to pad the suite.
+const DELIVERY_MILLIS: u64 = 300;
+
+/// What [`Harness::settle`] waits: several times a delivery, plus room for the
+/// fixture's one-off per-instance setup. Deliveries are spawned rather than
+/// awaited by the publisher, and there is nothing else to synchronise on.
+const SETTLE: Duration = Duration::from_millis(2_500);
+
+/// What the fixture reports about the instance that answered the probe.
+#[derive(Debug, Clone, Copy)]
+struct Counters {
+    /// Deliveries this instance had in flight at once, at its highest.
+    msg_peak: u64,
+    /// Deliveries this instance has handled.
+    msg_served: u64,
+    /// HTTP requests this instance has served, this probe included.
+    served: u64,
+}
+
+struct Harness<H: HostApi> {
+    _host: Arc<H>,
+    addr: std::net::SocketAddr,
+    messaging: Arc<InMemoryMessaging>,
+    workload_id: String,
+    host_header: &'static str,
+    subject: &'static str,
+    client: reqwest::Client,
+}
+
+/// Start the sleeper as a *component* (not a service) subscribed to `subject`,
+/// with the instance limits under test.
+async fn start_msg_sleeper(
+    host_header: &'static str,
+    subject: &'static str,
+    pool_size: i32,
+    max_concurrency: i32,
+    max_invocations: i32,
+) -> Result<Harness<impl HostApi>> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    let engine = Engine::builder().build()?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
+    let messaging = Arc::new(InMemoryMessaging::new());
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(ingress))
+        .with_plugin(Arc::new(InMemoryBlobstore::new(None)))?
+        .with_plugin(Arc::new(InMemoryKeyValue::new()))?
+        .with_plugin(Arc::new(TracingLogger::default()))?
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .with_plugin(messaging.clone())?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+
+    // Both host interfaces: messaging delivers the work, HTTP is how the
+    // per-instance counters are read back.
+    let mut host_interfaces = http_only_host_interfaces(host_header);
+    host_interfaces.push(WitInterface {
+        namespace: "wasmcloud".to_string(),
+        package: "messaging".to_string(),
+        interfaces: ["handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::new(0, 3, 0)),
+        config: HashMap::from([("subscriptions".to_string(), subject.to_string())]),
+        name: None,
+    });
+
+    let workload_id = uuid::Uuid::new_v4().to_string();
+    host.workload_start(WorkloadStartRequest {
+        workload_id: workload_id.clone(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: host_header.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "sleeper".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(MSG_SLEEPER_WASM),
+                local_resources: LocalResources {
+                    config: HashMap::from([("subscriptions".to_string(), subject.to_string())]),
+                    ..Default::default()
+                },
+                pool_size,
+                max_invocations,
+                max_concurrency,
+                ..Default::default()
+            }],
+            host_interfaces,
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("sleeper workload should start")?;
+
+    Ok(Harness {
+        _host: host,
+        addr,
+        messaging,
+        workload_id,
+        host_header,
+        subject,
+        client: reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .timeout(Duration::from_secs(20))
+            .build()?,
+    })
+}
+
+impl<H: HostApi> Harness<H> {
+    async fn publish(&self) -> Result<()> {
+        self.messaging
+            .publish(
+                &self.workload_id,
+                self.subject,
+                DELIVERY_MILLIS.to_string().into_bytes(),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("publish failed: {e}"))
+    }
+
+    /// Publish `n` messages back to back, so their deliveries overlap.
+    async fn publish_burst(&self, n: usize) -> Result<()> {
+        for _ in 0..n {
+            self.publish().await?;
+        }
+        Ok(())
+    }
+
+    /// Wait for every delivery in flight to finish, so the next probe is
+    /// answered by an idle instance rather than by a store the pool spared.
+    async fn settle(&self) {
+        tokio::time::sleep(SETTLE).await;
+    }
+
+    /// One HTTP request, reporting what the instance that served it has done.
+    ///
+    /// The probe is itself a call on the pool: it takes a warm instance when
+    /// one is free, and counts against `max_invocations` like any other call.
+    async fn probe(&self) -> Result<Counters> {
+        let resp = self
+            .client
+            .get(format!("http://{}/", self.addr))
+            .header("HOST", self.host_header)
+            .send()
+            .await?;
+        anyhow::ensure!(resp.status().is_success(), "status {}", resp.status());
+        let body = resp.text().await?;
+        Ok(Counters {
+            msg_peak: json_u64_field(&body, "msg_peak"),
+            msg_served: json_u64_field(&body, "msg_served"),
+            served: json_u64_field(&body, "served"),
+        })
+    }
+}
+
+/// The default. One warm instance, `max_concurrency` unset: it takes one
+/// delivery at a time and the rest of the burst is served from stores of their
+/// own, so no instance ever sees two at once.
+#[tokio::test]
+async fn without_max_concurrency_deliveries_do_not_overlap_on_an_instance() -> Result<()> {
+    let h = start_msg_sleeper("msg-conc-off", "conc.off", 1, 1, 0).await?;
+
+    h.publish_burst(4).await?;
+    h.settle().await;
+
+    let seen = h.probe().await?;
+    assert_eq!(
+        seen.msg_peak, 1,
+        "an instance must serve one delivery at a time unless the component asked \
+         for more, saw {seen:?}"
+    );
+    Ok(())
+}
+
+/// The opt-in. One warm instance with `max_concurrency: 8` takes all four
+/// deliveries at once — all of them on the instance that had already paid its
+/// setup, rather than three of them on fresh stores paying it again.
+#[tokio::test]
+async fn max_concurrency_overlaps_deliveries_on_one_instance() -> Result<()> {
+    let h = start_msg_sleeper("msg-conc-on", "conc.on", 1, 8, 0).await?;
+
+    h.publish_burst(4).await?;
+    h.settle().await;
+
+    let seen = h.probe().await?;
+    assert_eq!(
+        seen.msg_peak, 4,
+        "all four deliveries should have been in flight on the one instance at \
+         once, saw {seen:?}"
+    );
+    assert_eq!(
+        seen.msg_served, 4,
+        "and all four should have been served by it, saw {seen:?}"
+    );
+    Ok(())
+}
+
+/// Concurrency composes with `pool_size` rather than replacing it: two
+/// instances at two deliveries each cover the burst, and neither exceeds its
+/// own limit.
+#[tokio::test]
+async fn concurrency_is_bounded_per_instance() -> Result<()> {
+    let h = start_msg_sleeper("msg-conc-bounded", "conc.bounded", 2, 2, 0).await?;
+
+    h.publish_burst(4).await?;
+    h.settle().await;
+
+    let seen = h.probe().await?;
+    assert!(
+        (1..=2).contains(&seen.msg_peak),
+        "no instance may exceed max_concurrency of 2, saw {seen:?}"
+    );
+    Ok(())
+}
+
+/// The property the configuration claimed and did not have: with `poolSize`
+/// set, a second message reaches the instance the first one warmed, so
+/// everything the guest built in linear memory is still there.
+///
+/// Published one at a time on purpose. A burst beyond `max_concurrency` falls
+/// through to stores of its own, which is the saturation rule rather than the
+/// reuse this is about.
+#[tokio::test]
+async fn pool_size_keeps_guest_state_between_messages() -> Result<()> {
+    let h = start_msg_sleeper("msg-warm", "warm.state", 1, 1, 0).await?;
+
+    h.publish().await?;
+    h.settle().await;
+    let first = h.probe().await?;
+    assert_eq!(
+        first.msg_served, 1,
+        "the first message should have been handled, saw {first:?}"
+    );
+
+    h.publish().await?;
+    h.settle().await;
+    let second = h.probe().await?;
+
+    assert_eq!(
+        second.msg_served, 2,
+        "the second message must reach the instance the first one warmed; a count \
+         stuck at 1 is a fresh instance per message, saw {second:?}"
+    );
+    Ok(())
+}
+
+/// A delivery counts against `max_invocations` like any other call, and the
+/// instance is retired once the budget is spent.
+///
+/// Read through the *HTTP* counter, because a retired instance's own counters
+/// can never be read again — it stops admitting, so the probe that would ask it
+/// is served by its replacement. A replacement counting its requests from one
+/// is the observable consequence, and the control is what gives it meaning:
+/// with no budget the same three calls all land on one instance.
+#[tokio::test]
+async fn a_delivery_counts_against_max_invocations() -> Result<()> {
+    // Control: no budget, so the instance the first probe warms serves the
+    // delivery too and is still there for the second probe.
+    let unlimited = start_msg_sleeper("msg-budget-off", "budget.off", 1, 1, 0).await?;
+    let warmed = unlimited.probe().await?;
+    assert_eq!(
+        warmed.served, 1,
+        "the first probe should have warmed an instance, saw {warmed:?}"
+    );
+    unlimited.publish().await?;
+    unlimited.settle().await;
+    let after = unlimited.probe().await?;
+    assert_eq!(
+        (after.served, after.msg_served),
+        (2, 1),
+        "without a budget both probes and the delivery should be one instance's \
+         work, saw {after:?}"
+    );
+
+    // Two calls apiece. The probe and the delivery spend the budget between
+    // them, so the instance retires and the next probe gets a replacement.
+    let limited = start_msg_sleeper("msg-budget-on", "budget.on", 1, 1, 2).await?;
+    let warmed = limited.probe().await?;
+    assert_eq!(
+        warmed.served, 1,
+        "the first probe should have warmed an instance, saw {warmed:?}"
+    );
+    limited.publish().await?;
+    limited.settle().await;
+    let after = limited.probe().await?;
+
+    assert_eq!(
+        (after.served, after.msg_served),
+        (1, 0),
+        "the delivery should have spent the instance's last invocation, leaving \
+         this probe to a replacement counting from one, saw {after:?}"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
+++ b/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
@@ -93,7 +93,7 @@ async fn deliver(
     };
     timeout(
         Duration::from_secs(10),
-        ingress.deliver_trigger_service_message(workload_id, msg),
+        ingress.deliver_trigger_service_message(workload_id, msg, Vec::new()),
     )
     .await
     .context("deliver_trigger_service_message timed out")?

--- a/runtime-operator/test/e2e/workload_limits_test.go
+++ b/runtime-operator/test/e2e/workload_limits_test.go
@@ -214,11 +214,300 @@ spec:
 	})
 })
 
+// The same limits, arriving over the messaging trigger rather than HTTP.
+//
+// Worth a spec of its own because the two triggers reach the pool by different
+// routes: an HTTP request arrives at the gateway and is dispatched by the host's
+// own ingress, while a message arrives at the NatsMessaging plugin's
+// subscription loop, which has its own admission gate (`max_in_flight`) in front
+// of the pool. A limit that survives one path is no evidence it survives the
+// other, and the failure mode is again invisible — `maxConcurrency` unset looks
+// exactly like `maxConcurrency` dropped in transit.
+//
+// Only the async `@0.3.0` handler can be pooled at all: its `handle-message` is
+// an `async func`, so deliveries overlap on one instance. The `@0.2.0` handler
+// holds the store for the length of its call and keeps an instance per message,
+// which is why this spec pins the version explicitly.
+//
+// The fixture (messaging-sleeper-p3) is http-sleeper with the trigger swapped:
+// its messaging handler parks on the clock for the milliseconds the body names,
+// and reports the two counts that make the limits observable from outside the
+// cluster, both timing-independent:
+//
+//   - `msg_peak`: the most deliveries this instance ever had in flight at once.
+//     An instance serving one at a time reports 1 however hard it is driven, so
+//     a value above 1 can only come from `maxConcurrency` arriving.
+//   - `msg_served`: how many it has handled. A fresh instance starts at zero, so
+//     a count that carries across two rounds is one instance serving both —
+//     which is `poolSize` arriving.
+//
+// `maxInvocations` is deliberately not asserted here. Reading a counter means
+// probing the instance that holds it, and an instance retired by its budget is
+// exactly the one that can no longer answer; the budget is set high enough to
+// stay out of the way. That a delivery spends the budget at all is covered in
+// process by integration_messaging_concurrency.rs, which reads the consequence
+// (a replacement counting from one) rather than the retired instance.
+//
+// Needs the in-cluster registry and NATS; self-skips otherwise.
+var _ = Describe("Workload Messaging Limits", Ordered, func() {
+	const (
+		workloadName = "messaging-sleeper-p3"
+		fixture      = "messaging-sleeper-p3"
+		workloadHost = "messaging-sleeper.localhost.direct"
+		subject      = "test.limits.p3"
+
+		poolSize       = 1
+		maxConcurrency = 4
+		// Above every call this spec makes — two bursts plus its probes — so
+		// the instance is never retired mid-spec. A budget below that would
+		// retire the very instance whose counters the probes have to read, and
+		// every probe after it would be answered by a replacement reporting
+		// zeroes.
+		maxInvocations = 40
+
+		// Deliveries per round. Above maxConcurrency, so the instance is driven
+		// past its own bound and the excess falls through to stores of its own.
+		burst = 8
+		// What the fixture parks for, in the message body it parses. Long
+		// enough that the whole burst is still in flight when the last of it
+		// arrives.
+		deliveryMillis = "300"
+	)
+
+	var fixtureImage string
+
+	BeforeAll(func() {
+		if !inClusterRegistry {
+			Skip("skipping messaging limits e2e (needs the in-cluster registry)")
+		}
+		fixtureImage = registryRef(fixture)
+	})
+
+	AfterEach(func() {
+		if !CurrentSpecReport().Failed() {
+			return
+		}
+		dump := func(label string, args ...string) {
+			out, err := utils.Run(exec.Command("kubectl", args...))
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s ===\n%s\n", label, out)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s (FAILED: %s) ===\n", label, err)
+			}
+		}
+		dump("Workload CRs", "get", "workloads.runtime.wasmcloud.dev",
+			"-n", namespace, "-o", "yaml")
+		dump("Hostgroup logs", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=hostgroup", "--tail=400", "--prefix=true")
+	})
+
+	AfterAll(func() {
+		if fixtureImage == "" {
+			return
+		}
+		_ = exec.Command("kubectl", "delete", "workloaddeployment", workloadName,
+			"-n", namespace, "--ignore-not-found=true").Run()
+		// publishBurst names its pod per round; a spec failing between apply
+		// and its own delete would otherwise leak one into the namespace.
+		for round := 0; round < 2; round++ {
+			_ = exec.Command("kubectl", "delete", "pod",
+				fmt.Sprintf("nats-limits-pub-%d", round),
+				"-n", namespace, "--ignore-not-found=true").Run()
+		}
+	})
+
+	It("carries a component's declared limits through to messaging deliveries", func() {
+		By("deploying a messaging-triggered workload declaring every instance limit")
+		// Both host interfaces: messaging delivers the work, HTTP is how the
+		// per-instance counters are read back out of the cluster.
+		manifest := fmt.Sprintf(`apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          version: "0.3.0"
+          interfaces:
+            - handler
+          config:
+            host: %s
+        - namespace: wasmcloud
+          package: messaging
+          version: "0.3.0"
+          interfaces:
+            - handler
+          config:
+            subscriptions: "%s"
+      components:
+        - name: %s
+          image: %s
+          poolSize: %d
+          maxConcurrency: %d
+          maxInvocations: %d
+`, workloadName, namespace, workloadHost, subject, fixture, fixtureImage,
+			poolSize, maxConcurrency, maxInvocations)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(manifest)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply the WorkloadDeployment")
+
+		By("waiting for the WorkloadDeployment to become Ready")
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get", "workloaddeployment",
+				workloadName, "-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("True"))
+		}).WithTimeout(3 * time.Minute).Should(Succeed())
+
+		By("waiting for the workload to serve HTTP, so the counters are readable")
+		Eventually(func(g Gomega) {
+			_, err := probeOnce(workloadHost)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).WithTimeout(2 * time.Minute).Should(Succeed())
+
+		By("publishing bursts of messages and reading what the instance reports")
+		// Two rounds, each proving itself: the burst spends the instance's
+		// budget, so the second round can only report anything if the pool
+		// retired that instance and built a replacement.
+		peak, served := 0, 0
+		for round := 0; round < 2; round++ {
+			publishBurst(subject, burst, deliveryMillis, round)
+
+			// Deliveries are spawned rather than awaited by the publisher, so
+			// poll rather than sleeping a guessed interval. A probe arriving
+			// while the burst is still in flight is answered by a store of its
+			// own and reports zeroes, which is what the retry is for.
+			roundPeak, roundServed := 0, 0
+			Eventually(func(g Gomega) {
+				reply, err := probeOnce(workloadHost)
+				g.Expect(err).NotTo(HaveOccurred())
+				if reply.MsgPeak > roundPeak {
+					roundPeak = reply.MsgPeak
+				}
+				if reply.MsgServed > roundServed {
+					roundServed = reply.MsgServed
+				}
+				g.Expect(roundPeak).To(BeNumerically(">", 0),
+					"no delivery has been observed in round %d", round)
+			}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+			if roundPeak > peak {
+				peak = roundPeak
+			}
+			if roundServed > served {
+				served = roundServed
+			}
+		}
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"observed msg_peak=%d msg_served=%d\n", peak, served)
+
+		By("verifying maxConcurrency arrived on the messaging path")
+		// Without it an instance takes one delivery at a time and reports 1
+		// however hard it is driven, so this separates "the limit reached the
+		// runtime" from "the limit was dropped somewhere on this path".
+		Expect(peak).To(BeNumerically(">", 1),
+			"no instance ever overlapped deliveries — maxConcurrency did not reach "+
+				"the messaging path")
+
+		By("verifying maxConcurrency is also a bound")
+		Expect(peak).To(BeNumerically("<=", maxConcurrency),
+			"an instance exceeded maxConcurrency on the messaging path")
+
+		By("verifying poolSize arrived, so deliveries reuse an instance")
+		// A fresh instance starts at zero, so a count carrying past one round's
+		// worth is the second round landing on the instance the first warmed.
+		// Per-message instances — the behaviour before deliveries reached the
+		// pool — could never report more than one.
+		Expect(served).To(BeNumerically(">", maxConcurrency),
+			"no instance served more than a single round's deliveries — poolSize "+
+				"did not reach the messaging path")
+	})
+})
+
+// publishBurst publishes `count` messages carrying `body` to `subject` from a
+// one-shot nats-box pod against the in-cluster NATS service.
+//
+// `nats pub --count` sends them back to back, which is enough for the
+// deliveries to overlap: the host spawns a task per received message and each
+// one parks on the clock for the body's worth of milliseconds.
+func publishBurst(subject string, count int, body string, round int) {
+	name := fmt.Sprintf("nats-limits-pub-%d", round)
+	_ = exec.Command("kubectl", "delete", "pod", name,
+		"-n", namespace, "--ignore-not-found=true").Run()
+
+	// As in the messaging round-trip spec: the chart enables TLS + mTLS by
+	// default, so the pod mounts the cluster-generated data-plane cert secret
+	// and passes the cert / key / CA to the nats CLI. The volume is optional so
+	// this still runs if someone disables TLS by helm override.
+	//
+	// A flow sequence with every argument quoted, because `command` is a
+	// []string and an unquoted body of digits is a YAML *number* — which the
+	// API server refuses to unmarshal into one.
+	pod := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nats
+      image: natsio/nats-box:latest
+      command: [
+        "nats", "--server=nats://nats:4222",
+        "--tlsca=/data-cert/ca.crt",
+        "--tlscert=/data-cert/tls.crt",
+        "--tlskey=/data-cert/tls.key",
+        "pub", "--count=%d", %q, %q
+      ]
+      volumeMounts:
+        - name: data-cert
+          mountPath: /data-cert
+          readOnly: true
+  volumes:
+    - name: data-cert
+      secret:
+        secretName: wasmcloud-data-tls
+        optional: true
+`, name, namespace, count, subject, body)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(pod)
+	_, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "failed to create the nats publisher pod")
+
+	Eventually(func(g Gomega) {
+		out, err := utils.Run(exec.Command("kubectl", "get", "pod", name,
+			"-n", namespace, "-o", "jsonpath={.status.phase}"))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(strings.TrimSpace(out)).To(Equal("Succeeded"))
+	}).WithTimeout(2*time.Minute).Should(Succeed(),
+		"the nats publisher pod did not complete")
+
+	_ = exec.Command("kubectl", "delete", "pod", name,
+		"-n", namespace, "--ignore-not-found=true").Run()
+}
+
 // sleeperReply is what the http-sleeper fixture reports about the instance that
 // served the request.
 type sleeperReply struct {
 	PeakInFlight int `json:"peak_in_flight"`
 	Served       int `json:"served"`
+	// The same two counts for the messaging trigger, kept separately by the
+	// fixture so a probe (which is itself an HTTP call) cannot be mistaken for
+	// a delivery.
+	MsgPeak   int `json:"msg_peak"`
+	MsgServed int `json:"msg_served"`
 }
 
 // probeOnce sends one request through the gateway to the workload behind host.

--- a/xtask/src/e2e_images.rs
+++ b/xtask/src/e2e_images.rs
@@ -47,6 +47,7 @@ const FIXTURES: &[(&str, FixtureKind)] = &[
     // `wasmcloud:messaging@0.3.0`, so the e2e covers both revisions on a real
     // NATS bus rather than only the sync one.
     ("messaging-echo-p3", FixtureKind::P3),
+    ("messaging-sleeper-p3", FixtureKind::P3),
     ("keyvalue-implements", FixtureKind::P2),
     ("http-handler-p2", FixtureKind::P2),
     // Host component plugin fixtures (P3 async): kv-plugin serves acme:kv/store

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -104,6 +104,7 @@ const P2_FIXTURES: &[&str] = &[
 
 const P3_FIXTURES: &[&str] = &[
     "messaging-echo-p3",
+    "messaging-sleeper-p3",
     "nats-async-handler-p3",
     "nats-implements-p3",
     "messaging-dual-handler",


### PR DESCRIPTION
Closes #5455.

A component invoked by the `wasmcloud:messaging` trigger was instantiated from scratch for every message and never consulted the instance pool, so the `poolSize`, `maxConcurrency` and `maxInvocations` it declared were inert on that path while reading as configured. They were only honored for inbound HTTP and for component-to-component linked calls.

## What changed

`MessagingJob` already had the shape the pool needs. Its body is bytes rather than the `stream<u8>` the WIT carries. The stream is minted inside the invocation, once the store is chosen. This allows the job to be handle-free and can go to whichever instance is free. It becomes a `InstanceJob::Messaging`, and `MessagingTask` grows the `pool_slot` that already lets `HttpTask` serve both a service singleton and a pooled instance. Both messaging backends then dispatch a delivery the way inbound HTTP does.

The driver's `serves_http: bool` becomes a bound-export set. `Service::new` and `AsyncMessaging::new` type-check their export against the live instance and hand back the view every call on it reuses.

## Scope: `@0.3.0` only

Only the async handler can be pooled. `wasmcloud:messaging/handler@0.3.0`'s `handle-message` is an `async func`, so its call takes an `Accessor` and deliveries overlap on one instance; `@0.2.0`'s takes `&mut Store` for the length of its call and cannot share an instance at all.

This also does not change the current saturation policy. A delivery arriving once every instance is busy is served from its own store rather than queued. This means we do not do per-message instantiation and it does not by itself bound concurrency. `max_in_flight` and `admission_wait` remain what bound a component's total, and they still take their permit before any store is built.
