### PR TITLE
Fix guest-execution metering

### DIFF
--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -356,6 +356,13 @@ pub(crate) async fn new_store_from_templates(
     }
 
     let mut store = wasmtime::Store::new(engine, shared_ctx);
+    // A store on a fuel-metering engine starts at zero, and calling a guest
+    // without fuel traps. Fuel here is a counter, never a bound:
+    // `FuelConsumptionMeter::observe` resets it and reads the delta around the
+    // call it measures, and nothing else reads it at all. Giving every store
+    // the maximum is what lets a guest run while its consumption is counted.
+    // Errors when the engine is not metering fuel, which is the ordinary case.
+    let _ = store.set_fuel(u64::MAX);
     // Trap for every store built here, services included: trapping a service
     // means a supervisor restart, which beats carrying a wedged call forever.
     arm_epoch_deadline(&mut store, AbandonedCallPolicy::Trap);

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -1297,20 +1297,6 @@ pub fn exports_messaging_handler(component: &Component) -> bool {
         .any(|(export, _item)| export.starts_with("wasmcloud:messaging/handler"))
 }
 
-/// Waive the fuel limit on a store whose guest execution is measured some other
-/// way.
-///
-/// A store on a fuel-enabled engine starts at **zero** and instantiation runs
-/// guest code, so without this the component traps on instantiate. Fuel is an
-/// engine-wide switch (`--enable-meters` turns it on for the paths that do
-/// measure by it), so a path measuring by the epoch callback instead — see
-/// [`crate::observability::ExecutionTimeMeter`] — has to waive it rather than
-/// assume it is off. Errors when fuel is off, which is the ordinary case and
-/// not a failure.
-pub(crate) fn waive_fuel_limit<T>(store: &mut crate::wasmtime::Store<T>) {
-    let _ = store.set_fuel(u64::MAX);
-}
-
 pub fn imports_wasi_http(component: &Component) -> bool {
     let ty: wasmtime::component::types::Component = component.component_type();
     let engine = component.engine();

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -32,7 +32,7 @@ use crate::engine::abandon::{AbandonFlag, AbandonOnDrop, DispatchedCall};
 use crate::host::allowed_hosts::AllowedHost;
 use crate::host::trigger_service::{BrokerMessage, MessagingJob};
 use crate::{engine::ctx::SharedCtx, observability::Meters};
-use crate::{engine::workload::ResolvedWorkload, observability::FuelConsumptionMeter};
+use crate::{engine::workload::ResolvedWorkload, observability::GuestMeter};
 use anyhow::{Context, ensure};
 use http_body_util::BodyExt;
 use hyper::client::conn::http2;
@@ -1258,7 +1258,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         // Start the HTTP server, any incoming requests call Host::handle and then it's routed
         // to the workload based on host header.
         let handler = self.router.clone();
-        let fuel_meter = self.meters.read().await.fuel_consumption.clone();
+        let guest_meter = self.meters.read().await.guest();
         tokio::spawn(async move {
             if let Err(e) = run_http_server(
                 listener,
@@ -1267,7 +1267,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
                 service_handlers,
                 &mut shutdown_rx,
                 tls_acceptor,
-                fuel_meter,
+                guest_meter,
             )
             .await
             {
@@ -1542,7 +1542,7 @@ async fn run_http_server<T: Router>(
     service_handlers: ServiceHandlers,
     shutdown_rx: &mut mpsc::Receiver<()>,
     tls_acceptor: Option<TlsAcceptor>,
-    fuel_meter: FuelConsumptionMeter,
+    guest_meter: GuestMeter,
 ) -> anyhow::Result<()> {
     loop {
         tokio::select! {
@@ -1563,19 +1563,19 @@ async fn run_http_server<T: Router>(
                         let service_handlers_clone = service_handlers.clone();
                         let tls_acceptor_clone = tls_acceptor.clone();
                         let handler_clone = handler.clone();
-                        let fuel_meter = fuel_meter.clone();
+                        let guest_meter = guest_meter.clone();
                         tokio::spawn(async move {
                             let service = hyper::service::service_fn(move |req| {
                                 let handles = handles_clone.clone();
                                 let service_handlers = service_handlers_clone.clone();
                                 let handler = handler_clone.clone();
-                                let fuel_meter = fuel_meter.clone();
+                                let guest_meter = guest_meter.clone();
                                 async move {
                                     let extractor = opentelemetry_http::HeaderExtractor(req.headers());
                                     let remote_context =
                                         opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&extractor));
 
-                                    handle_http_request(handler, req, handles, service_handlers, fuel_meter).with_context(remote_context).await
+                                    handle_http_request(handler, req, handles, service_handlers, guest_meter).with_context(remote_context).await
                                 }
                             });
 
@@ -1668,7 +1668,7 @@ async fn handle_http_request<T: Router>(
     req: hyper::Request<hyper::body::Incoming>,
     workload_handles: WorkloadHandles,
     service_handlers: ServiceHandlers,
-    fuel_meter: FuelConsumptionMeter,
+    guest_meter: GuestMeter,
 ) -> Result<hyper::Response<HyperOutgoingBody>, hyper::Error> {
     let method = req.method().clone();
     let uri = req.uri().clone();
@@ -1752,7 +1752,7 @@ async fn handle_http_request<T: Router>(
                 workload.namespace = handle.namespace(),
                 workload.id = handle.id(),
             );
-            match invoke_component_handler(handle, instance_pre, &component_id, req, fuel_meter)
+            match invoke_component_handler(handle, instance_pre, &component_id, req, guest_meter)
                 .instrument(req_span)
                 .await
             {
@@ -1966,7 +1966,7 @@ async fn invoke_component_handler(
     instance_pre: InstancePre<SharedCtx>,
     component_id: &str,
     req: hyper::Request<hyper::body::Incoming>,
-    fuel_meter: FuelConsumptionMeter,
+    guest_meter: GuestMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
         let pool = workload_handle
@@ -2040,7 +2040,10 @@ async fn invoke_component_handler(
         let flag = call.flag();
         let (resp, watch) = call
             .await_head(crate::host::http_p3::handle_component_request_p3(
-                cold, req, flag, fuel_meter,
+                cold,
+                req,
+                flag,
+                guest_meter,
             ))
             .await
             .ok_or_else(|| anyhow::anyhow!("cold instance produced no response"))?;
@@ -2060,7 +2063,7 @@ async fn invoke_component_handler(
     // owned by a detached task that outlives the response head, so recovering
     // it for reuse needs a restructure the p3 path did not.
     let store = workload_handle.new_store(component_id).await?;
-    handle_component_request(store, instance_pre, req, fuel_meter).await
+    handle_component_request(store, instance_pre, req, guest_meter).await
 }
 
 /// Handle a component request using WASI HTTP (copied from wash/crates/src/cli/dev.rs)
@@ -2068,7 +2071,7 @@ pub async fn handle_component_request(
     mut store: Store<SharedCtx>,
     pre: InstancePre<SharedCtx>,
     req: hyper::Request<hyper::body::Incoming>,
-    fuel_meter: FuelConsumptionMeter,
+    guest_meter: GuestMeter,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let scheme = match req.uri().scheme() {
@@ -2109,7 +2112,7 @@ pub async fn handle_component_request(
             // Run the http request itself by instantiating and calling the component
             let proxy = pre.instantiate_async(&mut store).await?;
 
-            fuel_meter
+            guest_meter
                 .observe(
                     &[
                         KeyValue::new("plugin", "wasi-http"),

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -10,7 +10,7 @@
 //! [`crate::host::http::OutgoingHandler`] trait via its `send_request_p3` method.
 
 use crate::engine::instance_pool::ComponentInstance;
-use crate::observability::FuelConsumptionMeter;
+use crate::observability::GuestMeter;
 use http_body_util::BodyExt;
 use tracing::Instrument;
 use wasmtime_wasi_http::p3::bindings::Service;
@@ -85,9 +85,11 @@ pub(crate) async fn handle_component_request_p3(
     warm: ComponentInstance,
     req: hyper::Request<hyper::body::Incoming>,
     abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
-    fuel_meter: FuelConsumptionMeter,
+    guest_meter: GuestMeter,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
-    let _ = &fuel_meter; // fuel metering integration deferred to match P2's observe() pattern
+    // Not measured here: this path hands its store to `run_concurrent` and
+    // never holds a `&mut Store` around the call, so it has nothing to wrap.
+    let _ = &guest_meter;
 
     // Convert the hyper request body — map error type since hyper::Error doesn't impl Into<ErrorCode>
     let (parts, body) = req.into_parts();

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -151,11 +151,71 @@ fn directive(directive: impl AsRef<str>) -> anyhow::Result<Directive> {
         .with_context(|| format!("failed to parse filter: {}", directive.as_ref()))
 }
 
+/// How a host measures the time its guests spend running.
+///
+/// The two meters answer the same question and cost very differently, so a host
+/// picks one rather than paying for both:
+///
+/// * [`Self::Epoch`] samples the epoch callback every store arms anyway, so it
+///   costs the guest nothing at run time. It reports whole milliseconds and is
+///   a floor, not a total — see [`crate::engine::abandon::GuestExecution`].
+/// * [`Self::Fuel`] counts executed operations exactly, at the price of a
+///   counter compiled into every block of guest code, which the guest pays
+///   whether or not anyone reads the number.
+///
+/// [`Self::Fuel`] is also the only one that needs anything of the engine:
+/// `Config::consume_fuel` has to be on, and a store on such an engine starts
+/// with no fuel, so guests only run because every store is given a budget.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MeterKind {
+    /// Measure neither. The default: a host that was not asked to measure
+    /// guest execution should not make its guests slower.
+    #[default]
+    Off,
+    /// `guest.execution.time`, sampled from the epoch callback.
+    Epoch,
+    /// `fuel.consumption`, counted in the guest.
+    Fuel,
+}
+
+impl MeterKind {
+    /// Whether the engine has to compile fuel counters into its guests.
+    pub fn consumes_fuel(&self) -> bool {
+        matches!(self, Self::Fuel)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Epoch => "epoch",
+            Self::Fuel => "fuel",
+        }
+    }
+}
+
+impl std::str::FromStr for MeterKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "off" | "none" => Ok(Self::Off),
+            "epoch" => Ok(Self::Epoch),
+            "fuel" => Ok(Self::Fuel),
+            other => Err(format!(
+                "unknown meter `{other}`, expected one of: off, epoch, fuel"
+            )),
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct Meters {
+    /// Built only under [`MeterKind::Fuel`]; inert otherwise, so a call path
+    /// that measures with it records nothing rather than having to ask which
+    /// meter the host chose.
     pub fuel_consumption: FuelConsumptionMeter,
-    /// Sampled rather than burned, for the plugins that ask for it. Both meters
-    /// are built: which one a call path uses is that path's choice.
+    /// Built only under [`MeterKind::Epoch`], and inert otherwise for the same
+    /// reason.
     pub execution_time: ExecutionTimeMeter,
     /// User-defined meters
     pub meters: HashMap<String, Arc<dyn Any + Send + Sync + 'static>>,
@@ -180,10 +240,10 @@ pub fn execution_time_meter() -> Option<&'static ExecutionTimeMeter> {
 }
 
 impl Meters {
-    pub fn new(enabled: bool) -> Self {
+    pub fn new(kind: MeterKind) -> Self {
         let meters = Self {
-            fuel_consumption: FuelConsumptionMeter::new(enabled),
-            execution_time: ExecutionTimeMeter::new(enabled),
+            fuel_consumption: FuelConsumptionMeter::new(kind == MeterKind::Fuel),
+            execution_time: ExecutionTimeMeter::new(kind == MeterKind::Epoch),
             meters: Default::default(),
         };
         // First host with metering on wins. A second one in the same process
@@ -192,7 +252,7 @@ impl Meters {
         // Skipping the disabled ones matters: a host built with metering off
         // would otherwise claim the slot and silence every pooled call after
         // it, including calls on a later host that did ask for metrics.
-        if enabled {
+        if kind == MeterKind::Epoch {
             let _ = EXECUTION_TIME.set(meters.execution_time.clone());
         }
         meters

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -240,6 +240,14 @@ pub fn execution_time_meter() -> Option<&'static ExecutionTimeMeter> {
 }
 
 impl Meters {
+    /// The meter a call path measures through; see [`GuestMeter`].
+    pub fn guest(&self) -> GuestMeter {
+        GuestMeter {
+            fuel: self.fuel_consumption.clone(),
+            execution_time: self.execution_time.clone(),
+        }
+    }
+
     pub fn new(kind: MeterKind) -> Self {
         let meters = Self {
             fuel_consumption: FuelConsumptionMeter::new(kind == MeterKind::Fuel),
@@ -264,7 +272,54 @@ pub struct FuelConsumptionMeter {
     hist: Option<opentelemetry::metrics::Histogram<u64>>,
 }
 
+/// The guest-execution meter a host runs, whichever kind it chose.
+///
+/// A call path that can hand over its `&mut Store` measures through this rather
+/// than naming one of the two meters, so [`MeterKind`] decides *how* the
+/// measurement is taken and the path does not have to know. That is what makes
+/// [`MeterKind::Epoch`] universal: every path that measures at all can measure
+/// by epoch, including the ones that used to count fuel and nothing else.
+///
+/// The reverse does not hold. A pooled call runs under an `Accessor` with no
+/// `&mut Store` anywhere, so it cannot be wrapped like this and samples the
+/// epoch counter directly instead (`ExecutionSample` in the instance driver).
+/// [`MeterKind::Fuel`] therefore covers only the paths below, which is the one
+/// asymmetry between the two choices.
+#[derive(Clone, Default)]
+pub struct GuestMeter {
+    fuel: FuelConsumptionMeter,
+    execution_time: ExecutionTimeMeter,
+}
+
+impl GuestMeter {
+    /// Measure one call, by whichever meter this host was built with.
+    ///
+    /// Falls through to the call itself when neither is on, so a path never has
+    /// to ask whether metering is enabled.
+    pub async fn observe<F, R>(
+        &self,
+        attributes: &[KeyValue],
+        store: &mut wasmtime::Store<crate::engine::ctx::SharedCtx>,
+        func: F,
+    ) -> anyhow::Result<R>
+    where
+        F: AsyncFnOnce(&mut wasmtime::Store<crate::engine::ctx::SharedCtx>) -> anyhow::Result<R>,
+    {
+        if self.fuel.is_enabled() {
+            self.fuel.observe(attributes, store, func).await
+        } else {
+            self.execution_time.observe(attributes, store, func).await
+        }
+    }
+}
+
 impl FuelConsumptionMeter {
+    /// Whether this meter records anything, which is how [`GuestMeter`] picks
+    /// between the two without consulting the [`MeterKind`] again.
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.hist.is_some()
+    }
+
     pub(crate) fn new(enabled: bool) -> Self {
         let hist = enabled.then(|| {
             opentelemetry::global::meter("wash-runtime")

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -1860,6 +1860,10 @@ fn build_plugin_store(
             .with_resource_registry()
             .with_guest_memory(engine.guest_memory()),
     );
+    // The other half of the same requirement: on a fuel-metering engine a store
+    // starts with no fuel, and calling a guest without fuel traps. See
+    // `new_store_from_templates`, which does this for every workload store.
+    let _ = store.set_fuel(u64::MAX);
     // Required, not optional: the engine enables `epoch_interruption`, and a
     // store that never sets a deadline traps the moment it runs any guest code.
     // `WarnThenTrap` because this one store serves every workload that imports

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -651,7 +651,7 @@ impl HostPlugin for InMemoryMessaging {
 
         // Spawn the message processing task
         let task_component_id = component_id.clone();
-        let fuel_meter = self.meters.read().await.fuel_consumption.clone();
+        let guest_meter = self.meters.read().await.guest();
         // As in the NATS backend: bounded labels only, so the subject stays
         // on the span rather than minting a time series per value.
         let attributes = vec![
@@ -832,7 +832,7 @@ impl HostPlugin for InMemoryMessaging {
                             Ok(p) => p,
                         };
 
-                        let fuel_meter = fuel_meter.clone();
+                        let guest_meter = guest_meter.clone();
 
                         // As in the NATS backend: nothing awaits this call, so
                         // its deadline is a timer outliving the store's task.
@@ -849,7 +849,7 @@ impl HostPlugin for InMemoryMessaging {
                             let _permit = permit;
                             let _abandoned = abandoned;
                             let _deadline = deadline;
-                            let result = fuel_meter.observe(
+                            let result = guest_meter.observe(
                                 &[
                                     KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
                                     KeyValue::new("subject", msg.subject.to_string()),

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -297,7 +297,6 @@ pub(crate) async fn deliver_pooled(
         // the log.
         Dispatch::NeedsInstance(job) => {
             let mut store = workload.new_store(component_id).await?;
-            crate::engine::waive_fuel_limit(&mut store);
             let instance = pre.instantiate_async(&mut store).await?;
             pool.dispatch_on_new(ComponentInstance { store, instance }, job)
                 .err()
@@ -321,7 +320,6 @@ pub(crate) async fn deliver_pooled(
     tracing::debug!(component_id, "warm instances saturated; own store");
 
     let mut store = workload.new_store(component_id).await?;
-    crate::engine::waive_fuel_limit(&mut store);
     let instance = pre.instantiate_async(&mut store).await?;
     let handler = Arc::new(
         crate::host::trigger_service::AsyncMessaging::new(&mut store, &instance).map_err(|e| {

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -572,7 +572,7 @@ impl HostPlugin for NatsMessaging {
         }
 
         let mut messages = futures::stream::select_all(subscriptions);
-        let fuel_meter = self.meters.read().await.fuel_consumption.clone();
+        let guest_meter = self.meters.read().await.guest();
         // What a pooled delivery is measured under, built once here rather
         // than per message. Both are bounded by what is deployed; the subject a
         // message carries is not, so it stays on the span and the log line.
@@ -776,7 +776,7 @@ impl HostPlugin for NatsMessaging {
                             body,
                         };
 
-                        let fuel_meter = fuel_meter.clone();
+                        let guest_meter = guest_meter.clone();
 
                         // Nothing awaits this call, so its deadline is a timer
                         // outliving the store's own task; without it a guest
@@ -796,7 +796,7 @@ impl HostPlugin for NatsMessaging {
                             // Dropped when the call ends, however it ends.
                             let _abandoned = abandoned;
                             let _deadline = deadline;
-                            let result = fuel_meter.observe(
+                            let result = guest_meter.observe(
                                 &[
                                     KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
                                     KeyValue::new("subject", msg.subject.to_string()),

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -15,7 +15,6 @@ use tracing::{Instrument, debug, error, warn};
 
 use crate::engine::instance_driver::InstanceJob;
 use crate::engine::instance_pool::{ComponentInstance, Dispatch};
-use crate::engine::waive_fuel_limit;
 use crate::engine::workload::ResolvedWorkload;
 use crate::observability::ExecutionTimeMeter;
 use crate::wasmtime::component::{Accessor, InstancePre, Resource};
@@ -335,7 +334,6 @@ async fn build_instance(
         created = workload.new_store(component_id) => created?,
         _ = cancel_token.cancelled() => return Ok(None),
     };
-    waive_fuel_limit(&mut store);
     let instance = tokio::select! {
         instantiated = target.pre.instantiate_async(&mut store) => {
             instantiated.map_err(|e| anyhow::anyhow!("{e:#}"))?
@@ -1353,7 +1351,6 @@ pub(super) async fn spawn_jetstream_subscriptions(
                                     super::warm::Warmed::fresh((store, proxy))
                                 }
                             };
-                            waive_fuel_limit(&mut warmed.handler.0);
 
                             // One `Acker`, three uses: whoever settles keeps
                             // `acker`, and `progress` extends ack-wait without

--- a/crates/wash-runtime/tests/integration_fuel_metering.rs
+++ b/crates/wash-runtime/tests/integration_fuel_metering.rs
@@ -1,13 +1,13 @@
-//! Guest code still runs when the engine is metering fuel.
+//! Choosing a guest-execution meter, and the fuel budget the fuel one needs.
 //!
-//! `--enable-meters` turns on `Config::consume_fuel`, and a wasmtime store built
+//! `MeterKind::Fuel` turns on `Config::consume_fuel`, and a wasmtime store built
 //! on such an engine starts with **zero** fuel — calling into the guest traps
 //! immediately. `FuelConsumptionMeter::observe` sets a budget itself around the
 //! one call it brackets, so the paths it wraps were fine; every other path ran
 //! the guest on an empty budget.
 //!
-//! One test, because it captures process stderr, which is shared. The no-fuel
-//! control is `integration_cron_service`, which runs the same fixtures.
+//! The rest of these pin the choice itself: fuel is not free, so a host that did
+//! not ask for it must not compile its counters into every guest.
 
 use std::collections::HashMap;
 use std::io::Read;
@@ -17,23 +17,92 @@ use gag::BufferRedirect;
 use wash_runtime::{
     engine::Engine,
     host::{HostApi, HostBuilder},
+    observability::{MeterKind, Meters},
     types::{Component, Service, Workload, WorkloadStartRequest},
 };
 
 const CRON_SERVICE_WASM: &[u8] = include_bytes!("wasm/cron_service.wasm");
 const CRON_COMPONENT_WASM: &[u8] = include_bytes!("wasm/cron_component.wasm");
 
-/// A metering host runs its guests rather than trapping them.
+/// Whether this engine compiles fuel counters into its guests.
+///
+/// `get_fuel` is the observable form of `Config::consume_fuel`: it errors on an
+/// engine that is not metering fuel, which is what makes this an assertion about
+/// the engine rather than about a budget someone set.
+fn meters_fuel(engine: &Engine) -> bool {
+    wasmtime::Store::new(engine.inner(), ()).get_fuel().is_ok()
+}
+
+/// An engine built for a given meter, the way the CLI builds one.
+fn engine_for(kind: MeterKind) -> Result<Engine> {
+    Engine::builder()
+        .with_fuel_consumption(kind.consumes_fuel())
+        .build()
+}
+
+/// Fuel is off unless it is asked for.
+///
+/// `consume_fuel` compiles a counter into every block of guest code, and the
+/// guest pays it whether or not anyone reads the number. A default host must
+/// not.
+#[test]
+fn a_default_engine_does_not_meter_fuel() -> Result<()> {
+    assert!(
+        !meters_fuel(&Engine::builder().build()?),
+        "the default engine must not compile fuel counters into guests"
+    );
+    assert!(
+        !meters_fuel(&engine_for(MeterKind::Off)?),
+        "`off` must not compile fuel counters into guests"
+    );
+    Ok(())
+}
+
+/// Asking for epoch timing must not quietly turn fuel on.
+///
+/// This is the point of the choice: `guest.execution.time` is sampled from the
+/// epoch callback every store arms anyway, so it costs the guest nothing at run
+/// time. A host that picked it must not also pay fuel's per-block counters.
+#[test]
+fn epoch_metering_does_not_meter_fuel() -> Result<()> {
+    assert!(
+        !meters_fuel(&engine_for(MeterKind::Epoch)?),
+        "`epoch` must not compile fuel counters into guests"
+    );
+    // Meters are host state: building them decides which histograms exist,
+    // never how guests are compiled.
+    let _meters = Meters::new(MeterKind::Epoch);
+    assert!(
+        !meters_fuel(&Engine::builder().build()?),
+        "building epoch meters must not turn fuel on for an engine that did not ask"
+    );
+    Ok(())
+}
+
+/// The positive control, so the assertions above cannot pass by being incapable
+/// of firing.
+#[test]
+fn fuel_metering_meters_fuel() -> Result<()> {
+    assert!(
+        meters_fuel(&engine_for(MeterKind::Fuel)?),
+        "`fuel` must compile fuel counters into guests"
+    );
+    Ok(())
+}
+
+/// A fuel-metering host runs its guests rather than trapping them.
 ///
 /// The service calls the component on a timer, so reaching the component's
 /// message at all means a store was built, instantiated and called under fuel.
+/// Captures process stderr, which is shared, so it is the only test here that
+/// starts a host.
 #[tokio::test]
 async fn a_fuel_metering_host_runs_guest_code() -> Result<()> {
     let mut stderr_capture = BufferRedirect::stderr().expect("failed to redirect stderr");
 
-    let engine = Engine::builder().with_fuel_consumption(true).build()?;
     let host = HostBuilder::new()
-        .with_engine(engine)
+        .with_engine(engine_for(MeterKind::Fuel)?)
+        .with_meters(Meters::new(MeterKind::Fuel))
         .build()?
         .start()
         .await

--- a/crates/wash-runtime/tests/integration_fuel_metering.rs
+++ b/crates/wash-runtime/tests/integration_fuel_metering.rs
@@ -1,0 +1,86 @@
+//! Guest code still runs when the engine is metering fuel.
+//!
+//! `--enable-meters` turns on `Config::consume_fuel`, and a wasmtime store built
+//! on such an engine starts with **zero** fuel — calling into the guest traps
+//! immediately. `FuelConsumptionMeter::observe` sets a budget itself around the
+//! one call it brackets, so the paths it wraps were fine; every other path ran
+//! the guest on an empty budget.
+//!
+//! One test, because it captures process stderr, which is shared. The no-fuel
+//! control is `integration_cron_service`, which runs the same fixtures.
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use gag::BufferRedirect;
+use wash_runtime::{
+    engine::Engine,
+    host::{HostApi, HostBuilder},
+    types::{Component, Service, Workload, WorkloadStartRequest},
+};
+
+const CRON_SERVICE_WASM: &[u8] = include_bytes!("wasm/cron_service.wasm");
+const CRON_COMPONENT_WASM: &[u8] = include_bytes!("wasm/cron_component.wasm");
+
+/// A metering host runs its guests rather than trapping them.
+///
+/// The service calls the component on a timer, so reaching the component's
+/// message at all means a store was built, instantiated and called under fuel.
+#[tokio::test]
+async fn a_fuel_metering_host_runs_guest_code() -> Result<()> {
+    let mut stderr_capture = BufferRedirect::stderr().expect("failed to redirect stderr");
+
+    let engine = Engine::builder().with_fuel_consumption(true).build()?;
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .build()?
+        .start()
+        .await
+        .context("failed to start the fuel-metering host")?;
+
+    host.workload_start(WorkloadStartRequest {
+        workload_id: uuid::Uuid::new_v4().to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: "fuel-metered".to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(CRON_SERVICE_WASM),
+                local_resources: Default::default(),
+                max_restarts: 0,
+            }),
+            components: vec![Component {
+                name: "cron-component".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(CRON_COMPONENT_WASM),
+                local_resources: Default::default(),
+                max_invocations: 1,
+                max_concurrency: 1,
+                pool_size: 0,
+                ..Default::default()
+            }],
+            host_interfaces: vec![],
+            volumes: vec![],
+        },
+    })
+    .await
+    .context("a fuel-metering host refused to start the workload")?;
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let mut output = String::new();
+    stderr_capture
+        .read_to_string(&mut output)
+        .expect("failed to read captured stderr");
+    drop(stderr_capture);
+
+    assert!(
+        output.contains("Hello from the cron-component!"),
+        "the component never ran under fuel metering.\nCaptured stderr:\n{output}"
+    );
+
+    host.stop().await?;
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_meter_selection.rs
+++ b/crates/wash-runtime/tests/integration_meter_selection.rs
@@ -1,0 +1,98 @@
+//! The chosen meter is the one that actually records.
+//!
+//! Its own binary, and one test: reading back what was recorded means installing
+//! a global OTel meter provider, and that provider is process-wide. Three tests
+//! doing it in parallel each see whichever provider won the race.
+//!
+//! Without reading the histogram back these assertions would be vacuous. A
+//! `GuestMeter` whose meters are both inert runs the call and returns its value
+//! exactly like one that measured it, so "the call succeeded" proves nothing
+//! about metering. What distinguishes them is a data point.
+
+use anyhow::{Context, Result};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+use wash_runtime::{
+    engine::{
+        Engine,
+        ctx::{Ctx, SharedCtx},
+    },
+    observability::{MeterKind, Meters},
+};
+
+/// Runs one measured call under `kind` and returns the metric names that
+/// recorded a data point.
+async fn record_one(kind: MeterKind) -> Result<Vec<String>> {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .build();
+    // Installed before the meters are built: `Meters::new` resolves its
+    // histograms from whatever provider is global at that moment.
+    opentelemetry::global::set_meter_provider(provider.clone());
+
+    let engine = Engine::builder()
+        .with_fuel_consumption(kind.consumes_fuel())
+        .build()?;
+    let meter = Meters::new(kind).guest();
+    let ctx = Ctx::builder("test-workload", "test-component").build();
+    let mut store = wasmtime::Store::new(engine.inner(), SharedCtx::new(ctx));
+
+    let measured = meter
+        .observe(&[], &mut store, async |_store| Ok(7))
+        .await
+        .with_context(|| format!("the {kind:?} meter failed the call it was measuring"))?;
+    assert_eq!(measured, 7, "the measured call's own value must come back");
+
+    provider.force_flush()?;
+    Ok(exporter
+        .get_finished_metrics()?
+        .iter()
+        .flat_map(|rm| rm.scope_metrics())
+        .flat_map(|sm| sm.metrics())
+        .map(|m| m.name().to_string())
+        .collect())
+}
+
+/// Each choice records its own histogram and only its own, on a path that hands
+/// over a `&mut Store`.
+///
+/// The epoch case is what "epoch is universal" means. Such a path measures
+/// through `GuestMeter`, which uses the meter the host chose; before, those
+/// paths named the fuel meter, so under `epoch` the p2 HTTP path and both
+/// messaging backends recorded nothing at all.
+///
+/// One test, sequentially, because the meter provider each case installs is
+/// process-global.
+#[tokio::test]
+async fn each_meter_records_its_own_histogram() -> Result<()> {
+    let epoch = record_one(MeterKind::Epoch).await?;
+    assert!(
+        epoch.iter().any(|name| name == "guest.execution.time"),
+        "epoch metering recorded no execution time; got {epoch:?}"
+    );
+    assert!(
+        !epoch.iter().any(|name| name == "fuel.consumption"),
+        "epoch metering must not record fuel; got {epoch:?}"
+    );
+
+    let fuel = record_one(MeterKind::Fuel).await?;
+    assert!(
+        fuel.iter().any(|name| name == "fuel.consumption"),
+        "fuel metering recorded no consumption; got {fuel:?}"
+    );
+    assert!(
+        !fuel.iter().any(|name| name == "guest.execution.time"),
+        "fuel metering must not record execution time; got {fuel:?}"
+    );
+
+    // `off` is about these two only: the engine's own memory instruments are
+    // not guest-execution metering and are recorded regardless.
+    let off = record_one(MeterKind::Off).await?;
+    assert!(
+        !off.iter()
+            .any(|name| name == "guest.execution.time" || name == "fuel.consumption"),
+        "a host metering nothing recorded a guest-execution metric; got {off:?}"
+    );
+
+    Ok(())
+}

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -76,7 +76,7 @@ impl CliCommand for DevCommand {
 
         let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters());
+            .with_fuel_consumption(ctx.meters().consumes_fuel());
         for name in &dev_config.wasm_proposals {
             let proposal: WasmProposal = name
                 .parse()
@@ -87,7 +87,7 @@ impl CliCommand for DevCommand {
 
         let mut host_builder = Host::builder()
             .with_engine(engine.clone())
-            .with_meters(Meters::new(ctx.enable_meters()));
+            .with_meters(Meters::new(ctx.meters()));
 
         // Enable wasi config. `copy_environment = true` surfaces each
         // component's `LocalResources.environment` via `wasi:config/store`,

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -596,7 +596,7 @@ impl CliCommand for HostCommand {
 
         let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)
-            .with_fuel_consumption(ctx.enable_meters());
+            .with_fuel_consumption(ctx.meters().consumes_fuel());
         for proposal in &self.wasm_proposals {
             engine_builder = engine_builder.with_wasm_proposal(*proposal);
         }
@@ -699,7 +699,7 @@ impl CliCommand for HostCommand {
                         format!("{}.", wash_runtime::washlet::OPERATOR_API_PREFIX),
                     ]),
             ))?
-            .with_meters(Meters::new(ctx.enable_meters()));
+            .with_meters(Meters::new(ctx.meters()));
 
         #[cfg(feature = "wasm_component_model_implements")]
         {

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -253,7 +253,7 @@ pub struct CliContext {
     // the original working directory when the CLI was invoked, used for resolving relative paths in commands
     original_working_dir: PathBuf,
     // Enable fuel meter
-    enable_meters: bool,
+    meters: wash_runtime::observability::MeterKind,
 }
 
 impl Deref for CliContext {
@@ -270,7 +270,7 @@ pub struct CliContextBuilder {
     non_interactive: bool,
     config: Option<PathBuf>,
     project_dir: Option<PathBuf>,
-    enable_meters: bool,
+    meters: wash_runtime::observability::MeterKind,
     #[cfg(test)]
     keep_working_dir: bool,
 }
@@ -291,8 +291,8 @@ impl CliContextBuilder {
         self
     }
 
-    pub fn enable_meters(mut self, enable_meters: bool) -> Self {
-        self.enable_meters = enable_meters;
+    pub fn meters(mut self, meters: wash_runtime::observability::MeterKind) -> Self {
+        self.meters = meters;
         self
     }
 
@@ -385,7 +385,7 @@ impl CliContextBuilder {
             project_dir,
             original_working_dir,
             config: self.config,
-            enable_meters: self.enable_meters,
+            meters: self.meters,
         })
     }
 }
@@ -487,8 +487,8 @@ impl CliContext {
         locate_project_config(self.project_dir())
     }
 
-    pub fn enable_meters(&self) -> bool {
-        self.enable_meters
+    pub fn meters(&self) -> wash_runtime::observability::MeterKind {
+        self.meters
     }
 
     pub fn load_config<T>(&self, overrides: Option<T>) -> anyhow::Result<Config>

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -51,9 +51,13 @@ struct Cli {
     #[arg(short = 'C', default_value = find_project_root().into_os_string())]
     project_path: PathBuf,
 
-    /// Enable host meters
-    #[arg(long = "enable-meters", global = true)]
-    enable_meters: bool,
+    /// Which guest-execution meter to run: `off`, `epoch`, or `fuel`.
+    ///
+    /// `epoch` samples the clock the host already arms, so guests pay nothing
+    /// for it. `fuel` counts exactly, at the price of a counter compiled into
+    /// every block of guest code.
+    #[arg(long = "meters", global = true, default_value = "off")]
+    meters: wash_runtime::observability::MeterKind,
 
     #[command(subcommand)]
     command: Option<WashCliCommand>,
@@ -135,7 +139,7 @@ async fn main() {
         non_interactive: false,
         user_config: None,
         project_path: find_project_root(),
-        enable_meters: false,
+        meters: wash_runtime::observability::MeterKind::Off,
         command: None,
     });
 
@@ -211,7 +215,7 @@ async fn main() {
     let mut ctx_builder = CliContext::builder()
         .non_interactive(non_interactive)
         .project_dir(project_absolute_path)
-        .enable_meters(global_args.enable_meters);
+        .meters(global_args.meters);
 
     // Load custom config if provided, otherwise will default to XDG config path
     if let Some(config_path) = global_args.user_config {


### PR DESCRIPTION
After introducing epoch metering, we had a weird split where `--enable-meters` enabled both types of meters. In practice, only one type is ever desired. Either you're trying to limit instructions with fuel or you're using epoch to prevent spin locks. 

Fuel metering turns on `Config::consume_fuel`, and a wasmtime store built on such an engine starts at **zero** fuel calling into a guest without fuel traps. So asking for metering didn't add metering, it took the host down.

`FuelConsumptionMeter::observe` sets a budget itself around the one call it brackets, which is why the p2 HTTP path appeared to work and hid this. Every other path: pooled HTTP, linked calls, trigger services, NATS deliveries, host component plugins ran the guest on an empty budget.

Now `new_store_from_templates` for workload stores and `build_plugin_store` for the store a host component plugin serves every tenant from now consistently applies fuel.

That subsumes `wasmcloud:nats`'s own `waive_fuel_limit`, which is now removed. Careful with merging this and #5515 (it moved to a generic location as a bug fix).

### Choosing a meter

`--enable-meters` turned both meters on together, so a host that wanted only `guest.execution.time` sampled from the epoch callback every store arms anyway, and free to the guest also got `fuel.consumption`, whose counter is compiled into every block of guest code and paid whether or not anyone reads the number.

`--meters <off|epoch|fuel>` picks one. `off` is the default.

Splitting the meters naively would leave each choice covering half the host. This introduces a new `GuestMeter` that all paths measure through now. It holds both fuel and epoch meters and uses the one the host was built with, so `MeterKind` decides *how* a measurement is taken and the call site doesn't need to know.
