### PR TITLE
fix: keep a host serving through a redeploy burst

### DIFF
--- a/charts/runtime-operator/templates/_helpers.tpl
+++ b/charts/runtime-operator/templates/_helpers.tpl
@@ -373,6 +373,29 @@ secret.reloader.stakater.com/reload: {{ join "," $partition.secretFromNames | qu
 {{- end }}
 
 {{/*
+One host-group probe, resolved against the chart-wide default. Fields resolve
+one by one, so a group retuning one timing keeps the rest.
+
+Written as a key-by-key overlay rather than `merge` because sprig's merge
+treats every zero as unset: it would drop a group's `enabled: false` and its
+`initialDelaySeconds: 0` alike, in favour of whatever the chart-wide block
+says.
+
+Call with (dict "group" .probes "chart" $top.Values.runtime.probes "name" "liveness")
+and read the result back with `fromJson`.
+*/}}
+{{- define "runtime-operator.hostProbe" -}}
+{{- $probe := dict }}
+{{- range $field, $value := (index (.chart | default dict) .name) | default dict }}
+{{- $_ := set $probe $field $value }}
+{{- end }}
+{{- range $field, $value := (index (.group | default dict) .name) | default dict }}
+{{- $_ := set $probe $field $value }}
+{{- end }}
+{{- $probe | toJson }}
+{{- end }}
+
+{{/*
 Create the imagePullSecrets section for the chart.
 */}}
 {{- define "runtime-operator.imagePullSecrets" -}}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -15,9 +15,14 @@
        the ConfigMap this deployment mounts. */}}
 {{- /* A host group's own `resources` replaces the chart-wide block wholesale
        (no merge), and carries the host knobs `defaultHeapMemory`,
-       `coreInstances` and `guestMemoryMode` alongside the Kubernetes
-       requests/limits. */}}
+       `coreInstances`, `guestMemoryMode` and `maxConcurrentStarts` alongside
+       the Kubernetes requests/limits. */}}
 {{- $resources := .resources | default $top.Values.runtime.resources | default dict }}
+{{- /* Probes, unlike `resources`, merge per field: a group naming one timing
+       keeps the chart-wide values for the rest. */}}
+{{- $probeArgs := dict "group" .probes "chart" $top.Values.runtime.probes }}
+{{- $liveness := include "runtime-operator.hostProbe" (merge (dict "name" "liveness") $probeArgs) | fromJson }}
+{{- $readiness := include "runtime-operator.hostProbe" (merge (dict "name" "readiness") $probeArgs) | fromJson }}
 {{- $partition := include "runtime-operator.hostPluginPartition" . | fromJson }}
 {{- $cliPlugins := $partition.cli }}
 {{- $needsConfigFile := $partition.needsConfigFile }}
@@ -175,6 +180,10 @@ spec:
             - name: WASH_GUEST_MEMORY_MODE
               value: "{{ . }}"
             {{- end }}
