### PR TITLE
fix(chart,runtime): shutdown draining

### DIFF
--- a/.github/scripts/check-termination-grace.mjs
+++ b/.github/scripts/check-termination-grace.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Asserts every pod this repo ships is given long enough to run the shutdown
+// its own code implements, plus room to finish stopping afterwards.
+//
+// The deadlines are written down in code, and this reads them from there
+// rather than repeating the number:
+//
+//   crates/wash-runtime/src/washlet/mod.rs — COMMAND_DRAIN_TIMEOUT, how long a
+//     terminating host waits for the commands already running before it
+//     abandons them and stops, unbinding their plugins.
+//   runtime-gateway/proxy.go — how long the gateway lets the HTTP requests
+//     already in flight finish before it stops serving.
+//   controller-runtime's own 30s cap on how long a manager waits for its
+//     runnables, which bounds the operator and the gateway. That one lives in
+//     the dependency rather than in this repo, so it is written out below and
+//     the managers are checked for an override that would move it.
+//
+// A pod killed before its deadline never gets there: SIGKILL lands first and
+// the host leaves plugin bindings behind for the operator's unreachable-host
+// path to reap, or the gateway hangs up mid-response. Every deployment was
+// pinned at `terminationGracePeriodSeconds: 0` at one point, which made those
+// shutdowns unreachable in the only environment they were written for. This
+// check is what keeps that from coming back — from either side, since raising a
+// deadline past its pod's grace breaks the same way as lowering the grace under
+// its deadline.
+//
+// A Deployment this script has no rule for fails the check: a new pod needs
+// someone to decide what its shutdown is owed.
+//
+// Invoked by .github/workflows/charts.yml. Needs `helm` and `yq` on PATH.
+
+import { readFileSync } from 'node:fs';
+
+import { helmTemplate, yamlToDocs } from './lib/helm.mjs';
+
+const CHART_DIR = 'charts/runtime-operator';
+const RELEASE_NAME = 'runtime-operator';
+
+// The chart is not the only way the operator is installed; `make deploy` uses
+// this kustomize base, and it has its own grace to keep in step.
+const KUSTOMIZE_MANAGER = 'runtime-operator/config/manager/manager.yaml';
+
+// What Kubernetes gives a pod whose spec leaves the field out.
+const K8S_DEFAULT_GRACE = 30;
+
+// Room over the deadline for the pod to finish stopping once its drain is done
+// — the host still has to unbind every plugin, and a grace equal to the drain
+// is SIGKILL at the instant that work starts.
+const HEADROOM = 5;
+
+// sigs.k8s.io/controller-runtime's `defaultGracefulShutdownPeriod`: how long a
+// manager waits for its runnables to return before giving up on them.
+const MANAGER_SHUTDOWN = 30;
+// The managers that would have to opt out of it for the number to be wrong.
+const MANAGERS = ['runtime-operator/cmd/main.go', 'runtime-gateway/main.go'];
+
+// Deadlines read out of the source that implements them.
+const DRAINS = {
+  hostCommands: {
+    file: 'crates/wash-runtime/src/washlet/mod.rs',
+    pattern: /COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs\((\d+)\)/,
+    what: 'the host drains in-flight commands for',
+  },
+  gatewayRequests: {
+    file: 'runtime-gateway/proxy.go',
+    pattern: /gracefulShutdownTimeout = (\d+) \* time\.Second/,
+    what: 'the gateway drains in-flight requests for',
+  },
+};
+
+// Reads a shutdown deadline out of the source that implements it.
+function drainSeconds({ file, pattern, what }) {
+  const found = readFileSync(file, 'utf8').match(pattern);
+  if (!found) {
+    console.error(`Could not find how long ${what} in ${file}.`);
+    console.error('It moved or changed shape; re-point DRAINS at it in this script.');
+    process.exit(1);
+  }
+  return { seconds: Number(found[1]), what };
+}
+
+// The managers take controller-runtime's default shutdown period, so nothing in
+// this repo states it. An override would make MANAGER_SHUTDOWN a lie.
+function checkManagersTakeTheDefault() {
+  for (const manager of MANAGERS) {
+    if (readFileSync(manager, 'utf8').includes('GracefulShutdownTimeout')) {
+      console.error(`${manager} now sets its own GracefulShutdownTimeout.`);
+      console.error(`Read it from there instead of assuming ${MANAGER_SHUTDOWN}s in this script.`);
+      process.exit(1);
+    }
+  }
+}
+
+checkManagersTakeTheDefault();
+const hostCommands = drainSeconds(DRAINS.hostCommands);
+const gatewayRequests = drainSeconds(DRAINS.gatewayRequests);
+const managerRunnables = { seconds: MANAGER_SHUTDOWN, what: 'its manager waits for runnables for' };
+
+if (gatewayRequests.seconds > managerRunnables.seconds) {
+  console.error(
+    `The gateway drains requests for ${gatewayRequests.seconds}s, longer than the ` +
+      `${managerRunnables.seconds}s its manager waits for that drain to finish. Raise the ` +
+      "manager's GracefulShutdownTimeout or lower the drain; no pod grace can fix this one.",
+  );
+  process.exit(1);
+}
+
+// Keyed by the `wasmcloud.com/name` label the chart puts on every deployment.
+// `longest` is the slowest shutdown the pod can legitimately take.
+const RULES = {
+  hostgroup: {
+    longest: hostCommands,
+    values: 'runtime.terminationGracePeriodSeconds',
+  },
+  // Both managers are bounded by controller-runtime rather than by their own
+  // drains, the gateway's included — that drain runs inside a runnable the
+  // manager is waiting on.
+  'runtime-gateway': {
+    longest: managerRunnables,
+    values: 'gateway.terminationGracePeriodSeconds',
+  },
+  'runtime-operator': {
+    longest: managerRunnables,
+    values: 'operator.terminationGracePeriodSeconds',
+  },
+  // NATS closes its client connections and its JetStream store and is gone;
+  // nothing bounds it, so all that is asked is that it not be pinned at 0.
+  nats: {
+    longest: { seconds: 0, what: 'it handles SIGTERM and stops in' },
+    values: 'nats.terminationGracePeriodSeconds',
+  },
+};
+
+const failures = [];
+
+// Checks one pod spec's grace against the shutdown it has to cover.
+function checkGrace(name, rule, podSpec, source) {
+  const grace = podSpec?.terminationGracePeriodSeconds ?? K8S_DEFAULT_GRACE;
+  const required = rule.longest.seconds + HEADROOM;
+
+  if (grace < required) {
+    failures.push(
+      `${name}: terminationGracePeriodSeconds is ${grace}, but ${rule.longest.what} ` +
+        `${rule.longest.seconds}s and stopping takes longer still. ` +
+        `Raise \`${rule.values}\` in ${source} to at least ${required}.`,
+    );
+  } else {
+    console.log(`${name}: ${grace}s grace covers ${rule.longest.seconds}s + ${HEADROOM}s headroom`);
+  }
+}
+
+const deployments = yamlToDocs(helmTemplate(CHART_DIR, RELEASE_NAME)).filter(
+  (doc) => doc.kind === 'Deployment',
+);
+if (deployments.length === 0) {
+  console.error(`No Deployments rendered from ${CHART_DIR}; the chart or this check is broken.`);
+  process.exit(1);
+}
+
+for (const deployment of deployments) {
+  const name = deployment.metadata?.name;
+  const rule = RULES[deployment.metadata?.labels?.['wasmcloud.com/name']];
+  if (!rule) {
+    failures.push(
+      `${name}: no rule for this deployment. Add one to RULES in this script, keyed by its ` +
+        `\`wasmcloud.com/name\` label, saying what its shutdown has to cover.`,
+    );
+    continue;
+  }
+  checkGrace(name, rule, deployment.spec?.template?.spec, `${CHART_DIR}/values.yaml`);
+}
+
+const kustomized = yamlToDocs(readFileSync(KUSTOMIZE_MANAGER, 'utf8')).find(
+  (doc) => doc.kind === 'Deployment',
+);
+if (!kustomized) {
+  console.error(`No Deployment in ${KUSTOMIZE_MANAGER}; re-point this check at the operator's.`);
+  process.exit(1);
+}
+checkGrace(
+  `${KUSTOMIZE_MANAGER} (kustomize)`,
+  { longest: managerRunnables, values: 'terminationGracePeriodSeconds' },
+  kustomized.spec?.template?.spec,
+  KUSTOMIZE_MANAGER,
+);
+
+if (failures.length > 0) {
+  console.error('\nA pod is killed before it can finish shutting down:\n');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`\nAll ${deployments.length + 1} pods outlive their own shutdown.`);

