### PR TITLE
fix(wash): alias deprecated --enable-meters

### DIFF
--- a/crates/wash-runtime/src/engine/guest_memory.rs
+++ b/crates/wash-runtime/src/engine/guest_memory.rs
@@ -231,7 +231,7 @@ impl GuestMemoryBudget {
     /// and reads the atomics this budget already keeps, so nothing is recorded
     /// on the `memory.grow` path and the cost of being watched is zero.
     ///
-    /// Not gated behind `--enable-meters`, unlike
+    /// Not gated behind `--meters`, unlike
     /// [`crate::observability::FuelConsumptionMeter`]. That flag exists because
     /// fuel metering makes the guest measurably slower; this does not, and the
     /// high-water figure is the one an operator is told to watch before turning

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -59,8 +59,29 @@ struct Cli {
     #[arg(long = "meters", global = true, default_value = "off")]
     meters: wash_runtime::observability::MeterKind,
 
+    /// Deprecated spelling of `--meters fuel`.
+    #[arg(
+        long = "enable-meters",
+        global = true,
+        hide = true,
+        conflicts_with = "meters"
+    )]
+    enable_meters: bool,
+
     #[command(subcommand)]
     command: Option<WashCliCommand>,
+}
+
+impl Cli {
+    /// The meter to run, honoring the deprecated `--enable-meters`, which turned
+    /// on the fuel counter.
+    fn meters(&self) -> wash_runtime::observability::MeterKind {
+        if self.enable_meters {
+            wash_runtime::observability::MeterKind::Fuel
+        } else {
+            self.meters
+        }
+    }
 }
 
 /// The main CLI commands for wash
@@ -140,6 +161,7 @@ async fn main() {
         user_config: None,
         project_path: find_project_root(),
         meters: wash_runtime::observability::MeterKind::Off,
+        enable_meters: false,
         command: None,
     });
 
@@ -176,6 +198,10 @@ async fn main() {
                 .with_output_kind(global_args.output),
         );
     });
+
+    if global_args.enable_meters {
+        warn!("`--enable-meters` is deprecated, use `--meters fuel` instead");
+    }
 
     // Check if project path exists
     if !global_args.project_path.exists() {
@@ -215,7 +241,7 @@ async fn main() {
     let mut ctx_builder = CliContext::builder()
         .non_interactive(non_interactive)
         .project_dir(project_absolute_path)
-        .meters(global_args.meters);
+        .meters(global_args.meters());
 
     // Load custom config if provided, otherwise will default to XDG config path
     if let Some(config_path) = global_args.user_config {
@@ -349,4 +375,41 @@ fn find_project_root() -> PathBuf {
     }
 
     fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wash_runtime::observability::MeterKind;
+
+    #[test]
+    fn enable_meters_selects_fuel() {
+        let cli = Cli::try_parse_from(["wash", "--enable-meters", "inspect", "component.wasm"])
+            .expect("--enable-meters should parse");
+        assert_eq!(cli.meters(), MeterKind::Fuel);
+    }
+
+    #[test]
+    fn meters_flag_stands_alone() {
+        let cli = Cli::try_parse_from(["wash", "--meters", "epoch", "inspect", "component.wasm"])
+            .expect("--meters should parse");
+        assert_eq!(cli.meters(), MeterKind::Epoch);
+
+        let cli = Cli::try_parse_from(["wash", "inspect", "component.wasm"])
+            .expect("no meter flag should parse");
+        assert_eq!(cli.meters(), MeterKind::Off);
+    }
+
+    #[test]
+    fn both_meter_flags_conflict() {
+        Cli::try_parse_from([
+            "wash",
+            "--enable-meters",
+            "--meters",
+            "epoch",
+            "inspect",
+            "component.wasm",
+        ])
+        .expect_err("the deprecated flag and its replacement should conflict");
+    }
 }


### PR DESCRIPTION
We made a breaking change on main when replacing wash `--enable-meters` with `--meters` but this has not yet been released. Adding in this alias keeps it from being breaking.

```bash
$ wash --enable-meters inspect x.wasm
WARN `--enable-meters` is deprecated, use `--meters fuel` instead
$ wash --enable-meters --meters epoch inspect x.wasm
error: the argument '--enable-meters' cannot be used with '--meters <METERS>'
```