+            {{- with $resources.maxConcurrentStarts }}
+            - name: WASH_MAX_CONCURRENT_STARTS
+              value: "{{ . }}"
+            {{- end }}
             {{- with $top.Values.runtime.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -303,7 +312,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
-          {{- with omit $resources "defaultHeapMemory" "coreInstances" "guestMemoryMode" }}
+          {{- with omit $resources "defaultHeapMemory" "coreInstances" "guestMemoryMode" "maxConcurrentStarts" }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -321,17 +330,29 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if and (.http) (.http.enabled) }}
+          {{- /* A host serves workload routes on this port and nothing else,
+                 so both probes can only ask whether it still accepts
+                 connections. What each one does about that answer, and why
+                 they are timed apart, is documented on `runtime.probes`. */}}
+          {{- /* Every field but `enabled` is passed through as given, so a `0`
+                 reaches the manifest and `runtime.probes` stays the one place
+                 the timings are written down. */}}
+          {{- if $liveness.enabled }}
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 20
-            failureThreshold: 3
+            {{- range $field, $value := omit $liveness "enabled" }}
+            {{ $field }}: {{ $value }}
+            {{- end }}
+          {{- end }}
+          {{- if $readiness.enabled }}
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- range $field, $value := omit $readiness "enabled" }}
+            {{ $field }}: {{ $value }}
+            {{- end }}
+          {{- end }}
           {{- end }}
           securityContext:
             {{- toYaml $top.Values.runtime.securityContext | nindent 12 }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -313,10 +313,11 @@ runtime:
   # host: size `limits.memory` for your expected per-host workload density, or
   # remove it to leave host memory uncapped.
   #
-  # `defaultHeapMemory`, `coreInstances` and `guestMemoryMode` are host knobs
-  # rather than Kubernetes resource fields; the chart strips them out of the
-  # container's `resources` block and sets them as `WASH_DEFAULT_HEAP_MEMORY` /
-  # `WASH_CORE_INSTANCES` / `WASH_GUEST_MEMORY_MODE` for the host.
+  # `defaultHeapMemory`, `coreInstances`, `guestMemoryMode` and
+  # `maxConcurrentStarts` are host knobs rather than Kubernetes resource fields;
+  # the chart strips them out of the container's `resources` block and sets them
+  # as `WASH_DEFAULT_HEAP_MEMORY` / `WASH_CORE_INSTANCES` /
+  # `WASH_GUEST_MEMORY_MODE` / `WASH_MAX_CONCURRENT_STARTS` for the host.
   # Leaving them empty uses the host's own defaults.
   #
   # The simplest way to change host sizing for the whole release:
@@ -351,6 +352,55 @@ runtime:
     # headroom by setting `limits.memory` above the guest budget you want, or
     # by overriding `WASH_HOST_MAX_GUEST_MEMORY` below it via `runtime.env`.
     guestMemoryMode: ""
+    # -- How many workloads a host pulls and compiles at once. Each start it
+    # admits ends in a single-threaded compile, so this is how many cores a
+    # burst of starts takes from the ones serving HTTP and NATS — a host that
+    # stops accepting connections for long enough fails its liveness probe and
+    # is restarted, taking every workload on it with it. Set it to `1` on a
+    # host that must keep serving through a large redeploy, bearing in mind
+    # that the same permit covers the image pull, so a lower number serializes
+    # network waiting along with the compiling.
+    #
+    # Empty leaves the host to size itself: one fewer than the cores it can
+    # see, at most 4. Note what it sees — the count comes from the cgroup, so
+    # it follows `limits.cpu`, and a host with no cpu limit sizes itself
+    # against the whole node however small its `requests.cpu` is. Set this
+    # explicitly on a host group that is requested far below the node it lands
+    # on.
+    maxConcurrentStarts: ""
+  # -- Probes for host containers, rendered only for a host group that serves
+  # HTTP (`hostGroups[].http.enabled`); both connect to its `http` port. A host
+  # group sets its own with `hostGroups[].probes`, and any field left out of
+  # that falls back to the value here.
+  #
+  # Readiness and liveness are deliberately not tuned alike. Both connect to
+  # the port the host serves workload routes on, which the kernel answers from
+  # the listener's accept queue whether or not the host is polling it — so what
+  # a failure reports is a host busy enough to have let that queue fill.
+  # Leaving the Service over that is cheap, which is readiness' job. Restarting
+  # is a different trade: the pod loses every workload running on it, and the
+  # scheduler places them all again at once, which is the burst that stalled it
+  # in the first place. So liveness waits a good deal longer before calling a
+  # host dead.
+  #
+  # `liveness.enabled: false` leaves nothing to recycle a wedged host: the
+  # operator deletes the *Host* of a host it stops hearing from, and its
+  # workloads move, but the pod is not the operator's to delete and keeps
+  # running whatever it still holds. Disable it only where something else
+  # takes that job.
+  probes:
+    readiness:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+    liveness:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 5
   # -- Additional environment variables applied to every host group container,
   # appended after the chart-managed vars and before any per-host-group `env`.
   # Standard Kubernetes env shape (supports `valueFrom`).
@@ -692,6 +742,13 @@ runtime:
       #   defaultHeapMemory: "512MiB"
       #   coreInstances: "200"
       #   guestMemoryMode: "enforce"
+      #   maxConcurrentStarts: "1"
+      # -- Per-host-group probes. Merged field by field over
+      # `runtime.probes`, so a group can retune one timing and inherit the
+      # rest:
+      # probes:
+      #   liveness:
+      #     enabled: false
       # -- Extra CA bundles trusted when this group pulls images, added to the
       # chart-wide `runtime.ociCaPaths` rather than replacing it:
       # ociCaPaths:

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -14,15 +14,9 @@ use tracing::{debug, error, info, instrument, warn};
 pub const HOST_API_PREFIX: &str = "runtime.host";
 pub const OPERATOR_API_PREFIX: &str = "runtime.operator";
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
-/// How many `workload.start` requests a host pulls and compiles at once.
-///
-/// This is not a tuning knob: it bounds how many images are held in memory and
-/// compiled at once. The compile is the half that sets it — each permitted
-/// start ends in a Cranelift compile on the blocking pool, and a host pod with
-/// a couple of cores oversubscribed several times over starves the runtime
-/// threads it shares that CPU with, which is the stall this path exists to
-/// avoid. Sized to what a small pod can compile at once, not to what its
-/// network could pull.
+/// Most `workload.start` requests a host pulls and compiles at once, however
+/// many cores it has. Past this the images held in memory cost more than the
+/// extra parallelism buys.
 const MAX_CONCURRENT_STARTS: usize = 4;
 /// How long shutdown waits for in-flight commands before abandoning them.
 ///
@@ -32,6 +26,23 @@ const MAX_CONCURRENT_STARTS: usize = 4;
 /// anything. Better to abandon them and stop the host, which unbinds whatever
 /// they had bound anyway.
 const COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How many starts a host runs at once when nothing sets it.
+///
+/// Each permitted start ends in a Cranelift compile, and compilation here is
+/// single-threaded, so a permit is a core's worth of work for as long as the
+/// compile runs. `available_parallelism` reads the cgroup quota a container is
+/// limited to, and one core is left out of the count: a host that cannot poll
+/// its HTTP accept loop or drain its NATS socket while it compiles is one
+/// Kubernetes restarts out from under its workloads.
+fn default_max_concurrent_starts() -> usize {
+    std::thread::available_parallelism().map_or(1, |cores| starts_for_cores(cores.get()))
+}
+
+/// [`default_max_concurrent_starts`] against a known core count.
+fn starts_for_cores(cores: usize) -> usize {
+    cores.saturating_sub(1).clamp(1, MAX_CONCURRENT_STARTS)
+}
 
 pub mod types {
     pub mod v2 {
@@ -148,7 +159,8 @@ impl ClusterHostBuilder {
         self
     }
 
-    /// Caps how many `workload.start` requests this host serves at once.
+    /// Caps how many `workload.start` requests this host serves at once,
+    /// overriding [`default_max_concurrent_starts`].
     /// Zero is raised to one: a host that cannot start anything is not a host.
     pub fn with_max_concurrent_starts(mut self, starts: usize) -> Self {
         self.max_concurrent_starts = Some(starts.max(1));
@@ -205,7 +217,9 @@ impl ClusterHostBuilder {
             heartbeat_interval,
             cleanup_interval: self.cleanup_interval.unwrap_or(Duration::from_secs(300)),
             cleanup_age: self.cleanup_age.unwrap_or(Duration::from_secs(3600)),
-            max_concurrent_starts: self.max_concurrent_starts.unwrap_or(MAX_CONCURRENT_STARTS),
+            max_concurrent_starts: self
+                .max_concurrent_starts
+                .unwrap_or_else(default_max_concurrent_starts),
         })
     }
 }
@@ -248,6 +262,7 @@ impl ClusterHost {
         host_name=?host.hostname(),
         labels=?host.labels(),
         version=?host.version(),
+        max_concurrent_starts,
         "Host started");
 
         host.log_interfaces();
@@ -1013,6 +1028,17 @@ mod tests {
     use super::*;
     use crate::host::allowed_hosts::AllowedHost;
     use crate::host::allowed_ip_name::AllowedIpName;
+
+    /// A host always keeps a start it can run and a core it can serve on.
+    #[test]
+    fn starts_leave_a_core_to_serve_with() {
+        assert_eq!(starts_for_cores(0), 1);
+        assert_eq!(starts_for_cores(1), 1);
+        assert_eq!(starts_for_cores(2), 1);
+        assert_eq!(starts_for_cores(4), 3);
+        assert_eq!(starts_for_cores(5), MAX_CONCURRENT_STARTS);
+        assert_eq!(starts_for_cores(64), MAX_CONCURRENT_STARTS);
+    }
 
     /// Every instance limit a component declares on the wire has to reach the
     /// runtime. An in-process test builds `types::Component` directly and so

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -328,6 +328,15 @@ pub struct HostCommand {
     #[arg(long = "oci-cache-dir")]
     pub oci_cache_dir: Option<PathBuf>,
 
+    /// How many workloads this host pulls and compiles at once.
+    ///
+    /// Each start it admits ends in a single-threaded compile, so this is how
+    /// many cores a burst of starts can take from the ones serving HTTP and
+    /// NATS. Defaults to one fewer than the host can see, at most 4; lower it
+    /// on a host that must stay responsive while it starts things.
+    #[arg(long = "max-concurrent-starts", env = "WASH_MAX_CONCURRENT_STARTS")]
+    pub max_concurrent_starts: Option<usize>,
+
     /// Enable WASI OpenTelemetry plugin
     #[arg(long = "wasi-otel", default_value_t = false)]
     pub wasi_otel: bool,
@@ -750,6 +759,10 @@ impl CliCommand for HostCommand {
 
         if let Some(environment) = &self.environment {
             cluster_host_builder = cluster_host_builder.with_environment(environment);
+        }
+
+        if let Some(starts) = self.max_concurrent_starts {
+            cluster_host_builder = cluster_host_builder.with_max_concurrent_starts(starts);
         }
 
         // One publishing context for the whole host: workloads and plugins


### PR DESCRIPTION
A host pod stops accepting connections while it starts a burst of workloads, kubelet's liveness probe times out, and the container is restarted — losing every workload on it, which the scheduler then places back on it all at once.

Seen in the field as `Liveness probe failed: dial tcp <pod>:80: i/o timeout` followed by `Container host failed liveness probe, will be restarted`, and `lastState.terminated: {reason: Error, exitCode: 137}`. A connect that times out rather than being refused is a host whose accept queue filled while it was busy, not a host that died.

Two things make that outcome likely, and this changes both.

**A host admits four starts at once whatever it is running on.** Each one ends in a Cranelift compile, and compilation here is single-threaded (`wasmtime` is built without `parallel-compilation`), so four permits is four cores of work. On a pod with `limits.cpu: 2` that is the entire quota, leaving nothing to poll the HTTP accept loop or drain the NATS socket. The default is now one fewer than the cores the process can see, clamped to `1..=4` — `available_parallelism` reads the cgroup quota, so that same pod admits one start and keeps a core to serve with. `--max-concurrent-starts` / `WASH_MAX_CONCURRENT_STARTS` sets it directly, and the effective value is on the `Host started` log line.

For scale: measured on an M-series core with wash-runtime's own wasmtime features, `Component::new` runs 143 ms for a 1.7 MB component and 6.8 s for an 18 MB one, at 20 MB and 403 MB peak RSS. Four of those at once is what the old default permitted.

**Host probes were hardcoded, and both were tuned alike** — a tcp connect every 20s, three failures apart, so roughly a minute of not accepting restarted the pod. Readiness at that sensitivity is right: leaving the Service is the cheap reaction to a busy host. Liveness is not the same trade, so it now waits considerably longer (period 30s, timeout 5s, five failures). Turning it off is documented for what it is rather than recommended: the operator deletes the *Host* of a host it stops hearing from and its workloads move, but the pod is not the operator's to delete (its RBAC on pods is `get;list;patch;watch`), so nothing else recycles a wedged one.

Both are `runtime.probes` values now, overridable per host group. Unlike `resources`, a group's `probes` resolve field by field so retuning one timing keeps the rest — written as a key-by-key overlay rather than sprig's `merge`, which treats every zero as unset and would drop a group's `enabled: false` and its `initialDelaySeconds: 0` alike.

`resources.maxConcurrentStarts` joins the other host knobs parked in that block. Like them it reaches the host as an env var rather than an argument: the chart is routinely paired with a host image it does not ship, and an older host aborts on an argument it does not recognise but ignores an env var it has never heard of.

### Behaviour changes

- Hosts with 5 or more visible cores keep the old concurrency of 4. Smaller ones drop: two cores now admit one start at a time.
- Liveness takes about 2.5 minutes of unresponsiveness to restart a host, where it previously took about 1.

### Known limits, deliberately left

- `available_parallelism` reads the cgroup, so it follows `limits.cpu`. The chart ships `requests.cpu: 250m` and no cpu limit, and a host with no limit sizes itself against the whole node — the new default only bites where a limit is set. Documented on the value; deriving it from `requests.cpu` through the downward API would close the gap.
- The permit is taken before the image pull, so it gates network waiting as well as compiling. Lowering it slows a rollout by more than the compile time alone. Splitting the pull permit from the compile permit is the fix, and is its own change.
- Compiles are single-threaded only because `parallel-compilation` is absent from the workspace's `wasmtime` features. Measured on 10 cores, turning it on takes the 18 MB component from 6.09 s to 1.13 s and the 1.7 MB one from 60.7 ms to 15.1 ms. That is a better lever than this one — all cores briefly rather than one core for six seconds — and it would move the bound from a permit count to the size of the rayon pool the compile runs in. Also its own change, and it wants the pool bounded at the same time.

### Not covered here

The host still handles no `SIGTERM` (`wash host` waits on `ctrl_c()`, which is SIGINT), and the chart still gives host pods `terminationGracePeriodSeconds: 0` — so the washlet's 5s command drain and `host.stop()` are unreachable under Kubernetes. Neither causes this failure; both belong in their own change.

### Verification

- `cargo check`, `cargo clippy`, `cargo fmt --check` on `wash-runtime` and `wash`
- new unit test for the core-count derivation
- `helm lint`, `helm template`, and `kubeconform -strict` over the rendered chart
- rendered by hand for: defaults, a per-group probe field override (inherits the rest), a per-group `liveness.enabled: false` (probe omitted), and `maxConcurrentStarts` set (env rendered, `resources:` block unpolluted)