--- a/.github/scripts/lib/helm.mjs
+++ b/.github/scripts/lib/helm.mjs
@@ -1,0 +1,37 @@
+// Rendering a chart and reading the manifests back out, for the checks that
+// assert something about what a chart actually produces.
+//
+// Needs `helm` and `yq` on PATH; both ship on the GitHub-hosted runners.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const MAX_OUTPUT = 64 * 1024 * 1024;
+
+// Renders a chart, optionally with `--set` overrides (`key=value` strings).
+export function helmTemplate(chartDir, releaseName, sets = []) {
+  const args = ['template', releaseName, chartDir];
+  for (const s of sets) {
+    args.push('--set', s);
+  }
+  return execFileSync('helm', args, { encoding: 'utf8', maxBuffer: MAX_OUTPUT });
+}
+
+// Parses a multi-doc YAML stream into objects.
+export function yamlToDocs(yamlText) {
+  // yq -I 0 emits one compact JSON object per YAML doc, one per line.
+  const r = spawnSync('yq', ['-o', 'json', '-I', '0'], {
+    input: yamlText,
+    encoding: 'utf8',
+    maxBuffer: MAX_OUTPUT,
+  });
+  if (r.status !== 0) {
+    throw new Error(`yq failed (exit ${r.status}): ${r.stderr.trim()}`);
+  }
+  // Empty YAML docs (`---` with no body) round-trip through yq as `null`;
+  // drop them so downstream code can assume every doc is an object.
+  return r.stdout
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+    .filter((doc) => doc != null);
+}

--- a/.github/scripts/runtime-operator-rbac-parity.mjs
+++ b/.github/scripts/runtime-operator-rbac-parity.mjs
@@ -27,8 +27,9 @@
 // grant in scoped installs, which would silently defeat the watchNamespaces
 // scoping the chart advertises.
 
-import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+
+import { helmTemplate, yamlToDocs } from './lib/helm.mjs';
 
 const CHART_DIR = 'charts/runtime-operator';
 const GENERATED_ROLE = 'runtime-operator/config/rbac/role.yaml';
@@ -78,36 +79,6 @@ const RENDER_MODES = [
     ],
   },
 ];
