### PR TITLE
fix(wash-runtime): Add validation and activation for OTEL_ prefixed v…

### DIFF
--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -56,6 +56,52 @@ pub async fn flush_within(budget: Duration) -> bool {
 /// providers it built without every exit path having to be handed them.
 static SHUTDOWN: std::sync::OnceLock<Box<dyn Fn() + Send + Sync>> = std::sync::OnceLock::new();
 
+/// Env vars that name an OTLP destination. Presence of one of these is what turns exporting on.
+const OTLP_ENDPOINT_VARS: [&str; 4] = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+];
+
+fn validate_otlp_endpoint(var: &str, value: &str) -> Option<String> {
+    let Some((scheme, _)) = value.split_once("://") else {
+        return Some(format!(
+            "missing scheme in {var} ({value}): expected http:// or https://"
+        ));
+    };
+
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return Some(format!(
+            "unsupported OTLP endpoint scheme '{scheme}' in {var} ({value}): expected http:// or https://"
+        ));
+    }
+
+    if let Err(e) = value.parse::<http::Uri>() {
+        return Some(format!("invalid OTLP endpoint URL in {var} ({value}): {e}"));
+    }
+
+    None
+}
+
+fn otlp_activation(vars: impl IntoIterator<Item = (String, String)>) -> (bool, Option<String>) {
+    let mut configured = vars
+        .into_iter()
+        .filter(|(key, value)| {
+            OTLP_ENDPOINT_VARS.contains(&key.as_str()) && !value.trim().is_empty()
+        })
+        .peekable();
+
+    if configured.peek().is_none() {
+        return (false, None);
+    }
+
+    match configured.find_map(|(var, value)| validate_otlp_endpoint(&var, &value)) {
+        Some(msg) => (false, Some(msg)),
+        None => (true, None),
+    }
+}
+
 /// Initialize observability, setting up console & OpenTelemetry layers.
 ///
 /// Returns a shutdown function that should be called on process exit to flush