-
-function yamlToDocs(yamlText) {
-  // yq -I 0 emits one compact JSON object per YAML doc, one per line.
-  const r = spawnSync('yq', ['-o', 'json', '-I', '0'], {
-    input: yamlText,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  if (r.status !== 0) {
-    throw new Error(`yq failed (exit ${r.status}): ${r.stderr.trim()}`);
-  }
-  // Empty YAML docs (`---` with no body) round-trip through yq as `null`;
-  // drop them so downstream code can assume every doc is an object.
-  return r.stdout
-    .split('\n')
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line))
-    .filter((doc) => doc != null);
-}
-
-function helmTemplate(sets) {
-  const args = ['template', RELEASE_NAME, CHART_DIR];
-  for (const s of sets) {
-    args.push('--set', s);
-  }
-  return execFileSync('helm', args, {
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-}
 
 // Flat list of every rule the operator SA picks up across all bindings.
 // Scope is intentionally collapsed: tuple coverage doesn't care whether a
@@ -276,7 +247,7 @@ const dedupedNeeded = [...new Map(neededTuples.map((t) => [tupleKey(t), t])).val
 let parityFailed = false;
 let structureFailed = false;
 for (const mode of RENDER_MODES) {
-  const docs = yamlToDocs(helmTemplate(mode.sets));
+  const docs = yamlToDocs(helmTemplate(CHART_DIR, RELEASE_NAME, mode.sets));
   const chartRules = operatorRules(docs);
 
   const missing = dedupedNeeded.filter(

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -33,6 +33,9 @@ jobs:
               - 'charts/**'
               - 'runtime-operator/config/crd/bases/**'
               - '.github/workflows/charts.yml'
+              - '.github/scripts/check-termination-grace.mjs'
+              - 'crates/wash-runtime/src/washlet/mod.rs'
+              - 'runtime-gateway/proxy.go'
               - 'Makefile'
 
   test:
@@ -51,6 +54,8 @@ jobs:
         run: make helm-crds-check
       - name: Render
         run: make helm-render
+      - name: Verify every pod outlives its own shutdown
+        run: node .github/scripts/check-termination-grace.mjs
 
   # Runs `helm lint` + yamllint on the chart. The chart `version` is
   # release-driven (see .github/ct.yaml), so this does not enforce a version bump.

--- a/charts/runtime-operator/templates/gateway/deployment.yaml
+++ b/charts/runtime-operator/templates/gateway/deployment.yaml
@@ -53,5 +53,5 @@ spec:
             {{- toYaml .Values.gateway.securityContext | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/runtime-operator/templates/nats/deployment.yaml
+++ b/charts/runtime-operator/templates/nats/deployment.yaml
@@ -82,5 +82,5 @@ spec:
             {{- toYaml .Values.nats.securityContext | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ .Values.nats.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -99,5 +99,5 @@ spec:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ .Values.operator.terminationGracePeriodSeconds }}
 {{- end }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -337,6 +337,6 @@ spec:
             {{- toYaml $top.Values.runtime.securityContext | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: {{ $top.Values.runtime.terminationGracePeriodSeconds }}
 ---
 {{- end }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -97,6 +97,11 @@ nats:
     name: ""
     # -- Annotations to add to the service account
     annotations: {}
+  # -- How long a terminating NATS pod has to shut down before it is killed.
+  # On `SIGTERM` the server closes its client connections and its JetStream
+  # store, so the hosts connected to it see a disconnect rather than a stalled
+  # socket. It exits as soon as that is done; this is only the ceiling.
+  terminationGracePeriodSeconds: 30
 
 operator:
   enabled: true
@@ -201,6 +206,14 @@ operator:
   #   extraArgs:
   #     - "-cpu-backpressure-threshold=75"
   extraArgs: []
+  # -- How long a terminating operator pod has to shut down before it is
+  # killed. On `SIGTERM` the manager stops its controllers and lets the
+  # reconciles already running finish, waiting up to controller-runtime's 30s
+  # for them, so anything at or below that is SIGKILL at the moment it gives
+  # up. It does not release its leader election lease
+  # (`LeaderElectionReleaseOnCancel` is off), so the replacement waits out
+  # `LeaseDuration` either way.
+  terminationGracePeriodSeconds: 45
 
 gateway:
   # -- DEPRECATED: runtime-gateway is being removed. HTTP routing is now handled
@@ -254,6 +267,12 @@ gateway:
     name: ""
     # -- Annotations to add to the service account
     annotations: {}
+  # -- How long a terminating gateway pod has to shut down before it is killed.
+  # On `SIGTERM` the gateway stops accepting connections and gives the requests
+  # already in flight up to 15s to finish, so anything below that hangs up on a
+  # caller mid-response. It runs that drain inside a controller-runtime manager,
+  # which waits up to 30s for it, so the grace clears the longer of the two.
+  terminationGracePeriodSeconds: 45
 
 runtime:
   # -- Extra CA certificate bundles (paths inside the host container) trusted
@@ -362,6 +381,13 @@ runtime:
   # -- Additional CLI args appended to every host group container, for host
   # flags the chart does not template. Merged with per-host-group `extraArgs`.
   extraArgs: []
+  # -- How long a terminating host pod has to shut down before it is killed.
+  # On `SIGTERM` the host stops taking work, waits up to 5s for the commands
+  # already running to finish, then stops itself — unbinding every plugin the
+  # workloads it holds are bound to. Kubernetes sends `SIGKILL` when this
+  # expires, so anything below that 5s drain cuts the shutdown short and leaves
+  # the unbinding to the operator's unreachable-host path instead.
+  terminationGracePeriodSeconds: 15
   hostGroups:
     - name: default
       # -- Namespace to deploy this host group's Deployment, Service, generated

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -31,7 +31,7 @@ const MAX_CONCURRENT_STARTS: usize = 4;
 /// period a terminating pod gets, so it is killed before `host.stop()` unbinds
 /// anything. Better to abandon them and stop the host, which unbinds whatever
 /// they had bound anyway.
-const COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+pub const COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub mod types {
     pub mod v2 {

--- a/crates/wash-runtime/tests/integration_washlet_api.rs
+++ b/crates/wash-runtime/tests/integration_washlet_api.rs
@@ -13,6 +13,9 @@
 //!   that then fails (OCI pull failure in the washlet) gives the ID back.
 //! - `finalize`'s idempotent teardown: stop/status of an unknown ID answer
 //!   `WORKLOAD_STATE_NOT_FOUND` instead of erroring.
+//! - Shutdown's drain: the commands already running get `COMMAND_DRAIN_TIMEOUT`
+//!   to finish and are abandoned after it, so one stalled on a pull cannot hold
+//!   a terminating host past the grace period its pod was given.
 //! - Host registration: the published heartbeat and the `heartbeat` RPC carry
 //!   the host ID, the `hostgroup` label, and the environment the operator
 //!   records verbatim, plus a workload count that tracks running workloads.
@@ -34,10 +37,15 @@ use testcontainers::{
     core::{IntoContainerPort, WaitFor},
     runners::AsyncRunner,
 };
-use wash_runtime::washlet::{ClusterHostBuilder, heartbeat_subject, rpc_subject, types::v2};
+use wash_runtime::washlet::{
+    COMMAND_DRAIN_TIMEOUT, ClusterHostBuilder, heartbeat_subject, rpc_subject, types::v2,
+};
 
 const HOST_GROUP: &str = "e2e";
 const ENVIRONMENT: &str = "e2e-env";
+/// Slack over the drain for the abort to unwind and `host.stop()` to run, on a
+/// runner busy with the rest of the suite.
+const ABANDON_MARGIN: Duration = Duration::from_secs(10);
 
 struct TestHarness {
     api_client: async_nats::Client,
@@ -700,4 +708,39 @@ async fn heartbeat_reports_identity_and_workload_count() -> Result<()> {
     assert_eq!(refreshed.workload_count, 1);
 
     harness.shutdown().await
+}
+
+/// Shutdown waits for the commands already running — but a start stalled on an
+/// unreachable registry runs to its own pull timeout, which is minutes. Waiting
+/// that out means the pod is killed before `host.stop()` unbinds anything, so
+/// the drain is bounded and whatever outlasts it is abandoned.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn shutdown_abandons_a_start_that_outlasts_the_drain() -> Result<()> {
+    let mut harness = setup().await?;
+    let registry = StallingRegistry::bind().await?;
+
+    let start = registry.spawn_start(&harness, "washlet-api-e2e-stalled-shutdown");
+    wait_for(Duration::from_secs(10), || registry.reached() > 0)
+        .await
+        .context("no start reached the stalling registry")?;
+
+    // Awaited here rather than through `TestHarness::shutdown` so the elapsed
+    // time covers the drain alone, not the container teardown behind it.
+    let began = std::time::Instant::now();
+    let stopped = (&mut harness.shutdown).await;
+    let drained_in = began.elapsed();
+    start.abort();
+    stopped.context("shutdown failed with a start still in flight")?;
+
+    assert!(
+        drained_in >= COMMAND_DRAIN_TIMEOUT,
+        "shutdown gave the start in flight {drained_in:?}, short of the {COMMAND_DRAIN_TIMEOUT:?} drain"
+    );
+    assert!(
+        drained_in < COMMAND_DRAIN_TIMEOUT + ABANDON_MARGIN,
+        "shutdown held for {drained_in:?} on a start stalled at its registry; \
+         it must abandon the start once the {COMMAND_DRAIN_TIMEOUT:?} drain is up"
+    );
+    Ok(())
 }

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context as _, bail, ensure};
 use bytes::Bytes;
 use clap::Args;
-use tokio::{select, sync::mpsc};
+use tokio::select;
 use tracing::{debug, info, instrument, warn};
 use wash_runtime::{
     engine::{Engine, WasmProposal},
@@ -25,7 +25,7 @@ use wash_runtime::{
 use crate::{
     cli::{
         CliCommand, CliContext, CommandOutput, component_build::build_dev_component,
-        oci::OCI_CACHE_DIR,
+        oci::OCI_CACHE_DIR, signal,
     },
     config::{Config, load_config},
     wit::WitConfig,
@@ -39,6 +39,10 @@ pub struct DevCommand {}
 impl CliCommand for DevCommand {
     async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
         wash_runtime::init_crypto();
+
+        // Armed before the build below, so a signal during it stops this
+        // process rather than being ignored until the session is up.
+        let shutdown = signal::arm()?;
 
         let project_dir = ctx.project_dir();
         info!(path = ?project_dir, "starting development session for project");
@@ -397,20 +401,6 @@ impl CliCommand for DevCommand {
         let host = host_builder.build()?.start().await?;
         host.log_interfaces();
 
-        let (stop_tx, mut stop_rx) = mpsc::channel::<()>(1);
-
-        // Spawn a task to handle Ctrl + C signal
-        tokio::spawn(async move {
-            tokio::signal::ctrl_c()
-                .await
-                .context("failed to wait for ctrl_c signal")?;
-            stop_tx
-                .send(())
-                .await
-                .context("failed to send stop signal after receiving Ctrl + c")?;
-            Result::<_, anyhow::Error>::Ok(())
-        });
-
         info!("development session started, building and deploying component...");
 
         let build_result = build_dev_component(ctx, &config)
@@ -447,9 +437,13 @@ impl CliCommand for DevCommand {
         let display_addr = http_addr.replace("0.0.0.0", "127.0.0.1");
         info!(address = %format!("{}://{}", protocol, display_addr), "listening for HTTP requests");
 
+        // The component is running, so from here a signal stops the session
+        // rather than ending the process.
+        let shutdown = shutdown.ready();
+
         select! {
             // Process a stop
-            _ = stop_rx.recv() => {
+            _ = shutdown => {
                 info!("Stopping development session ...");
             },
         }

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -9,7 +9,7 @@ use wash_runtime::{
     plugin::{self},
 };
 
-use crate::cli::{CliCommand, CliContext, CommandOutput};
+use crate::cli::{CliCommand, CliContext, CommandOutput, signal};
 use crate::config::{HttpClientTrustRoots, load_config};
 
 #[derive(Debug, Clone, Args)]
@@ -543,6 +543,10 @@ impl CliCommand for HostCommand {
         // crypto provider available. Idempotent; also called by Ingress::new.
         wash_runtime::init_crypto();
 
+        // Armed before the plugin pulls below, so a signal during them stops
+        // this process rather than being ignored until the host is up.
+        let shutdown = signal::arm()?;
+
         // Picked up the same way `wash dev` reads its own config file: global
         // config merged with the project-local one, if any. `wash host` has
         // no CLI-flags-as-config-overrides of its own (unlike `wash dev`'s
@@ -874,13 +878,15 @@ impl CliCommand for HostCommand {
         let cluster_host = cluster_host_builder
             .build()
             .context("failed to build cluster host")?;
+
+        // The host is about to start taking work, so from here a signal runs
+        // the shutdown below rather than ending the process.
+        let shutdown = shutdown.ready();
         let host_cleanup = wash_runtime::washlet::run_cluster_host(cluster_host)
             .await
             .context("failed to start cluster node")?;
 
-        tokio::signal::ctrl_c()
-            .await
-            .context("failed to listen for shutdown signal")?;
+        shutdown.await;
 
         info!("Stopping host...");
 

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -34,6 +34,7 @@ pub mod host;
 pub mod inspect;
 pub mod new;
 pub mod oci;
+pub mod signal;
 pub mod update;
 pub mod wit;
 
@@ -512,12 +513,36 @@ impl CliContext {
             return Ok(true);
         }
 
+        restore_cursor_on_interrupt();
+
         Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt(prompt)
             .default(true)
             .interact()
             .context("failed to read user confirmation")
     }
+}
+
+/// Leaves a terminal usable when a prompt is interrupted: dialoguer hides the
+/// cursor while it reads, and the default disposition for `SIGINT` would end
+/// the process with it still hidden.
+///
+/// Installed here rather than at startup because it exits, which is only right
+/// for a command sitting on a prompt — one running its own shutdown installs
+/// [`signal::arm`] instead, and this handler would both pre-empt that shutdown
+/// and replace the handler it registered.
+fn restore_cursor_on_interrupt() {
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+
+    INSTALLED.call_once(|| {
+        if let Err(e) = ctrlc::set_handler(|| {
+            let _ = dialoguer::console::Term::stdout().show_cursor();
+            // Exit with standard SIGINT code (128 + 2)
+            std::process::exit(130);
+        }) {
+            tracing::warn!(err = ?e, "failed to set ctrl_c handler, an interrupted prompt may leave the cursor hidden");
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/wash/src/cli/signal.rs
+++ b/crates/wash/src/cli/signal.rs
@@ -1,0 +1,121 @@
+//! Shutdown signals for the commands that run until they are told to stop.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::Context as _;
+use tokio::sync::oneshot;
+
+/// What a process leaving on the signal it was given exits with.
+const INTERRUPTED: i32 = 130;
+const TERMINATED: i32 = 143;
+
+/// The armed shutdown signals.
+pub struct Shutdown {
+    signalled: oneshot::Receiver<()>,
+    ready: Arc<AtomicBool>,
+}
+
+/// Arms the signals asking this process to shut down, before the work they
+/// interrupt begins.
+///
+/// Kubernetes terminates a pod with `SIGTERM` and escalates to `SIGKILL` only
+/// once the grace period runs out, so a command listening for `SIGINT` alone is
+/// killed outright in a cluster and never reaches its shutdown.
+///
+/// Until [`Shutdown::ready`], a signal ends the process: a command still
+/// starting up has nothing to shut down yet, and one that sat on the signal
+/// instead could not be stopped at all while it pulled an image. After it, the
+/// signal goes to the future `ready` returns, and a second signal leaves
+/// immediately rather than waiting that shutdown out.
+pub fn arm() -> anyhow::Result<Shutdown> {
+    let mut signals = Signals::arm()?;
+    let (signalled, receiver) = oneshot::channel();
+    let ready = Arc::new(AtomicBool::new(false));
+
+    tokio::spawn({
+        let ready = Arc::clone(&ready);
+        async move {
+            let code = signals.next().await;
+            if !ready.load(Ordering::SeqCst) {
+                std::process::exit(code);
+            }
+            let _ = signalled.send(());
+            std::process::exit(signals.next().await);
+        }
+    });
+
+    Ok(Shutdown {
+        signalled: receiver,
+        ready,
+    })
+}
+
+impl Shutdown {
+    /// Hands the next signal to the returned future instead of ending the
+    /// process. Call it once there is something to shut down; awaiting the
+    /// future waits for that signal.
+    pub fn ready(self) -> impl Future<Output = ()> + Send {
+        self.ready.store(true, Ordering::SeqCst);
+        async move {
+            let _ = self.signalled.await;
+        }
+    }
+}
+
+struct Signals {
+    #[cfg(unix)]
+    interrupt: tokio::signal::unix::Signal,
+    #[cfg(unix)]
+    terminate: tokio::signal::unix::Signal,
+    #[cfg(windows)]
+    interrupt: tokio::signal::windows::CtrlC,
+    #[cfg(windows)]
+    shutdown: tokio::signal::windows::CtrlShutdown,
+    #[cfg(windows)]
+    close: tokio::signal::windows::CtrlClose,
+}
+
+#[cfg(unix)]
+impl Signals {
+    fn arm() -> anyhow::Result<Self> {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        Ok(Self {
+            interrupt: signal(SignalKind::interrupt()).context("failed to listen for SIGINT")?,
+            terminate: signal(SignalKind::terminate()).context("failed to listen for SIGTERM")?,
+        })
+    }
+
+    /// Waits for the next signal, answering with the exit code it asks for.
+    async fn next(&mut self) -> i32 {
+        tokio::select! {
+            _ = self.interrupt.recv() => INTERRUPTED,
+            _ = self.terminate.recv() => TERMINATED,
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Signals {
+    /// Ctrl-C, plus the two events a console sends a process it is about to
+    /// end: the window closing or the user logging off, and system shutdown.
+    fn arm() -> anyhow::Result<Self> {
+        use tokio::signal::windows::{ctrl_c, ctrl_close, ctrl_shutdown};
+
+        Ok(Self {
+            interrupt: ctrl_c().context("failed to listen for Ctrl-C")?,
+            shutdown: ctrl_shutdown().context("failed to listen for the shutdown event")?,
+            close: ctrl_close().context("failed to listen for the console close event")?,
+        })
+    }
+
+    async fn next(&mut self) -> i32 {
+        tokio::select! {
+            _ = self.interrupt.recv() => INTERRUPTED,
+            _ = self.shutdown.recv() => TERMINATED,
+            _ = self.close.recv() => TERMINATED,
+        }
+    }
+}

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -297,17 +297,6 @@ async fn main() {
         }
     }
 
-    // Since some interactive commands may hide the cursor, we need to ensure it is shown again on exit
-    if let Err(e) = ctrlc::set_handler(move || {
-        let term = dialoguer::console::Term::stdout();
-        let _ = term.show_cursor();
-
-        // Exit with standard SIGINT code (128 + 2)
-        std::process::exit(130);
-    }) {
-        warn!(err = ?e, "failed to set ctrl_c handler, interactive prompts may not restore cursor visibility");
-    }
-
     let command_output = if let Some(command) = cli.command {
         run_command(ctx, command).await
     } else {

--- a/crates/wash/tests/integration_host_signal.rs
+++ b/crates/wash/tests/integration_host_signal.rs
@@ -1,17 +1,28 @@
-//! Pins the shutdown a terminating `wash host` runs: the signal reaches the
-//! graceful path — drain in-flight commands, stop the host, unbind its plugins
-//! — rather than killing the process where it stands.
+//! Pins what a signal does to `wash host`, on both sides of the point where
+//! there is something to shut down.
 //!
-//! Kubernetes sends `SIGTERM`; a terminal sends `SIGINT`. Both are tested,
-//! because they took different routes to the same failure: `SIGTERM` had no
-//! handler at all, and `SIGINT` had one that exited before the shutdown it
-//! had just started could finish.
+//! Once the host is running the signal has to reach the graceful path — drain
+//! in-flight commands, stop the host, unbind its plugins — rather than killing
+//! the process where it stands. Kubernetes sends `SIGTERM`; a terminal sends
+//! `SIGINT`. Both are covered, because they took different routes to the same
+//! failure: `SIGTERM` had no handler at all, and `SIGINT` had one that exited
+//! before the shutdown it had just started could finish.
 //!
-//! Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
+//! While the host is still starting there is nothing to shut down, and the
+//! signal has to end the process instead. Holding it until startup finishes is
+//! the other way to get this wrong: a host part-way through an image pull would
+//! ignore every Ctrl-C it was sent.
+//!
+//! The running case needs Docker (NATS) and is `#[ignore]`d; the startup case
+//! needs nothing but the binary.
 
 #![cfg(unix)]
 
+use std::net::SocketAddr;
+use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -35,9 +46,95 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 /// `host.stop()`.
 const STOPPING: &str = "Stopping host...";
 
-/// Runs `wash host` against a throwaway NATS, signals it with `signal`, and
-/// returns its exit code and log once it is gone.
-async fn host_signalled_with(signal: &str) -> Result<(Option<i32>, String)> {
+/// 128 plus the signal number: what a process exits with when it leaves on the
+/// signal it was given rather than running a shutdown.
+const INTERRUPTED: i32 = 130;
+const TERMINATED: i32 = 143;
+
+/// A `wash host` under test, with its log collected as it runs.
+struct HostProcess {
+    child: Child,
+    log: tokio::task::JoinHandle<std::io::Result<String>>,
+    started: oneshot::Receiver<()>,
+}
+
+impl HostProcess {
+    /// Starts a host against `nats_url`, with a home and working directory of
+    /// its own and nothing inherited: the host reads `RUST_LOG` for the log
+    /// lines asserted here and `WASH_*` for half its flags, so whatever is set
+    /// on the machine running the test would otherwise decide what it sees.
+    fn spawn(nats_url: &str, home: &Path) -> Result<Self> {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_wash"))
+            .args([
+                "host",
+                "--host-group",
+                "signal-test",
+                "--scheduler-nats-url",
+                nats_url,
+                "--data-nats-url",
+                nats_url,
+            ])
+            .env_clear()
+            .current_dir(home)
+            .env("HOME", home)
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context("failed to spawn wash host")?;
+
+        let stderr = child.stderr.take().context("stderr was piped")?;
+        let (started_tx, started) = oneshot::channel();
+        let log = tokio::spawn(async move {
+            let mut started_tx = Some(started_tx);
+            let mut lines = BufReader::new(stderr).lines();
+            let mut log = String::new();
+            while let Some(line) = lines.next_line().await? {
+                if line.contains("Host started")
+                    && let Some(tx) = started_tx.take()
+                {
+                    let _ = tx.send(());
+                }
+                log.push_str(&line);
+                log.push('\n');
+            }
+            Ok::<_, std::io::Error>(log)
+        });
+
+        Ok(Self {
+            child,
+            log,
+            started,
+        })
+    }
+
+    /// Signals the host the way anything outside this process would — `kill(1)`
+    /// rather than a Rust-side handle, so it sees exactly what kubelet or a
+    /// terminal sends it — and reports how it went out.
+    async fn signalled_with(mut self, signal: &str) -> Result<(Option<i32>, String)> {
+        let pid = self.child.id().context("host has already exited")?;
+        let killed = std::process::Command::new("kill")
+            .arg(format!("-{signal}"))
+            .arg(pid.to_string())
+            .status()
+            .context("failed to run kill")?;
+        if !killed.success() {
+            bail!("kill -{signal} {pid} failed: {killed}");
+        }
+
+        let status = timeout(SHUTDOWN_TIMEOUT, self.child.wait())
+            .await
+            .with_context(|| format!("host still running {SHUTDOWN_TIMEOUT:?} after SIG{signal}"))?
+            .context("failed to wait for the host to exit")?;
+
+        Ok((status.code(), self.log.await??))
+    }
+}
+
+/// Runs a host on a throwaway NATS, waits until it is up, and signals it.
+async fn running_host_signalled_with(signal: &str) -> Result<(Option<i32>, String)> {
     let nats = GenericImage::new("nats", "2.12.8-alpine")
         .with_exposed_port(4222.tcp())
         .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
@@ -47,78 +144,86 @@ async fn host_signalled_with(signal: &str) -> Result<(Option<i32>, String)> {
         .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
     let nats_url = format!("nats://127.0.0.1:{}", nats.get_host_port_ipv4(4222).await?);
 
-    // A home and working directory of its own, and nothing inherited: the
-    // host reads `RUST_LOG` for the log lines asserted below and `WASH_*` for
-    // half its flags, so whatever is set on the machine running the test would
-    // otherwise decide what this test sees.
     let home = TempDir::new().context("failed to create temp home")?;
-    let mut child = Command::new(env!("CARGO_BIN_EXE_wash"))
-        .args([
-            "host",
-            "--host-group",
-            "signal-test",
-            "--scheduler-nats-url",
-            &nats_url,
-            "--data-nats-url",
-            &nats_url,
-        ])
-        .env_clear()
-        .current_dir(home.path())
-        .env("HOME", home.path())
-        .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("RUST_LOG", "info")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .context("failed to spawn wash host")?;
+    let mut host = HostProcess::spawn(&nats_url, home.path())?;
 
-    let stderr = child.stderr.take().context("stderr was piped")?;
-    let (started_tx, started_rx) = oneshot::channel();
-    let log = tokio::spawn(async move {
-        let mut started_tx = Some(started_tx);
-        let mut lines = BufReader::new(stderr).lines();
-        let mut log = String::new();
-        while let Some(line) = lines.next_line().await? {
-            if line.contains("Host started")
-                && let Some(tx) = started_tx.take()
-            {
-                let _ = tx.send(());
-            }
-            log.push_str(&line);
-            log.push('\n');
-        }
-        Ok::<_, std::io::Error>(log)
-    });
-
-    if timeout(STARTUP_TIMEOUT, started_rx).await.is_err() {
-        let _ = child.kill().await;
-        bail!("host never started: {}", log.await??);
+    if timeout(STARTUP_TIMEOUT, &mut host.started).await.is_err() {
+        bail!("host never started: {}", host.log.await??);
     }
-
-    signal_child(&child, signal)?;
-    let status = timeout(SHUTDOWN_TIMEOUT, child.wait())
-        .await
-        .with_context(|| format!("host still running {SHUTDOWN_TIMEOUT:?} after SIG{signal}"))?
-        .context("failed to wait for the host to exit")?;
-
-    Ok((status.code(), log.await??))
+    host.signalled_with(signal).await
 }
 
-/// Signals the host the way anything outside this process would — `kill(1)`
-/// rather than a Rust-side handle, so the process sees exactly what kubelet or
-/// a terminal sends it.
-fn signal_child(child: &Child, signal: &str) -> Result<()> {
-    let pid = child.id().context("host has already exited")?;
-    let killed = std::process::Command::new("kill")
-        .arg(format!("-{signal}"))
-        .arg(pid.to_string())
-        .status()
-        .context("failed to run kill")?;
-    if !killed.success() {
-        bail!("kill -{signal} {pid} failed: {killed}");
+/// Parks a host in its startup and signals it there.
+async fn starting_host_signalled_with(signal: &str) -> Result<(Option<i32>, String)> {
+    let nats = StalledNats::bind().await?;
+    let home = TempDir::new().context("failed to create temp home")?;
+    let host = HostProcess::spawn(&nats.url(), home.path())?;
+
+    // The host connects to its scheduler NATS after arming its signals and long
+    // before it has a host to stop, so a connection here puts the signal below
+    // squarely inside the startup window.
+    let reached = timeout(STARTUP_TIMEOUT, async {
+        while nats.reached() == 0 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    if reached.is_err() {
+        bail!("host never reached its NATS: {}", host.log.await??);
     }
-    Ok(())
+
+    host.signalled_with(signal).await
+}
+
+/// A listener that completes the TCP connect and then says nothing, so the
+/// host's NATS handshake hangs and it stays in startup.
+struct StalledNats {
+    addr: SocketAddr,
+    reached: Arc<AtomicUsize>,
+    accept: tokio::task::JoinHandle<()>,
+}
+
+impl StalledNats {
+    async fn bind() -> Result<Self> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind stalling NATS")?;
+        let addr = listener
+            .local_addr()
+            .context("failed to read stalling NATS address")?;
+        let reached = Arc::new(AtomicUsize::new(0));
+        let accept = tokio::spawn({
+            let reached = Arc::clone(&reached);
+            async move {
+                // Accepted and held, never answered.
+                let mut accepted = Vec::new();
+                while let Ok((stream, _)) = listener.accept().await {
+                    reached.fetch_add(1, Ordering::SeqCst);
+                    accepted.push(stream);
+                }
+            }
+        });
+        Ok(Self {
+            addr,
+            reached,
+            accept,
+        })
+    }
+
+    fn url(&self) -> String {
+        format!("nats://{}", self.addr)
+    }
+
+    /// Connections accepted so far: one per attempt the host made to reach it.
+    fn reached(&self) -> usize {
+        self.reached.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for StalledNats {
+    fn drop(&mut self) {
+        self.accept.abort();
+    }
 }
 
 /// The signal Kubernetes sends a terminating pod. Without a handler for it the
@@ -127,7 +232,7 @@ fn signal_child(child: &Child, signal: &str) -> Result<()> {
 #[tokio::test]
 #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn sigterm_runs_the_graceful_shutdown() -> Result<()> {
-    let (code, log) = host_signalled_with("TERM").await?;
+    let (code, log) = running_host_signalled_with("TERM").await?;
     assert_eq!(code, Some(0), "host did not exit cleanly on SIGTERM: {log}");
     assert!(log.contains(STOPPING), "host skipped its shutdown: {log}");
     Ok(())
@@ -138,8 +243,44 @@ async fn sigterm_runs_the_graceful_shutdown() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
 async fn sigint_runs_the_graceful_shutdown() -> Result<()> {
-    let (code, log) = host_signalled_with("INT").await?;
+    let (code, log) = running_host_signalled_with("INT").await?;
     assert_eq!(code, Some(0), "host did not exit cleanly on SIGINT: {log}");
     assert!(log.contains(STOPPING), "host skipped its shutdown: {log}");
+    Ok(())
+}
+
+/// A pod terminated while its host is still starting — stuck on an unreachable
+/// NATS here, an image pull in a cluster. There is nothing to shut down yet, so
+/// the signal has to end the process: the exit code says the host answered it,
+/// where dying by the signal would mean nothing was listening, and a test that
+/// times out here means the signal was recorded and then ignored.
+#[tokio::test]
+async fn sigterm_during_startup_ends_the_process() -> Result<()> {
+    let (code, log) = starting_host_signalled_with("TERM").await?;
+    assert_eq!(
+        code,
+        Some(TERMINATED),
+        "host did not leave on SIGTERM during startup: {log}"
+    );
+    assert!(
+        !log.contains(STOPPING),
+        "host ran a shutdown for a host it had not started: {log}"
+    );
+    Ok(())
+}
+
+/// The same, for the Ctrl-C of someone who has waited long enough on a pull.
+#[tokio::test]
+async fn sigint_during_startup_ends_the_process() -> Result<()> {
+    let (code, log) = starting_host_signalled_with("INT").await?;
+    assert_eq!(
+        code,
+        Some(INTERRUPTED),
+        "host did not leave on SIGINT during startup: {log}"
+    );
+    assert!(
+        !log.contains(STOPPING),
+        "host ran a shutdown for a host it had not started: {log}"
+    );
     Ok(())
 }

--- a/crates/wash/tests/integration_host_signal.rs
+++ b/crates/wash/tests/integration_host_signal.rs
@@ -1,0 +1,145 @@
+//! Pins the shutdown a terminating `wash host` runs: the signal reaches the
+//! graceful path — drain in-flight commands, stop the host, unbind its plugins
+//! — rather than killing the process where it stands.
+//!
+//! Kubernetes sends `SIGTERM`; a terminal sends `SIGINT`. Both are tested,
+//! because they took different routes to the same failure: `SIGTERM` had no
+//! handler at all, and `SIGINT` had one that exited before the shutdown it
+//! had just started could finish.
+//!
+//! Requires Docker (NATS); marked `#[ignore]`, run with `cargo test --include-ignored`.
+
+#![cfg(unix)]
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use tempfile::TempDir;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{
+    GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+};
+use tokio::io::{AsyncBufReadExt as _, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+/// Long enough for a debug-build host to come up on a loaded CI runner.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(90);
+/// Comfortably past the host's own 5s command drain.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// What the host logs on the graceful path, after the signal and before
+/// `host.stop()`.
+const STOPPING: &str = "Stopping host...";
+
+/// Runs `wash host` against a throwaway NATS, signals it with `signal`, and
+/// returns its exit code and log once it is gone.
+async fn host_signalled_with(signal: &str) -> Result<(Option<i32>, String)> {
+    let nats = GenericImage::new("nats", "2.12.8-alpine")
+        .with_exposed_port(4222.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+        .with_cmd(["-js"])
+        .start()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to start nats: {e}"))?;
+    let nats_url = format!("nats://127.0.0.1:{}", nats.get_host_port_ipv4(4222).await?);
+
+    // A home and working directory of its own, and nothing inherited: the
+    // host reads `RUST_LOG` for the log lines asserted below and `WASH_*` for
+    // half its flags, so whatever is set on the machine running the test would
+    // otherwise decide what this test sees.
+    let home = TempDir::new().context("failed to create temp home")?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wash"))
+        .args([
+            "host",
+            "--host-group",
+            "signal-test",
+            "--scheduler-nats-url",
+            &nats_url,
+            "--data-nats-url",
+            &nats_url,
+        ])
+        .env_clear()
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("failed to spawn wash host")?;
+
+    let stderr = child.stderr.take().context("stderr was piped")?;
+    let (started_tx, started_rx) = oneshot::channel();
+    let log = tokio::spawn(async move {
+        let mut started_tx = Some(started_tx);
+        let mut lines = BufReader::new(stderr).lines();
+        let mut log = String::new();
+        while let Some(line) = lines.next_line().await? {
+            if line.contains("Host started")
+                && let Some(tx) = started_tx.take()
+            {
+                let _ = tx.send(());
+            }
+            log.push_str(&line);
+            log.push('\n');
+        }
+        Ok::<_, std::io::Error>(log)
+    });
+
+    if timeout(STARTUP_TIMEOUT, started_rx).await.is_err() {
+        let _ = child.kill().await;
+        bail!("host never started: {}", log.await??);
+    }
+
+    signal_child(&child, signal)?;
+    let status = timeout(SHUTDOWN_TIMEOUT, child.wait())
+        .await
+        .with_context(|| format!("host still running {SHUTDOWN_TIMEOUT:?} after SIG{signal}"))?
+        .context("failed to wait for the host to exit")?;
+
+    Ok((status.code(), log.await??))
+}
+
+/// Signals the host the way anything outside this process would — `kill(1)`
+/// rather than a Rust-side handle, so the process sees exactly what kubelet or
+/// a terminal sends it.
+fn signal_child(child: &Child, signal: &str) -> Result<()> {
+    let pid = child.id().context("host has already exited")?;
+    let killed = std::process::Command::new("kill")
+        .arg(format!("-{signal}"))
+        .arg(pid.to_string())
+        .status()
+        .context("failed to run kill")?;
+    if !killed.success() {
+        bail!("kill -{signal} {pid} failed: {killed}");
+    }
+    Ok(())
+}
+
+/// The signal Kubernetes sends a terminating pod. Without a handler for it the
+/// process takes the default disposition and dies where it stands, which is
+/// every plugin left bound behind it.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn sigterm_runs_the_graceful_shutdown() -> Result<()> {
+    let (code, log) = host_signalled_with("TERM").await?;
+    assert_eq!(code, Some(0), "host did not exit cleanly on SIGTERM: {log}");
+    assert!(log.contains(STOPPING), "host skipped its shutdown: {log}");
+    Ok(())
+}
+
+/// The same path from a terminal. This one exits cleanly only as long as no
+/// process-wide handler exits ahead of the shutdown it starts.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn sigint_runs_the_graceful_shutdown() -> Result<()> {
+    let (code, log) = host_signalled_with("INT").await?;
+    assert_eq!(code, Some(0), "host did not exit cleanly on SIGINT: {log}");
+    assert!(log.contains(STOPPING), "host skipped its shutdown: {log}");
+    Ok(())
+}

--- a/runtime-gateway/proxy.go
+++ b/runtime-gateway/proxy.go
@@ -10,6 +10,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// How long the gateway lets the requests already in flight finish once it is
+// told to stop. The pod's terminationGracePeriodSeconds has to clear it, or
+// SIGKILL lands mid-response; .github/scripts/check-termination-grace.mjs
+// reads this and checks that it does.
+const gracefulShutdownTimeout = 15 * time.Second
+
 type HTTPGateway struct {
 	BindAddr string
 	Proxy    *httputil.ReverseProxy
@@ -26,9 +32,15 @@ func (h *HTTPGateway) SetupWithManager(ctx context.Context, manager ctrl.Manager
 func (h *HTTPGateway) Start(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("http-gateway")
 
+	// Requests take the manager's context values — its logger — but not its
+	// cancellation. Cancelling it is what starts the shutdown, and handing that
+	// same context to the handlers cancels every request the drain below exists
+	// to let finish, answering each one 502 instead.
+	serving := context.WithoutCancel(ctx)
+
 	publicFacing := &http.Server{
 		BaseContext: func(_ net.Listener) context.Context {
-			return ctx
+			return serving
 		},
 		Addr:              h.BindAddr,
 		Handler:           h.Proxy,
@@ -38,9 +50,11 @@ func (h *HTTPGateway) Start(ctx context.Context) error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	drained := make(chan struct{})
 	go func() {
+		defer close(drained)
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 		defer cancel()
 
 		if err := publicFacing.Shutdown(shutdownCtx); err != nil {
@@ -53,6 +67,12 @@ func (h *HTTPGateway) Start(ctx context.Context) error {
 	if err := publicFacing.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err
 	}
+
+	// Shutdown closes the listener first, so ListenAndServe returns while the
+	// requests already in flight are still being served. Returning here ends
+	// this runnable, and with it the manager and the process, hanging up on
+	// every one of them.
+	<-drained
 
 	return nil
 

--- a/runtime-gateway/proxy_test.go
+++ b/runtime-gateway/proxy_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+// freePort returns an address nothing is listening on, for a server that takes
+// its address as a string rather than a listener.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve a port: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("release the reserved port: %v", err)
+	}
+	return addr
+}
+
+type proxiedResponse struct {
+	status int
+	err    error
+}
+
+// A terminating gateway has to finish what it is already serving. The gateway
+// is a controller-runtime runnable, so the manager waits for Start to return
+// and the process exits behind it — and the shutdown it runs closes the
+// listener before it drains, which is what makes both halves of this easy to
+// get wrong: returning as soon as the listener closes ends the process with
+// requests in flight, and handing those requests a context that the shutdown
+// itself cancels aborts them where they stand.
+func TestStartWaitsForInFlightRequests(t *testing.T) {
+	var releaseOnce sync.Once
+	released := make(chan struct{})
+	release := func() { releaseOnce.Do(func() { close(released) }) }
+
+	received := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(received)
+		select {
+		case <-released:
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+		}
+	}))
+	// Registered before the release below so cleanup runs it second: closing
+	// the backend waits for its handlers, which are waiting on the release.
+	t.Cleanup(backend.Close)
+	t.Cleanup(release)
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	addr := freePort(t)
+	gateway := &HTTPGateway{
+		BindAddr: addr,
+		Proxy: &httputil.ReverseProxy{
+			Rewrite: func(r *httputil.ProxyRequest) { r.SetURL(backendURL) },
+		},
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(stop)
+	started := make(chan error, 1)
+	go func() { started <- gateway.Start(ctx) }()
+
+	waitForListener(t, addr)
+
+	responded := make(chan proxiedResponse, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr + "/")
+		if err != nil {
+			responded <- proxiedResponse{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		// Read it out so the connection goes idle and the drain can finish.
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			responded <- proxiedResponse{err: err}
+			return
+		}
+		responded <- proxiedResponse{status: resp.StatusCode}
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the backend never received the proxied request")
+	}
+
+	// The pod is terminating with that request still being served.
+	stop()
+
+	select {
+	case err := <-started:
+		t.Fatalf("Start returned (%v) with a request still in flight; the process exits behind it", err)
+	case got := <-responded:
+		t.Fatalf("the in-flight request was cut short by the shutdown: %+v", got)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	release()
+
+	got := <-responded
+	if got.err != nil {
+		t.Fatalf("the in-flight request did not complete: %v", got.err)
+	}
+	if got.status != http.StatusOK {
+		t.Errorf("in-flight request finished with %d, want %d", got.status, http.StatusOK)
+	}
+
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Errorf("Start returned %v, want nil once drained", err)
+		}
+	case <-time.After(gracefulShutdownTimeout):
+		t.Fatal("Start never returned after the drain finished")
+	}
+}
+
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			if err := conn.Close(); err != nil {
+				t.Fatalf("close the probe connection: %v", err)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("the gateway never listened on %s", addr)
+}

--- a/runtime-operator/config/manager/manager.yaml
+++ b/runtime-operator/config/manager/manager.yaml
@@ -92,4 +92,8 @@ spec:
             cpu: 10m
             memory: 64Mi
       serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10
+      # Clears controller-runtime's 30s wait for its runnables, with room to
+      # exit after it. Kept in step with the chart's
+      # `operator.terminationGracePeriodSeconds` by
+      # .github/scripts/check-termination-grace.mjs.
+      terminationGracePeriodSeconds: 45

--- a/runtime-operator/internal/controller/runtime/host_pod_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/host_pod_controller_test.go
@@ -109,10 +109,10 @@ func TestDeleteHostForPod(t *testing.T) {
 	})
 
 	t.Run("spares a replacement registered inside the grace window", func(t *testing.T) {
-		// The chart pins terminationGracePeriodSeconds to 0, but the
-		// Kubernetes default is 30s and a hand-written manifest or a drain
-		// gets one. DeletionTimestamp then sits in the future, covering the
-		// live hosts a replacement registered while this Pod wound down.
+		// A terminating pod gets a grace period — 30s on the Kubernetes
+		// default, 15s for a host pod from the chart — so DeletionTimestamp
+		// sits that far in the future, covering the live hosts a replacement
+		// registered while this Pod wound down.
 		recycled := hostAt("replacement-host", podIP, condemnedAt.Add(8*time.Second))
 		c := newHostPodClient(t, recycled)
 		r := &HostPodReconciler{Client: c, OperatorNamespace: testNamespace}


### PR DESCRIPTION
A terminating `wash host` never ran the shutdowns for properly draining the host. `crates/wash/src/cli/host.rs` waited on `tokio::signal::ctrl_c()`, which is SIGINT.

The chart's container runs `wash host` so in Kubernetes SIGTERM killed the process. Draining in `host.stop()`, and the plugin unbinding behind it were unreachable in k8s.

Every pod in the chart has `terminationGracePeriodSeconds: 0`, so kubelet followed SIGTERM with an immediate SIGKILL. Nothing had room to finish: host's 5s `COMMAND_DRAIN_TIMEOUT`, gateway's 15s request drain, nor the operator's reconciles.

The gateway's `Shutdown` closes the listener before it drains, so `ListenAndServe` returned and `Start` returned with it. `Start` is a controller-runtime runnable, so the manager stopped waiting and the process exited.

## Fix

`crates/wash/src/cli/signal.rs` arms SIGINT and SIGTERM before the work they interrupt. `wash host` opens that window as the host starts taking work and `wash dev` once its component is running.

The gateway waits for its drain before returning, and serves requests from a context carrying the manager's values without its cancellation.

Chart graces are values-driven: **15** for hostgroups (clears the 5s drain), **45** for the operator and gateway (clears controller-runtime's 30s wait for runnables), **30** for nats. The kustomize base behind `make deploy` was on 10 and moves to 45.

`.github/scripts/check-termination-grace.mjs` is a drift and headroom checker. It reads each deadline out of the source that implements it and asserts every pod clears it with headroom. Catches drift from either side: a grace lowered under a deadline, or a deadline raised past its grace. It fails on a deployment it has no rule for, and on a manager that sets its own terminationGracePeriod.