@@ -90,9 +136,13 @@ pub fn initialize_observability(
         .with_ansi(ansi_colors)
         .with_filter(fmt_filter);
 
-    let otel_enabled = std::env::vars().any(|(key, _)| key.starts_with("OTEL_"));
-    if !otel_enabled {
+    let (otlp_enabled, otlp_warning) = otlp_activation(std::env::vars());
+    if !otlp_enabled {
         Registry::default().with(fmt_layer).init();
+
+        if let Some(msg) = otlp_warning {
+            tracing::warn!("{msg}; continuing without OTLP export");
+        }
 
         // Nothing to flush: `flush` finds no registered shutdown and returns.
         return Ok(Box::new(flush));
@@ -113,10 +163,39 @@ pub fn initialize_observability(
         ))
         .build();
 
+    // Build all three exporters up front, before initializing the subscriber, so a
+    // build failure (e.g. an endpoint tonic can't use) degrades to console-only
+    // logging instead of leaving a half-initialized subscriber in place.
+    let exporters = (|| -> anyhow::Result<_> {
+        let log_exporter = opentelemetry_otlp::LogExporter::builder()
+            .with_tonic()
+            .build()
+            .context("failed to create OTLP log exporter")?;
+        let tracer_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build()
+            .context("failed to create OTLP span exporter")?;
+        let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .build()
+            .context("failed to create OTLP metric exporter")?;
+        Ok((log_exporter, tracer_exporter, metric_exporter))
+    })();
+
+    let (log_exporter, tracer_exporter, metric_exporter) = match exporters {
+        Ok(exporters) => exporters,
+        Err(e) => {
+            Registry::default().with(fmt_layer).init();
+            tracing::warn!(
+                "failed to initialize OTLP export: {e:#}; continuing without OTLP export"
+            );
+
+            // Nothing to flush: `flush` finds no registered shutdown and returns.
+            return Ok(Box::new(flush));
+        }
+    };
+
     // OTel logging layer
-    let log_exporter = opentelemetry_otlp::LogExporter::builder()
-        .with_tonic()
-        .build()?;
     let log_provider = opentelemetry_sdk::logs::LoggerProviderBuilder::default()
         .with_batch_exporter(log_exporter)
         .with_resource(resource.clone())
@@ -127,9 +206,6 @@ pub fn initialize_observability(
         OpenTelemetryTracingBridge::new(&log_provider).with_filter(filter_otel_logs);
 
     // OTel tracing layer
-    let tracer_exporter = opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .build()?;
     let tracer_provider = opentelemetry_sdk::trace::TracerProviderBuilder::default()
         .with_batch_exporter(tracer_exporter)
         .with_resource(resource.clone())
@@ -151,11 +227,6 @@ pub fn initialize_observability(
         .with(otel_logs_layer)
         .with(otel_tracer_layer)
         .init();
-
-    let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
-        .with_tonic()
-        .build()
-        .context("failed to create OTEL tonic exporter")?;
 
     let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
         .with_periodic_exporter(metric_exporter)
@@ -678,5 +749,107 @@ mod tests {
         // The default is what a serverless host should run: rate, errors and
         // duration, which cost the guest two clock reads.
         assert_eq!(MeterKind::default(), MeterKind::Duration);
+    }
+
+    fn vars(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn non_endpoint_otel_vars_do_not_configure_otlp() {
+        assert_eq!(
+            otlp_activation(vars(&[
+                ("OTEL_SERVICE_NAME", "my-service"),
+                ("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=ci"),
+                ("OTEL_LOG_LEVEL", "debug"),
+                ("SOME_OTHER_VAR", "irrelevant"),
+            ])),
+            (false, None)
+        );
+    }
+
+    #[test]
+    fn each_endpoint_var_configures_otlp() {
+        for var in OTLP_ENDPOINT_VARS {
+            assert_eq!(
+                otlp_activation(vars(&[(var, "http://localhost:4317")])),
+                (true, None),
+                "expected {var} to configure OTLP"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_or_whitespace_endpoint_values_do_not_configure_otlp() {
+        assert_eq!(
+            otlp_activation(vars(&[
+                ("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+                ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "   "),
+            ])),
+            (false, None)
+        );
+    }
+
+    #[test]
+    fn unsupported_scheme_is_rejected_with_actionable_message() {
+        let msg =
+            validate_otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", "unix:///dev/otel-grpc.sock")
+                .expect("unix scheme should be rejected");
+        assert!(
+            msg.contains("unsupported OTLP endpoint scheme 'unix'"),
+            "message was: {msg}"
+        );
+        assert!(
+            msg.contains("expected http:// or https://"),
+            "message was: {msg}"
+        );
+    }
+
+    #[test]
+    fn http_and_https_schemes_are_accepted() {
+        assert_eq!(
+            validate_otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+            None
+        );
+        assert_eq!(
+            validate_otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector:4317"),
+            None
+        );
+        assert_eq!(
+            validate_otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", "HTTP://localhost:4317"),
+            None
+        );
+    }
+
+    #[test]
+    fn missing_scheme_is_rejected() {
+        let msg = validate_otlp_endpoint("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317")
+            .expect("value without a scheme should be rejected");
+        assert!(msg.contains("missing scheme"), "message was: {msg}");
+    }
+
+    #[test]
+    fn otlp_activation_enables_export_only_with_configured_endpoint() {
+        assert_eq!(
+            otlp_activation(vars(&[("OTEL_SERVICE_NAME", "my-service")])),
+            (false, None)
+        );
+        assert_eq!(
+            otlp_activation(vars(&[(
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "http://localhost:4317"
+            )])),
+            (true, None)
+        );
+
+        let (enabled, warning) = otlp_activation(vars(&[(
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "unix:///dev/otel-grpc.sock",
+        )]));
+        assert!(!enabled);
+        assert!(warning.is_some());
     }
 }

--- a/examples/otel-config/README.md
+++ b/examples/otel-config/README.md
@@ -41,7 +41,7 @@ wash dev
 In a second terminal:
 
 ```bash
-curl http://localhost:8000/
+curl http://localhost:8001/
 ```
 
 Expected behavior on the first request:
@@ -144,7 +144,10 @@ docker run --rm -it \
 - `18889` — OTLP gRPC ingest endpoint
 
 In a second terminal, point `wash dev` at the dashboard's OTLP endpoint. wash-runtime's
-exporter activates whenever any `OTEL_*` env var is set and uses gRPC by default:
+exporter activates when an OTLP endpoint variable is set — `OTEL_EXPORTER_OTLP_ENDPOINT`
+or a signal-specific `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT` — and speaks
+gRPC over `http://` or `https://` by default. Other `OTEL_*` vars (e.g. `OTEL_SERVICE_NAME`)
+do not by themselves turn on export:
 
 ```shell
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:18889 wash dev
@@ -157,7 +160,7 @@ so it stays on the command line. The Resource identity is sourced from
 In a third terminal, trigger a request:
 
 ```shell
-curl http://localhost:8000/
+curl http://localhost:8001/
 ```
 
 Open the dashboard at [http://localhost:18888](http://localhost:18888). You should see:


### PR DESCRIPTION
…ars to be able

to log verbose message instead of delegating the error handling to tonic builder.

This PR aimed to resolved issue #5474.

## Description

Add scheme validation for `OTEL_*` env var to have more precise error messages. The error messages are printed but non blocking.

## QA session

Here some e2e tests ran from my local machine after rebuilding wash


### Error message when unsupported endpoint

Command
`OTEL_EXPORTER_OTLP_ENDPOINT=unix:///dev/otel-grpc.sock ./target/release/wash --help`

Output
```
2026-09-02T21:22:35.972920Z  WARN unsupported OTLP endpoint scheme 'unix' in OTEL_EXPORTER_OTLP_ENDPOINT (unix:///dev/otel-grpc.sock): expected http:// or https://; continuing without OTLP export
```


### False-activation case

Command
`OTEL_RESOURCE_ATTRIBUTES=deployment.environment=ci OTEL_SERVICE_NAME=ci ./target/release/wash --help`

Output: no warning
`The Wasm Shell (wash) for developing and publishing Wasm components`

### Running wash with unsupported OTEL_EXPORTER_OTLP_ENDPOINT

Warning displayed, but no crash.
```
OTEL_EXPORTER_OTLP_ENDPOINT=unix:///dev/otel-grpc.sock /home/nitame/Work/foss/wasmCloud/target/release/wash dev
2026-09-02T21:16:33.910977Z  WARN unsupported OTLP endpoint scheme 'unix' in OTEL_EXPORTER_OTLP_ENDPOINT (unix://localhost:18889): expected http:// or https://; continuing without OTLP export
2026-09-02T21:16:34.170606Z  INFO starting development session for project path="/home/nitame/Work/foss/wasmCloud/examples/otel-config"
[truncated]
2026-09-02T21:16:34.386137Z  INFO listening for HTTP requests address=http://127.0.0.1:8001
``` 

### Running wash with correct config

Running dashboard Aspire inside a container
```
info: Aspire.Dashboard.DashboardWebApplication[0]
      Dashboard is running in a container. Access the dashboard from the host using port forwarding.
```

Launch wash. No warnings
```
[truncated]
2026-09-02T21:28:45.284544Z  INFO listening for HTTP requests address=http://127.0.0.1:8001
```

Dashboard display HTTP call trace

<img width="1915" height="723" alt="screenshot-2026-09-02_23-34-05" src="https://github.com/user-attachments/assets/969467bd-2e19-4467-a695-ba357c32d02b" />

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->