### PR TITLE
 One attribute scheme for guest metrics

### DIFF
--- a/crates/wash-runtime/src/engine/abandon.rs
+++ b/crates/wash-runtime/src/engine/abandon.rs
@@ -337,19 +337,58 @@ impl ExecutionCredit {
 /// a store serving several at once — a pooled instance, a plugin store, any
 /// component under the concurrent ABI — includes its neighbours' execution.
 /// Fuel was per-store in exactly the same way.
+///
+/// That is why this credits `guest.execution.total` itself, here, where the
+/// execution is observed and the store is known: a store several calls share
+/// has no per-call answer to give, but it has one of its own. A per-call
+/// histogram sample is left to the calls that can prove they had the store
+/// alone — see [`Self::enter`].
+///
+/// The counter is a **floor**, for the same reason the histogram is and one
+/// more. It is credited only from callback fires, so execution below one
+/// sampling window is invisible; and [`rearm_for_call`] pushes the deadline out
+/// at the start of every call, so a store taking calls faster than a window
+/// can starve the callback and credit nothing at all. Read it as "at least this
+/// much guest execution happened here", never as utilisation.
 #[derive(Default, Debug)]
-pub struct GuestExecution(AtomicU64);
+pub struct GuestExecution {
+    millis: AtomicU64,
+    /// Whose execution this store runs, stamped once when it is built. Absent
+    /// only on a store built outside a workload — the engine's own probes.
+    ///
+    /// Kept here because the store outlives every call on it, which is what
+    /// lets a task on the store name itself without the dispatcher that sent
+    /// it having to know: a service's HTTP ingress has no workload handle to
+    /// look one up from, and does not need one.
+    /// Whose execution this store runs. Read by a task on the store that has
+    /// to name itself — a service's HTTP ingress has no workload handle to look
+    /// one up from.
+    stamp: std::sync::OnceLock<crate::observability::WorkloadIdentity>,
+}
 
 impl GuestExecution {
     /// Guest execution credited to this store so far, in milliseconds.
     pub fn millis(&self) -> u64 {
-        self.0.load(Ordering::Relaxed)
+        self.millis.load(Ordering::Relaxed)
+    }
+
+    /// Stamp whose execution this store runs. First stamp wins; a store's
+    /// identity does not change under it.
+    pub fn set_identity(&self, identity: crate::observability::WorkloadIdentity) {
+        let _ = self.stamp.set(identity);
+    }
+
+    /// Whose execution this store runs, for a task on it that has to name
+    /// itself. `None` on a store built outside a workload.
+    pub fn identity(&self) -> Option<&crate::observability::WorkloadIdentity> {
+        self.stamp.get()
     }
 
     fn add(&self, millis: u64) {
-        if millis > 0 {
-            self.0.fetch_add(millis, Ordering::Relaxed);
+        if millis == 0 {
+            return;
         }
+        self.millis.fetch_add(millis, Ordering::Relaxed);
     }
 }
 

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -123,54 +123,51 @@ pub(crate) trait PluginJob: Send + 'static {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 }
 
-/// Measures the guest execution one pooled call adds, and records it when
-/// dropped.
+/// Times one guest invocation, and records it when dropped.
 ///
-/// Every pooled call is metered, not just the ones a plugin remembered to wrap:
-/// `guest.execution.time` is the only signal an operator has for what a warm
-/// instance is spending, and a histogram whose population depends on which
-/// call site opted in cannot be read as a distribution.
+/// Wall clock, which is what a caller waited and what a latency dashboard is
+/// asking for. It is exact per call, unlike a delta of the store-wide execution
+/// counter, which is only this call's when no other call shared the store —
+/// see [`crate::engine::abandon::GuestExecution`], which answers the separate
+/// question of how much CPU a workload burned.
 ///
 /// Recording on drop is what makes it cover a call that ends by trapping or
-/// timing out — the two an operator most wants in the histogram, and the two an
-/// early return would otherwise skip.
+/// timing out — the two an operator most wants, and the two an early return
+/// would otherwise skip. `error` names what went wrong for the ones that can
+/// say; a call that ends without setting it is recorded as a success.
 ///
-/// Started once the export has resolved, not before: a call that never reached
-/// guest code has no execution to report, and recording it anyway would put a
-/// 0ms observation in the same bucket as a genuinely fast call.
-///
-/// A plugin serving a call from a store of its own — because the component
-/// declared no pool, or because every instance was busy — starts one of these
-/// too, so a component's measurements do not depend on whether it opted into
-/// pooling.
-pub(crate) struct ExecutionSample {
-    executed: Arc<crate::engine::abandon::GuestExecution>,
-    before: u64,
+/// Costs nothing on a host that is not metering: the meter is looked up once at
+/// the start, and finding none skips the clock as well as the record.
+pub(crate) struct InvocationSample {
+    /// `None` when nothing will record this, which is the default host.
+    started: Option<std::time::Instant>,
     attributes: Arc<[opentelemetry::KeyValue]>,
+    error: Option<&'static str>,
 }
 
-impl ExecutionSample {
-    pub(crate) fn start(
-        accessor: &Accessor<SharedCtx>,
-        attributes: Arc<[opentelemetry::KeyValue]>,
-    ) -> Self {
-        let executed = accessor.with(|mut access| Arc::clone(&access.get().executed));
-        let before = executed.millis();
+impl InvocationSample {
+    pub(crate) fn start(attributes: Arc<[opentelemetry::KeyValue]>) -> Self {
         Self {
-            executed,
-            before,
+            started: crate::observability::invocation_meter().map(|_| std::time::Instant::now()),
             attributes,
+            error: None,
         }
+    }
+
+    /// Mark what went wrong, for a call site that knows. The value is a short
+    /// bounded name — `trap`, `timeout` — never anything a caller supplies.
+    pub(crate) fn failed(&mut self, error: &'static str) {
+        self.error = Some(error);
     }
 }
 
-impl Drop for ExecutionSample {
+impl Drop for InvocationSample {
     fn drop(&mut self) {
-        if let Some(meter) = crate::observability::execution_time_meter() {
-            meter.record(
-                &self.attributes,
-                self.executed.millis().saturating_sub(self.before),
-            );
+        let Some(started) = self.started else {
+            return;
+        };
+        if let Some(meter) = crate::observability::invocation_meter() {
+            meter.record(&self.attributes, started.elapsed(), self.error);
         }
     }
 }
@@ -285,7 +282,7 @@ impl AccessorTask<SharedCtx> for LinkedTask {
                 return Ok(());
             }
         };
-        let _sample = ExecutionSample::start(accessor, attributes);
+        let _sample = InvocationSample::start(attributes);
 
         let mut results = vec![Val::Bool(false); results_len];
         let call_timeout = crate::timeouts::ephemeral_call();
@@ -481,7 +478,6 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
-                                    attributes,
                                 } = *job;
                                 let Some(service) = bound.http.as_ref().map(Arc::clone) else {
                                     // Admission declines HTTP for an instance
@@ -498,7 +494,6 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
-                                    attributes,
                                     pool_slot: Some(PoolSlot {
                                         state: Arc::clone(&task_state),
                                         _in_flight: guard,

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -70,6 +70,9 @@ pub(crate) struct LinkedJob {
     /// The abandonment flag of the dispatched call enforcing this job's
     /// deadline (see [`crate::engine::abandon`]).
     pub(crate) abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+    /// What this call is measured under, built where the link is prepared —
+    /// the manifest identity a linked call needs is not reachable from here.
+    pub(crate) attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 /// Work an instance can be given. Every shape runs as a concurrent task on the
@@ -143,13 +146,13 @@ pub(crate) trait PluginJob: Send + 'static {
 pub(crate) struct ExecutionSample {
     executed: Arc<crate::engine::abandon::GuestExecution>,
     before: u64,
-    attributes: Vec<opentelemetry::KeyValue>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 impl ExecutionSample {
     pub(crate) fn start(
         accessor: &Accessor<SharedCtx>,
-        attributes: Vec<opentelemetry::KeyValue>,
+        attributes: Arc<[opentelemetry::KeyValue]>,
     ) -> Self {
         let executed = accessor.with(|mut access| Arc::clone(&access.get().executed));
         let before = executed.millis();
@@ -260,6 +263,7 @@ impl AccessorTask<SharedCtx> for LinkedTask {
             export_name,
             reply,
             abandoned,
+            attributes,
         } = *self.job;
         let instance = self.instance;
 
@@ -281,6 +285,7 @@ impl AccessorTask<SharedCtx> for LinkedTask {
                 return Ok(());
             }
         };
+        let _sample = ExecutionSample::start(accessor, attributes);
 
         let mut results = vec![Val::Bool(false); results_len];
         let call_timeout = crate::timeouts::ephemeral_call();
@@ -476,6 +481,7 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
+                                    attributes,
                                 } = *job;
                                 let Some(service) = bound.http.as_ref().map(Arc::clone) else {
                                     // Admission declines HTTP for an instance
@@ -492,6 +498,7 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
+                                    attributes,
                                     pool_slot: Some(PoolSlot {
                                         state: Arc::clone(&task_state),
                                         _in_flight: guard,

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -387,33 +387,41 @@ pub(crate) async fn new_store_from_templates(
     Ok(store)
 }
 
-/// The warm-instance pool of the component this call targets, or `None` when
-/// this store must not be parked — see [`instance_pool::poolable`], which also
-/// accounts for the linked components instantiated into the same store.
+/// The callee's warm-instance pool, or `None` when this store must not be
+/// parked — see [`instance_pool::poolable`], which also accounts for the linked
+/// components instantiated into the same store.
 ///
 /// Read from the component map per call rather than captured at link time, so
 /// a component whose entry is replaced does not keep serving from a pool that
 /// belongs to the old entry.
-/// The callee's pool, and the manifest identity its calls are measured under.
-///
-/// Both come from one read of the component map, so they cannot disagree about
-/// which snapshot they saw. The identity is the *callee's* because it is the
-/// callee's guest code the histogram times, and it is built only when a pool
-/// exists — an unpooled call is not measured, so resolving it would be three
-/// allocations of pure waste on the default path.
-async fn callee_pool_and_identity(
-    call: &EphemeralLinkedCall,
-) -> Option<(Arc<InstancePool>, crate::observability::WorkloadIdentity)> {
+async fn callee_instance_pool(call: &EphemeralLinkedCall) -> Option<Arc<InstancePool>> {
     let components = call.components.read().await;
     let linked: HashSet<Arc<str>> = call.linked_component_ids.iter().cloned().collect();
-    let pool = instance_pool::poolable(&components, &call.active_component_id, &linked)?;
-    let component = components.get(&call.active_component_id)?;
-    let identity = crate::observability::WorkloadIdentity::new(
-        component.metadata().workload_namespace(),
-        component.metadata().workload_name(),
-        component.name(),
-    );
-    Some((pool, identity))
+    instance_pool::poolable(&components, &call.active_component_id, &linked)
+}
+
+/// What a linked call is measured under, or an empty set when nothing will
+/// record it.
+///
+/// The identity is the *callee's*, because it is the callee's guest code the
+/// histogram times, and every path that runs that code uses this — pooled or in
+/// a store of its own, plain args or relocated ones.
+///
+/// Nothing records unless the host chose the epoch meter, so on every other
+/// host this is a read lock, a `format!` and six allocations per linked call
+/// for a value no one reads. An empty set is what a sample that records nothing
+/// needs.
+async fn linked_attributes(
+    call: &EphemeralLinkedCall,
+    inv: &LinkedExportInvocation,
+) -> Arc<[opentelemetry::KeyValue]> {
+    let Some(identity) = callee_identity(call).await else {
+        return Arc::from([]);
+    };
+    identity.attributes(
+        "linked",
+        &format!("{}#{}", inv.import_name, inv.export_name),
+    )
 }
 
 async fn new_ephemeral_store(
@@ -468,7 +476,7 @@ async fn new_ephemeral_store(
         (active, linked, linked_instances)
     };
 
-    new_store_from_templates(
+    let store = new_store_from_templates(
         &call.engine,
         call.http_handler.clone(),
         &active,
@@ -476,7 +484,28 @@ async fn new_ephemeral_store(
         &linked_instances,
         false,
     )
-    .await
+    .await?;
+    if let Some(identity) = callee_identity(call).await {
+        store.data().executed.set_identity(identity);
+    }
+    Ok(store)
+}
+
+/// The callee's manifest identity, for stamping a store or naming a call.
+///
+/// `None` when nothing will read it, or when the component has left the map —
+/// a call racing a teardown, which is about to fail anyway.
+async fn callee_identity(
+    call: &EphemeralLinkedCall,
+) -> Option<crate::observability::WorkloadIdentity> {
+    crate::observability::invocation_meter()?;
+    let components = call.components.read().await;
+    let component = components.get(&call.active_component_id)?;
+    Some(crate::observability::WorkloadIdentity::new(
+        component.metadata().workload_namespace(),
+        component.metadata().workload_name(),
+        component.name(),
+    ))
 }
 
 #[derive(Clone)]
@@ -567,6 +596,10 @@ async fn invoke_ephemeral_relocated(
     param_tys: Arc<[Type]>,
     result_tys: Arc<[Type]>,
 ) -> wasmtime::Result<()> {
+    // This path runs guest code like the plain one, so it is measured like it:
+    // a signature carrying a `stream` or `future` is not a reason for a call to
+    // be missing from the histogram.
+    let attributes = linked_attributes(ephemeral_call, inv).await;
     // Extract args in the caller store: source-stream pumps run under the
     // caller's (long-lived) runtime, so their drain signals are dropped here.
     let args = accessor.with(|mut access| -> wasmtime::Result<Vec<Relocated>> {
@@ -646,6 +679,8 @@ async fn invoke_ephemeral_relocated(
                         }
                         Ok((func, arg_vals))
                     })?;
+                    let _sample =
+                        crate::engine::instance_driver::InvocationSample::start(attributes);
                     let mut results_buf = vec![Val::Bool(false); result_tys.len()];
                     let call_timeout = crate::timeouts::ephemeral_call();
                     timeout(
@@ -762,14 +797,15 @@ async fn invoke_ephemeral_plain(
         "invoking ephemeral dynamic export"
     );
 
-    let pooled = callee_pool_and_identity(ephemeral_call).await;
+    let pool = callee_instance_pool(ephemeral_call).await;
+    let attributes = linked_attributes(ephemeral_call, inv).await;
 
     // The params travel into the pooled job. A job the pool declines hands
     // them back, so the cold path below reuses that allocation rather than
     // cloning them a second time.
     let mut declined_params = None;
 
-    if let Some((pool, identity)) = pooled.as_ref() {
+    if let Some(pool) = pool.as_ref() {
         let (reply, reply_rx) = tokio::sync::oneshot::channel();
         // Deadline enforced here, in the caller's task, outside the callee's
         // store — where a non-yielding callee cannot block it (see
@@ -786,10 +822,7 @@ async fn invoke_ephemeral_plain(
             export_name: inv.export_name.clone(),
             reply,
             abandoned: call.flag(),
-            attributes: identity.attributes(
-                "linked",
-                &format!("{}#{}", inv.import_name, inv.export_name),
-            ),
+            attributes: Arc::clone(&attributes),
         }));
         let outcome = match pool.try_dispatch(job) {
             Dispatch::Sent => Ok(()),
@@ -870,6 +903,10 @@ async fn invoke_ephemeral_plain(
                         )
                     })
                 })?;
+                // Started once the export resolves, as on the pooled path: a
+                // component that declared no pool is the default, and its calls
+                // belong in the same histogram.
+                let _sample = crate::engine::instance_driver::InvocationSample::start(attributes);
                 let call_timeout = crate::timeouts::ephemeral_call();
                 timeout(
                     call_timeout,

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -394,10 +394,26 @@ pub(crate) async fn new_store_from_templates(
 /// Read from the component map per call rather than captured at link time, so
 /// a component whose entry is replaced does not keep serving from a pool that
 /// belongs to the old entry.
-async fn callee_instance_pool(call: &EphemeralLinkedCall) -> Option<Arc<InstancePool>> {
+/// The callee's pool, and the manifest identity its calls are measured under.
+///
+/// Both come from one read of the component map, so they cannot disagree about
+/// which snapshot they saw. The identity is the *callee's* because it is the
+/// callee's guest code the histogram times, and it is built only when a pool
+/// exists — an unpooled call is not measured, so resolving it would be three
+/// allocations of pure waste on the default path.
+async fn callee_pool_and_identity(
+    call: &EphemeralLinkedCall,
+) -> Option<(Arc<InstancePool>, crate::observability::WorkloadIdentity)> {
     let components = call.components.read().await;
     let linked: HashSet<Arc<str>> = call.linked_component_ids.iter().cloned().collect();
-    instance_pool::poolable(&components, &call.active_component_id, &linked)
+    let pool = instance_pool::poolable(&components, &call.active_component_id, &linked)?;
+    let component = components.get(&call.active_component_id)?;
+    let identity = crate::observability::WorkloadIdentity::new(
+        component.metadata().workload_namespace(),
+        component.metadata().workload_name(),
+        component.name(),
+    );
+    Some((pool, identity))
 }
 
 async fn new_ephemeral_store(
@@ -746,14 +762,14 @@ async fn invoke_ephemeral_plain(
         "invoking ephemeral dynamic export"
     );
 
-    let pool = callee_instance_pool(ephemeral_call).await;
+    let pooled = callee_pool_and_identity(ephemeral_call).await;
 
     // The params travel into the pooled job. A job the pool declines hands
     // them back, so the cold path below reuses that allocation rather than
     // cloning them a second time.
     let mut declined_params = None;
 
-    if let Some(pool) = pool.as_ref() {
+    if let Some((pool, identity)) = pooled.as_ref() {
         let (reply, reply_rx) = tokio::sync::oneshot::channel();
         // Deadline enforced here, in the caller's task, outside the callee's
         // store — where a non-yielding callee cannot block it (see
@@ -770,6 +786,10 @@ async fn invoke_ephemeral_plain(
             export_name: inv.export_name.clone(),
             reply,
             abandoned: call.flag(),
+            attributes: identity.attributes(
+                "linked",
+                &format!("{}#{}", inv.import_name, inv.export_name),
+            ),
         }));
         let outcome = match pool.try_dispatch(job) {
             Dispatch::Sent => Ok(()),

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1484,6 +1484,12 @@ impl ResolvedWorkload {
     /// deep-clone its by-value `Linker`, and `pre_instantiate_ref` needs only
     /// read access, so concurrent callers don't serialize on a write lock.
     /// Nothing is retained past the returned store.
+    /// A store for `component_id`, stamped with whose execution it runs.
+    ///
+    /// The stamp is what lets the epoch callback credit `guest.execution.total`
+    /// without a call to hang the number on — the only correct instrument for a
+    /// store several calls share. See
+    /// [`crate::engine::abandon::GuestExecution`].
     pub async fn new_store(
         &self,
         component_id: &str,
@@ -1511,7 +1517,7 @@ impl ResolvedWorkload {
                 linked_instances,
             )
         };
-        new_store_from_templates(
+        let store = new_store_from_templates(
             &engine,
             self.http_handler.clone(),
             &active_template,
@@ -1519,7 +1525,17 @@ impl ResolvedWorkload {
             &linked_instances,
             false,
         )
-        .await
+        .await?;
+        // Skipped when nothing will read it: the p2 HTTP path builds a store
+        // per request and the per-message messaging paths one per message, so
+        // the read lock and the allocations below are on their hot path.
+        if crate::observability::invocation_meter().is_some() {
+            store
+                .data()
+                .executed
+                .set_identity(self.component_identity(component_id).await);
+        }
+        Ok(store)
     }
 
     /// The pool a request store for `component_id` may be parked in, or `None`
@@ -1541,28 +1557,44 @@ impl ResolvedWorkload {
             .map_or(1, |component| component.instances.call_concurrency())
     }
 
-    /// The manifest identity a component's guest-execution measurements carry.
+    /// The manifest identity an item's guest-execution measurements carry.
     ///
     /// Manifest names throughout, never the ids — see
     /// [`crate::observability::WorkloadIdentity`] for why. Resolve it once
     /// where a subscription or a route is set up rather than per call: the
-    /// component name costs a read lock, and it cannot change under a
-    /// resolved workload.
+    /// name costs a read lock, and it cannot change under a resolved workload.
     pub async fn component_identity(
         &self,
-        component_id: &str,
+        item_id: &str,
     ) -> crate::observability::WorkloadIdentity {
+        // The workload's service is bound as an item like any component and its
+        // id arrives here the same way, but it lives outside the component map
+        // — so answer for it explicitly rather than letting the lookup miss.
+        // Every messaging delivery to a trigger service passes a service id,
+        // so a miss here is the steady state for those workloads, not a race.
+        // `service` is the name `wasmcloud:messaging`'s admission counter uses
+        // for the same item, so the two metrics agree.
+        if let Some(service) = &self.service
+            && service.id() == item_id
+        {
+            return crate::observability::WorkloadIdentity::new(
+                self.namespace(),
+                self.name(),
+                "service",
+            );
+        }
         let name = self
             .components
             .read()
             .await
-            .get(component_id)
+            .get(item_id)
             .map(|component| Arc::<str>::from(component.name()));
         crate::observability::WorkloadIdentity::new(
             self.namespace(),
             self.name(),
-            // A component absent from the map is one being torn down; the call
-            // that raced it still has to be measured under something.
+            // Neither a live component nor the service: an item being torn
+            // down. The call that raced it still has to be measured under
+            // something.
             name.as_deref().unwrap_or("unknown"),
         )
     }
@@ -1606,7 +1638,7 @@ impl ResolvedWorkload {
         is_service: bool,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
         let recipe = self.service_store_recipe(metadata).await?;
-        new_store_from_templates(
+        let store = new_store_from_templates(
             &recipe.engine,
             recipe.http_handler.clone(),
             &recipe.active_template,
@@ -1614,7 +1646,36 @@ impl ResolvedWorkload {
             &recipe.linked_instances,
             is_service,
         )
-        .await
+        .await?;
+        // A service's store is the one that most needs this: it serves every
+        // ingress the workload has, concurrently, for the life of the workload,
+        // so no call on it can attribute a delta to itself and
+        // `guest.execution.total` is all there is. See
+        // [`crate::engine::abandon::GuestExecution`].
+        if crate::observability::invocation_meter().is_some() {
+            store
+                .data()
+                .executed
+                .set_identity(self.service_identity(metadata));
+        }
+        Ok(store)
+    }
+
+    /// The identity a service's store runs under.
+    ///
+    /// Named `service` rather than by a component name it does not have — the
+    /// same name `wasmcloud:messaging`'s admission counter gives it, so the two
+    /// metrics join. A component's store is stamped by [`Self::new_store`],
+    /// which resolves its real manifest name.
+    fn service_identity(
+        &self,
+        metadata: &WorkloadMetadata,
+    ) -> crate::observability::WorkloadIdentity {
+        crate::observability::WorkloadIdentity::new(
+            metadata.workload_namespace(),
+            metadata.workload_name(),
+            "service",
+        )
     }
 
     /// Capture everything needed to (re)build this service's store, so the

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1541,6 +1541,32 @@ impl ResolvedWorkload {
             .map_or(1, |component| component.instances.call_concurrency())
     }
 
+    /// The manifest identity a component's guest-execution measurements carry.
+    ///
+    /// Manifest names throughout, never the ids — see
+    /// [`crate::observability::WorkloadIdentity`] for why. Resolve it once
+    /// where a subscription or a route is set up rather than per call: the
+    /// component name costs a read lock, and it cannot change under a
+    /// resolved workload.
+    pub async fn component_identity(
+        &self,
+        component_id: &str,
+    ) -> crate::observability::WorkloadIdentity {
+        let name = self
+            .components
+            .read()
+            .await
+            .get(component_id)
+            .map(|component| Arc::<str>::from(component.name()));
+        crate::observability::WorkloadIdentity::new(
+            self.namespace(),
+            self.name(),
+            // A component absent from the map is one being torn down; the call
+            // that raced it still has to be measured under something.
+            name.as_deref().unwrap_or("unknown"),
+        )
+    }
+
     pub(crate) async fn instance_pool_for_component(
         &self,
         component_id: &str,

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1018,16 +1018,6 @@ pub struct ServiceHttpJob {
     pub req: hyper::Request<hyper::body::Incoming>,
     pub resp_tx: tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
     pub abandoned: Arc<AbandonFlag>,
-    /// What this call is measured under, or `None` for a call that cannot be
-    /// measured per request.
-    ///
-    /// Built by the dispatcher, the layer that knows the workload's manifest
-    /// identity — see [`crate::observability::WorkloadIdentity`]. It is `None`
-    /// on the service path: a service is one store serving every request at
-    /// once, and `GuestExecution` counts a *store's* execution, so a per-request
-    /// sample there would report every concurrent request's time as its own.
-    /// The pooled path is bounded by `maxConcurrency` and does measure.
-    pub attributes: Option<Arc<[opentelemetry::KeyValue]>>,
 }
 
 /// The attribute set an inbound HTTP call is measured under: the shared scheme
@@ -1042,7 +1032,35 @@ pub(crate) fn http_attributes(
     identity.attributes_with(
         "wasi-http",
         operation,
-        opentelemetry::KeyValue::new("method", known_method(method)),
+        opentelemetry::KeyValue::new(HTTP_REQUEST_METHOD, known_method(method)),
+    )
+}
+
+/// What a call on an already-built store is measured under, taken from the
+/// store rather than from whoever dispatched to it.
+///
+/// A service's HTTP ingress has no workload handle to resolve an identity from
+/// — `workload_handles` holds only components that export `wasi:http` — and it
+/// does not need one: the store it runs on was stamped when it was built.
+///
+/// Empty when nothing will record it. Only `ExecutionSample` reads this, and
+/// nothing reads that unless the host chose the epoch meter, so on every other
+/// host building it is a `Vec`, an `Arc` and four `String`s per request for a
+/// value that is dropped.
+pub(crate) fn stored_http_attributes(
+    executed: &crate::engine::abandon::GuestExecution,
+    method: &hyper::Method,
+) -> Arc<[opentelemetry::KeyValue]> {
+    if crate::observability::invocation_meter().is_none() {
+        return Arc::from([]);
+    }
+    let Some(identity) = executed.identity() else {
+        return Arc::from([]);
+    };
+    identity.attributes_with(
+        "wasi-http",
+        HTTP_OPERATION_P3,
+        opentelemetry::KeyValue::new(HTTP_REQUEST_METHOD, known_method(method)),
     )
 }
 
@@ -1051,7 +1069,10 @@ pub(crate) fn http_attributes(
 /// `hyper::Method` accepts an arbitrary extension token, so the method a client
 /// sends is caller-invented like the URI is. Folding the unregistered ones into
 /// one bucket is what keeps it usable as an attribute; the exact token stays on
-/// the span. This is the treatment the OTel HTTP semconv prescribes.
+/// the span. This is the treatment the OTel HTTP semconv prescribes, and it is
+/// recorded under the semconv's own key — the same `http.request.method` the
+/// spans here carry, so a histogram and a trace join on it without a relabel,
+/// and so `_OTHER` means what a reader of that convention expects.
 fn known_method(method: &hyper::Method) -> &'static str {
     match *method {
         hyper::Method::GET => "GET",
@@ -1380,13 +1401,17 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         // Only components that export wasi:http are routable HTTP entrypoints.
         // Anything else stays unregistered and routes to a 404.
         if crate::engine::exports_wasi_http(instance_pre.component()) {
+            // Resolved before the write lock is taken: it awaits a read of the
+            // component map, and holding the handles' writer across that stalls
+            // every inbound request, which reads the same lock to route.
+            let identity = resolved_handle.component_identity(component_id).await;
             self.workload_handles.write().await.insert(
                 resolved_handle.id().to_string(),
                 (
                     resolved_handle.clone(),
                     instance_pre,
                     component_id.to_string(),
-                    resolved_handle.component_identity(component_id).await,
+                    identity,
                 ),
             );
         }
@@ -1778,7 +1803,6 @@ async fn handle_http_request<T: Router>(
             req,
             resp_tx,
             abandoned: call.flag(),
-            attributes: None,
         };
         let response = if sender.send(job).await.is_err() {
             error!(host = %workload_id, "service HTTP instance is not running");
@@ -2061,12 +2085,10 @@ async fn invoke_component_handler(
             use crate::engine::instance_pool::Dispatch;
             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
             let call = DispatchedCall::new("HTTP (pooled)", crate::timeouts::http_response());
-            let attributes = Some(http_attributes(identity, req.method(), HTTP_OPERATION_P3));
             let outcome = match pool.try_dispatch(InstanceJob::Http(Box::new(ServiceHttpJob {
                 req,
                 resp_tx,
                 abandoned: call.flag(),
-                attributes,
             }))) {
                 Dispatch::Sent => Ok(()),
                 // The pool has room. Build and instantiate the store out here,
@@ -2121,10 +2143,7 @@ async fn invoke_component_handler(
         let flag = call.flag();
         let (resp, watch) = call
             .await_head(crate::host::http_p3::handle_component_request_p3(
-                cold,
-                req,
-                flag,
-                guest_meter,
+                cold, req, flag,
             ))
             .await
             .ok_or_else(|| anyhow::anyhow!("cold instance produced no response"))?;

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -40,7 +40,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioTimer},
     server::conn::auto,
 };
-use opentelemetry::{KeyValue, context::FutureExt};
+use opentelemetry::context::FutureExt;
 use opentelemetry_semantic_conventions::attribute::{
     HTTP_REQUEST_METHOD, HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_STATUS_CODE, OTEL_STATUS_CODE,
     RPC_GRPC_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_PATH,
@@ -804,7 +804,7 @@ pub trait HostHandler: Send + Sync + 'static {
         &self,
         _workload_id: &str,
         _msg: BrokerMessage,
-        _attributes: Vec<opentelemetry::KeyValue>,
+        _attributes: std::sync::Arc<[opentelemetry::KeyValue]>,
     ) -> anyhow::Result<Result<(), String>> {
         anyhow::bail!("this host does not support trigger service messaging delivery")
     }
@@ -995,9 +995,21 @@ fn watch_body(
     })
 }
 
-/// A map from host header to resolved workload handles and their associated component id
-pub type WorkloadHandles =
-    Arc<RwLock<HashMap<String, (ResolvedWorkload, InstancePre<SharedCtx>, String)>>>;
+/// A map from host header to resolved workload handles, their associated
+/// component id, and the identity that component's calls are measured under.
+pub type WorkloadHandles = Arc<
+    RwLock<
+        HashMap<
+            String,
+            (
+                ResolvedWorkload,
+                InstancePre<SharedCtx>,
+                String,
+                crate::observability::WorkloadIdentity,
+            ),
+        >,
+    >,
+>;
 
 /// An inbound HTTP request routed to a long-lived service instance, paired with
 /// a oneshot for its response and the abandonment flag of the [`DispatchedCall`]
@@ -1006,7 +1018,63 @@ pub struct ServiceHttpJob {
     pub req: hyper::Request<hyper::body::Incoming>,
     pub resp_tx: tokio::sync::oneshot::Sender<anyhow::Result<hyper::Response<HyperOutgoingBody>>>,
     pub abandoned: Arc<AbandonFlag>,
+    /// What this call is measured under, or `None` for a call that cannot be
+    /// measured per request.
+    ///
+    /// Built by the dispatcher, the layer that knows the workload's manifest
+    /// identity — see [`crate::observability::WorkloadIdentity`]. It is `None`
+    /// on the service path: a service is one store serving every request at
+    /// once, and `GuestExecution` counts a *store's* execution, so a per-request
+    /// sample there would report every concurrent request's time as its own.
+    /// The pooled path is bounded by `maxConcurrency` and does measure.
+    pub attributes: Option<Arc<[opentelemetry::KeyValue]>>,
 }
+
+/// The attribute set an inbound HTTP call is measured under: the shared scheme
+/// plus the request method, which is bounded by the HTTP spec. The URI and Host
+/// header are deliberately absent — a caller invents those, and a label a
+/// caller can invent mints a permanent time series per distinct value.
+pub(crate) fn http_attributes(
+    identity: &crate::observability::WorkloadIdentity,
+    method: &hyper::Method,
+    operation: &'static str,
+) -> Arc<[opentelemetry::KeyValue]> {
+    identity.attributes_with(
+        "wasi-http",
+        operation,
+        opentelemetry::KeyValue::new("method", known_method(method)),
+    )
+}
+
+/// The request method, or `_OTHER` for anything outside the registered set.
+///
+/// `hyper::Method` accepts an arbitrary extension token, so the method a client
+/// sends is caller-invented like the URI is. Folding the unregistered ones into
+/// one bucket is what keeps it usable as an attribute; the exact token stays on
+/// the span. This is the treatment the OTel HTTP semconv prescribes.
+fn known_method(method: &hyper::Method) -> &'static str {
+    match *method {
+        hyper::Method::GET => "GET",
+        hyper::Method::HEAD => "HEAD",
+        hyper::Method::POST => "POST",
+        hyper::Method::PUT => "PUT",
+        hyper::Method::DELETE => "DELETE",
+        hyper::Method::CONNECT => "CONNECT",
+        hyper::Method::OPTIONS => "OPTIONS",
+        hyper::Method::TRACE => "TRACE",
+        hyper::Method::PATCH => "PATCH",
+        _ => "_OTHER",
+    }
+}
+
+/// The WIT exports an inbound request can invoke, and what its measurements
+/// are grouped by. Bounded by the interface, unlike the request's URI.
+///
+/// Two of them, because the p2 per-request path and the p3 pooled path call
+/// different exports; merging them would group calls under an export one of the
+/// two never invokes.
+pub(crate) const HTTP_OPERATION_P2: &str = "wasi:http/incoming-handler#handle";
+pub(crate) const HTTP_OPERATION_P3: &str = "wasi:http/handler#handle";
 
 /// A map from workload id to the channel of its HTTP-serving service instance.
 /// Empty unless a workload's service opts into HTTP ingress (a p3 feature).
@@ -1318,6 +1386,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
                     resolved_handle.clone(),
                     instance_pre,
                     component_id.to_string(),
+                    resolved_handle.component_identity(component_id).await,
                 ),
             );
         }
@@ -1394,7 +1463,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         &self,
         workload_id: &str,
         msg: BrokerMessage,
-        attributes: Vec<opentelemetry::KeyValue>,
+        attributes: std::sync::Arc<[opentelemetry::KeyValue]>,
     ) -> anyhow::Result<Result<(), String>> {
         let sender = self
             .messaging_handlers
@@ -1709,6 +1778,7 @@ async fn handle_http_request<T: Router>(
             req,
             resp_tx,
             abandoned: call.flag(),
+            attributes: None,
         };
         let response = if sender.send(job).await.is_err() {
             error!(host = %workload_id, "service HTTP instance is not running");
@@ -1744,7 +1814,7 @@ async fn handle_http_request<T: Router>(
     };
 
     let response = match workload_handle {
-        Some((handle, instance_pre, component_id)) => {
+        Some((handle, instance_pre, component_id, identity)) => {
             let req_span = tracing::span!(
                 tracing::Level::INFO,
                 "invoke_component_handler",
@@ -1752,9 +1822,16 @@ async fn handle_http_request<T: Router>(
                 workload.namespace = handle.namespace(),
                 workload.id = handle.id(),
             );
-            match invoke_component_handler(handle, instance_pre, &component_id, req, guest_meter)
-                .instrument(req_span)
-                .await
+            match invoke_component_handler(
+                handle,
+                instance_pre,
+                &component_id,
+                req,
+                guest_meter,
+                &identity,
+            )
+            .instrument(req_span)
+            .await
             {
                 Ok(resp) => resp,
                 Err(e) => {
@@ -1967,6 +2044,8 @@ async fn invoke_component_handler(
     component_id: &str,
     req: hyper::Request<hyper::body::Incoming>,
     guest_meter: GuestMeter,
+    // Resolved once when the route was registered: this runs per request.
+    identity: &crate::observability::WorkloadIdentity,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
     if crate::engine::targets_wasip3_http(instance_pre.component()) {
         let pool = workload_handle
@@ -1982,10 +2061,12 @@ async fn invoke_component_handler(
             use crate::engine::instance_pool::Dispatch;
             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
             let call = DispatchedCall::new("HTTP (pooled)", crate::timeouts::http_response());
+            let attributes = Some(http_attributes(identity, req.method(), HTTP_OPERATION_P3));
             let outcome = match pool.try_dispatch(InstanceJob::Http(Box::new(ServiceHttpJob {
                 req,
                 resp_tx,
                 abandoned: call.flag(),
+                attributes,
             }))) {
                 Dispatch::Sent => Ok(()),
                 // The pool has room. Build and instantiate the store out here,
@@ -2063,7 +2144,7 @@ async fn invoke_component_handler(
     // owned by a detached task that outlives the response head, so recovering
     // it for reuse needs a restructure the p3 path did not.
     let store = workload_handle.new_store(component_id).await?;
-    handle_component_request(store, instance_pre, req, guest_meter).await
+    handle_component_request(store, instance_pre, req, guest_meter, identity).await
 }
 
 /// Handle a component request using WASI HTTP (copied from wash/crates/src/cli/dev.rs)
@@ -2072,6 +2153,7 @@ pub async fn handle_component_request(
     pre: InstancePre<SharedCtx>,
     req: hyper::Request<hyper::body::Incoming>,
     guest_meter: GuestMeter,
+    identity: &crate::observability::WorkloadIdentity,
 ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let scheme = match req.uri().scheme() {
@@ -2082,14 +2164,7 @@ pub async fn handle_component_request(
         None => Scheme::Http,
     };
 
-    let method = req.method().to_string();
-    let host_header = req
-        .headers()
-        .get(hyper::header::HOST)
-        .and_then(|h| h.to_str().ok())
-        .map(|h| h.to_string())
-        .unwrap_or_default();
-    let uri = req.uri().to_string();
+    let attributes = http_attributes(identity, req.method(), HTTP_OPERATION_P2);
 
     let req = store.data_mut().http().new_incoming_request(scheme, req)?;
     let out = store.data_mut().http().new_response_outparam(sender)?;
@@ -2113,23 +2188,14 @@ pub async fn handle_component_request(
             let proxy = pre.instantiate_async(&mut store).await?;
 
             guest_meter
-                .observe(
-                    &[
-                        KeyValue::new("plugin", "wasi-http"),
-                        KeyValue::new("method", method),
-                        KeyValue::new("host", host_header),
-                        KeyValue::new("uri", uri),
-                    ],
-                    &mut store,
-                    async move |store| {
-                        proxy
-                            .wasi_http_incoming_handler()
-                            .call_handle(store, req, out)
-                            .await?;
+                .observe(&attributes, &mut store, async move |store| {
+                    proxy
+                        .wasi_http_incoming_handler()
+                        .call_handle(store, req, out)
+                        .await?;
 
-                        Ok(())
-                    },
-                )
+                    Ok(())
+                })
                 .await?;
 
             Ok(())

--- a/crates/wash-runtime/src/host/http_p3.rs
+++ b/crates/wash-runtime/src/host/http_p3.rs
@@ -10,7 +10,6 @@
 //! [`crate::host::http::OutgoingHandler`] trait via its `send_request_p3` method.
 
 use crate::engine::instance_pool::ComponentInstance;
-use crate::observability::GuestMeter;
 use http_body_util::BodyExt;
 use tracing::Instrument;
 use wasmtime_wasi_http::p3::bindings::Service;
@@ -85,12 +84,11 @@ pub(crate) async fn handle_component_request_p3(
     warm: ComponentInstance,
     req: hyper::Request<hyper::body::Incoming>,
     abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
-    guest_meter: GuestMeter,
 ) -> anyhow::Result<hyper::Response<P3Body>> {
-    // Not measured here: this path hands its store to `run_concurrent` and
-    // never holds a `&mut Store` around the call, so it has nothing to wrap.
-    let _ = &guest_meter;
-
+    // Named from the store this call was given, the same way `HttpTask` does:
+    // the dispatcher does not have to know whose execution it is.
+    let attributes =
+        crate::host::http::stored_http_attributes(&warm.store.data().executed, req.method());
     // Convert the hyper request body — map error type since hyper::Error doesn't impl Into<ErrorCode>
     let (parts, body) = req.into_parts();
     let body = body
@@ -139,6 +137,11 @@ pub(crate) async fn handle_component_request_p3(
 
             let run = store
                 .run_concurrent(async move |store| {
+                    // The requests that reach this path are the ones a full
+                    // pool turned away; leaving them out would empty the
+                    // histogram exactly when the host is overloaded.
+                    let _sample =
+                        crate::engine::instance_driver::InvocationSample::start(attributes);
                     let mut parts_tx = Some(parts_tx);
                     // `async move` so `handler_fut` owns `frame_tx`: it drops the
                     // instant the response body completes, delivering end-of-stream

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -66,6 +66,9 @@ pub(crate) struct HttpTask {
     /// It is registered on the store for the life of the call so the epoch
     /// callback can see it — the only way to end a guest that never yields.
     pub(crate) abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
+    /// What this call is measured under, or `None` when it cannot be measured
+    /// per request — see [`crate::host::http::ServiceHttpJob`].
+    pub(crate) attributes: Option<std::sync::Arc<[opentelemetry::KeyValue]>>,
     /// This call's tether to a pooled instance: holds its in-flight slot and
     /// can retire the instance. `None` for a service, whose singleton instance
     /// is not the pool's to retire.
@@ -79,6 +82,7 @@ impl AccessorTask<SharedCtx> for HttpTask {
             req,
             resp_tx,
             abandoned,
+            attributes,
             pool_slot,
         } = self;
 
@@ -87,6 +91,13 @@ impl AccessorTask<SharedCtx> for HttpTask {
         let calls = accessor.with(|mut access| {
             crate::engine::abandon::rearm_for_call(&mut access);
             std::sync::Arc::clone(&access.get().abandoned)
+        });
+        // Only the pooled path measures. A service shares one store across
+        // every concurrent request and the counter behind this is per store, so
+        // a per-request sample there would report its neighbours' time as its
+        // own.
+        let _sample = attributes.map(|attributes| {
+            crate::engine::instance_driver::ExecutionSample::start(accessor, attributes)
         });
 
         let (parts, body) = req.into_parts();

--- a/crates/wash-runtime/src/host/trigger_service/http.rs
+++ b/crates/wash-runtime/src/host/trigger_service/http.rs
@@ -66,9 +66,6 @@ pub(crate) struct HttpTask {
     /// It is registered on the store for the life of the call so the epoch
     /// callback can see it — the only way to end a guest that never yields.
     pub(crate) abandoned: std::sync::Arc<crate::engine::abandon::AbandonFlag>,
-    /// What this call is measured under, or `None` when it cannot be measured
-    /// per request — see [`crate::host::http::ServiceHttpJob`].
-    pub(crate) attributes: Option<std::sync::Arc<[opentelemetry::KeyValue]>>,
     /// This call's tether to a pooled instance: holds its in-flight slot and
     /// can retire the instance. `None` for a service, whose singleton instance
     /// is not the pool's to retire.
@@ -82,7 +79,6 @@ impl AccessorTask<SharedCtx> for HttpTask {
             req,
             resp_tx,
             abandoned,
-            attributes,
             pool_slot,
         } = self;
 
@@ -92,13 +88,16 @@ impl AccessorTask<SharedCtx> for HttpTask {
             crate::engine::abandon::rearm_for_call(&mut access);
             std::sync::Arc::clone(&access.get().abandoned)
         });
-        // Only the pooled path measures. A service shares one store across
-        // every concurrent request and the counter behind this is per store, so
-        // a per-request sample there would report its neighbours' time as its
-        // own.
-        let _sample = attributes.map(|attributes| {
-            crate::engine::instance_driver::ExecutionSample::start(accessor, attributes)
+        // Named from the store this runs on, which was stamped with whose
+        // execution it is when it was built — a service's ingress has no
+        // workload handle to look one up from. Whether the sample is recorded
+        // is `InvocationSample`'s call, not this one's: a service shares its
+        // store, so its samples are dropped in favour of the store's own
+        // counter, and a pooled instance's are kept when it ran alone.
+        let attributes = accessor.with(|mut access| {
+            crate::host::http::stored_http_attributes(&access.get().executed, req.method())
         });
+        let _sample = crate::engine::instance_driver::InvocationSample::start(attributes);
 
         let (parts, body) = req.into_parts();
         let body = body

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -76,7 +76,7 @@ pub struct MessagingJob {
     /// What this call is measured under. Built by the dispatcher, which is the
     /// layer that knows the workload's manifest identity — see
     /// [`crate::observability::WorkloadIdentity`].
-    pub attributes: Vec<opentelemetry::KeyValue>,
+    pub attributes: std::sync::Arc<[opentelemetry::KeyValue]>,
 }
 
 /// The messaging handler export a trigger service must provide.
@@ -147,7 +147,7 @@ pub(crate) struct MessagingTask {
     pub(crate) abandoned: Arc<AbandonFlag>,
     /// What this call is measured under; see
     /// [`crate::observability::WorkloadIdentity`].
-    pub(crate) attributes: Vec<opentelemetry::KeyValue>,
+    pub(crate) attributes: std::sync::Arc<[opentelemetry::KeyValue]>,
     /// This delivery's tether to a pooled instance: holds its in-flight slot
     /// and can retire the instance. `None` for the two shapes with no instance
     /// to retire — a service, whose singleton is not the pool's, and a cold

--- a/crates/wash-runtime/src/host/trigger_service/messaging.rs
+++ b/crates/wash-runtime/src/host/trigger_service/messaging.rs
@@ -174,7 +174,7 @@ impl AccessorTask<SharedCtx> for MessagingTask {
         });
         // Both delivery shapes — a pooled instance and a long-lived service —
         // land here, so one sample covers both.
-        let _sample = crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
+        let _sample = crate::engine::instance_driver::InvocationSample::start(attributes);
 
         let deliver = async {
             // The `@0.3.0` body is a native `stream<u8>`; mint one carrying the

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -205,7 +205,6 @@ impl PreparedIngress {
                     req,
                     resp_tx,
                     abandoned,
-                    attributes,
                 }) = rx.recv().await
                 {
                     if let Err(e) = accessor.spawn(HttpTask {
@@ -213,7 +212,6 @@ impl PreparedIngress {
                         req,
                         resp_tx,
                         abandoned,
-                        attributes,
                         pool_slot: None,
                     }) {
                         tracing::error!(err = %e, "failed to spawn HTTP invocation task");

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -205,6 +205,7 @@ impl PreparedIngress {
                     req,
                     resp_tx,
                     abandoned,
+                    attributes,
                 }) = rx.recv().await
                 {
                     if let Err(e) = accessor.spawn(HttpTask {
@@ -212,6 +213,7 @@ impl PreparedIngress {
                         req,
                         resp_tx,
                         abandoned,
+                        attributes,
                         pool_slot: None,
                     }) {
                         tracing::error!(err = %e, "failed to spawn HTTP invocation task");

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -221,6 +221,93 @@ pub struct Meters {
     pub meters: HashMap<String, Arc<dyn Any + Send + Sync + 'static>>,
 }
 
+/// Who ran the guest code a measurement covers, in the terms a manifest author
+/// and a dashboard both recognize.
+///
+/// Every guest-execution measurement carries these three, whichever plugin
+/// drove the call and whichever of the two histograms records it, so one query
+/// groups calls across all of them. See [`Self::attributes`] for the full
+/// scheme.
+///
+/// Deliberately **not** the workload or component id: both are
+/// `uuid::Uuid::new_v4()` minted per workload construction, so attributing a
+/// series with one mints a fresh series on every restart, rolling update and
+/// replica — growth driven by deployment churn, and a value no operator can map
+/// back to a workload. The ids keep their place on the span and the log line,
+/// where identity is per-event and therefore free. This is the same rule
+/// `wasmcloud:messaging`'s admission counter follows.
+#[derive(Clone, Debug)]
+pub struct WorkloadIdentity {
+    /// The workload's manifest namespace.
+    pub namespace: Arc<str>,
+    /// The workload's manifest name.
+    pub name: Arc<str>,
+    /// The component's *manifest* name, so a workload running more than one
+    /// component can still be told apart.
+    pub component: Arc<str>,
+}
+
+impl WorkloadIdentity {
+    pub fn new(namespace: &str, name: &str, component: &str) -> Self {
+        Self {
+            namespace: Arc::from(namespace),
+            name: Arc::from(name),
+            component: Arc::from(component),
+        }
+    }
+
+    /// The attribute set shared by every guest-execution measurement.
+    ///
+    /// `plugin` names the host surface that drove the call, bounded by what is
+    /// compiled in. `operation` names the WIT export invoked — for example
+    /// `wasmcloud:nats/core-handler#handle-message` — bounded by the interface
+    /// set a component declares. Neither can be invented by traffic, so the
+    /// series count stays bounded by what is deployed.
+    ///
+    /// A call surface with a further *bounded* dimension appends its own
+    /// through [`Self::attributes_with`]. Anything a caller can invent belongs
+    /// on the span instead, where it costs one event rather than one time
+    /// series per histogram bucket, forever.
+    ///
+    /// Shared rather than owned: every value here is fixed for the life of a
+    /// subscription or a route, so callers build one set when that is set up
+    /// and clone the handle per call. Rebuilding it per call would allocate the
+    /// vector and five strings on a delivery hot path to arrive at the same
+    /// answer every time.
+    pub fn attributes(&self, plugin: &'static str, operation: &str) -> Arc<[KeyValue]> {
+        self.build(plugin, operation, None)
+    }
+
+    /// As [`Self::attributes`], plus one further dimension this surface bounds
+    /// itself — an HTTP method, a configured subscription.
+    pub fn attributes_with(
+        &self,
+        plugin: &'static str,
+        operation: &str,
+        extra: KeyValue,
+    ) -> Arc<[KeyValue]> {
+        self.build(plugin, operation, Some(extra))
+    }
+
+    fn build(
+        &self,
+        plugin: &'static str,
+        operation: &str,
+        extra: Option<KeyValue>,
+    ) -> Arc<[KeyValue]> {
+        let mut attributes = Vec::with_capacity(5 + usize::from(extra.is_some()));
+        attributes.extend([
+            KeyValue::new("plugin", plugin),
+            KeyValue::new("operation", operation.to_string()),
+            KeyValue::new("workload.namespace", self.namespace.to_string()),
+            KeyValue::new("workload.name", self.name.to_string()),
+            KeyValue::new("component", self.component.to_string()),
+        ]);
+        attributes.extend(extra);
+        attributes.into()
+    }
+}
+
 /// The execution-time histogram, reachable without a `Meters` in hand.
 ///
 /// A pooled call runs inside the driver's `run_concurrent`, several layers

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -2,9 +2,12 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 
 use anyhow::Context;
 
+use std::time::Duration;
+
 use opentelemetry::{KeyValue, trace::TracerProvider};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::attribute::ERROR_TYPE;
 use opentelemetry_semantic_conventions::resource;
 use tracing::Level;
 use tracing_subscriber::{
@@ -151,30 +154,30 @@ fn directive(directive: impl AsRef<str>) -> anyhow::Result<Directive> {
         .with_context(|| format!("failed to parse filter: {}", directive.as_ref()))
 }
 
-/// How a host measures the time its guests spend running.
+/// What a host measures about its guests.
 ///
-/// The two meters answer the same question and cost very differently, so a host
-/// picks one rather than paying for both:
+/// Rate, errors and duration ([`InvocationMeter`]) are what an operator asks
+/// for first and cost two clock reads, so they are what `Duration` — the
+/// default — gives. `Fuel` adds an exact count of the operations a guest
+/// executed, which is the only accurate guest-work signal this runtime has and
+/// is not free: `Config::consume_fuel` compiles a counter into every block of
+/// guest code, and the guest pays it whether or not anyone reads the number.
 ///
-/// * [`Self::Epoch`] samples the epoch callback every store arms anyway, so it
-///   costs the guest nothing at run time. It reports whole milliseconds and is
-///   a floor, not a total — see [`crate::engine::abandon::GuestExecution`].
-/// * [`Self::Fuel`] counts executed operations exactly, at the price of a
-///   counter compiled into every block of guest code, which the guest pays
-///   whether or not anyone reads the number.
-///
-/// [`Self::Fuel`] is also the only one that needs anything of the engine:
-/// `Config::consume_fuel` has to be on, and a store on such an engine starts
-/// with no fuel, so guests only run because every store is given a budget.
+/// There is no epoch option. Epoch sampling looked free, and was, but it
+/// reports a *store's* execution only when the store runs a full sampling
+/// window without a call starting — and `rearm_for_call` restarts that window
+/// on every call. A store taking calls more often than once per window credits
+/// nothing at all, so the signal fell to zero exactly as a host got busy. See
+/// [`crate::engine::abandon::GuestExecution`], which still counts for the
+/// teardown it was built for.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum MeterKind {
-    /// Measure neither. The default: a host that was not asked to measure
-    /// guest execution should not make its guests slower.
-    #[default]
+    /// Measure nothing.
     Off,
-    /// `guest.execution.time`, sampled from the epoch callback.
-    Epoch,
-    /// `fuel.consumption`, counted in the guest.
+    /// `guest.invocation.duration`: rate, errors and duration.
+    #[default]
+    Duration,
+    /// The above, plus `fuel.consumption`.
     Fuel,
 }
 
@@ -184,10 +187,15 @@ impl MeterKind {
         matches!(self, Self::Fuel)
     }
 
+    /// Whether anything is measured at all.
+    pub fn records(&self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Off => "off",
-            Self::Epoch => "epoch",
+            Self::Duration => "duration",
             Self::Fuel => "fuel",
         }
     }
@@ -199,10 +207,10 @@ impl std::str::FromStr for MeterKind {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "off" | "none" => Ok(Self::Off),
-            "epoch" => Ok(Self::Epoch),
+            "duration" => Ok(Self::Duration),
             "fuel" => Ok(Self::Fuel),
             other => Err(format!(
-                "unknown meter `{other}`, expected one of: off, epoch, fuel"
+                "unknown meter `{other}`, expected one of: off, duration, fuel"
             )),
         }
     }
@@ -210,13 +218,14 @@ impl std::str::FromStr for MeterKind {
 
 #[derive(Clone, Default)]
 pub struct Meters {
+    /// Rate, errors and duration. Built for any [`MeterKind`] but `Off`: it
+    /// costs the guest two clock reads, and it is the one an operator needs
+    /// first.
+    pub invocation: InvocationMeter,
     /// Built only under [`MeterKind::Fuel`]; inert otherwise, so a call path
     /// that measures with it records nothing rather than having to ask which
     /// meter the host chose.
     pub fuel_consumption: FuelConsumptionMeter,
-    /// Built only under [`MeterKind::Epoch`], and inert otherwise for the same
-    /// reason.
-    pub execution_time: ExecutionTimeMeter,
     /// User-defined meters
     pub meters: HashMap<String, Arc<dyn Any + Send + Sync + 'static>>,
 }
@@ -289,6 +298,17 @@ impl WorkloadIdentity {
         self.build(plugin, operation, Some(extra))
     }
 
+    /// The identity trio both instruments carry. One definition, so a rename
+    /// cannot leave `guest.execution.time` and `guest.execution.total`
+    /// disagreeing about the key to join on.
+    fn identity_keys(&self) -> [KeyValue; 3] {
+        [
+            KeyValue::new("workload.namespace", self.namespace.to_string()),
+            KeyValue::new("workload.name", self.name.to_string()),
+            KeyValue::new("component", self.component.to_string()),
+        ]
+    }
+
     fn build(
         &self,
         plugin: &'static str,
@@ -296,34 +316,76 @@ impl WorkloadIdentity {
         extra: Option<KeyValue>,
     ) -> Arc<[KeyValue]> {
         let mut attributes = Vec::with_capacity(5 + usize::from(extra.is_some()));
-        attributes.extend([
-            KeyValue::new("plugin", plugin),
-            KeyValue::new("operation", operation.to_string()),
-            KeyValue::new("workload.namespace", self.namespace.to_string()),
-            KeyValue::new("workload.name", self.name.to_string()),
-            KeyValue::new("component", self.component.to_string()),
-        ]);
+        attributes.push(KeyValue::new("plugin", plugin));
+        attributes.push(KeyValue::new("operation", operation.to_string()));
+        attributes.extend(self.identity_keys());
         attributes.extend(extra);
         attributes.into()
     }
 }
 
-/// The execution-time histogram, reachable without a `Meters` in hand.
+/// Rate, errors and duration for one guest invocation — the three questions
+/// asked of a serverless platform, from one instrument.
 ///
-/// A pooled call runs inside the driver's `run_concurrent`, several layers
-/// below anything holding a `Meters`, and carrying one down to every driver
-/// would thread a metric through the engine's whole dispatch path. The
-/// histogram is a handle rather than host state — OTel's own meter registry is
-/// process-global for the same reason — so it is published here once and read
-/// where a call actually ends.
-static EXECUTION_TIME: std::sync::OnceLock<ExecutionTimeMeter> = std::sync::OnceLock::new();
+/// Wall clock, not guest execution: it is what a caller waited, it is exact per
+/// call, and it costs two `Instant::now()`. `guest.execution.total` answers the
+/// different question of how much CPU a workload burned, and cannot answer this
+/// one — the epoch sampler credits a *store*, and only in whole sampling
+/// windows.
+///
+/// One histogram rather than three instruments, which is what the OTel
+/// conventions do: its count is the rate, and `error.type` — present only on a
+/// failure, per the convention — separates the errors out of the same series.
+#[derive(Clone, Default)]
+pub struct InvocationMeter {
+    duration: Option<opentelemetry::metrics::Histogram<f64>>,
+}
 
-/// The execution-time meter, once a host has built its [`Meters`].
-///
-/// `None` before that, and on a host that did not enable metering the meter
-/// itself is inert, so a caller never has to ask which.
-pub fn execution_time_meter() -> Option<&'static ExecutionTimeMeter> {
-    EXECUTION_TIME.get()
+impl InvocationMeter {
+    pub(crate) fn new(enabled: bool) -> Self {
+        let duration = enabled.then(|| {
+            opentelemetry::global::meter("wash-runtime")
+                .f64_histogram("guest.invocation.duration")
+                .with_description("Wall-clock duration of one guest invocation")
+                .with_unit("s")
+                .with_boundaries(vec![
+                    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+                ])
+                .build()
+        });
+        Self { duration }
+    }
+
+    /// Record one invocation. `error` names what went wrong, and is absent when
+    /// nothing did — the convention's own way of marking a failure, so an error
+    /// rate is a filter on this series rather than a second instrument to keep
+    /// in step with it.
+    /// Whether this meter records anything.
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.duration.is_some()
+    }
+
+    pub fn record(&self, attributes: &[KeyValue], elapsed: Duration, error: Option<&'static str>) {
+        let Some(duration) = &self.duration else {
+            return;
+        };
+        match error {
+            None => duration.record(elapsed.as_secs_f64(), attributes),
+            Some(error) => {
+                let mut with_error = attributes.to_vec();
+                with_error.push(KeyValue::new(ERROR_TYPE, error));
+                duration.record(elapsed.as_secs_f64(), &with_error);
+            }
+        }
+    }
+}
+
+/// The invocation meter, reachable the same way and for the same reason as the
+/// execution counter below.
+static INVOCATION: std::sync::OnceLock<InvocationMeter> = std::sync::OnceLock::new();
+
+pub fn invocation_meter() -> Option<&'static InvocationMeter> {
+    INVOCATION.get()
 }
 
 impl Meters {
@@ -331,24 +393,24 @@ impl Meters {
     pub fn guest(&self) -> GuestMeter {
         GuestMeter {
             fuel: self.fuel_consumption.clone(),
-            execution_time: self.execution_time.clone(),
+            invocation: self.invocation.clone(),
         }
     }
 
     pub fn new(kind: MeterKind) -> Self {
         let meters = Self {
-            fuel_consumption: FuelConsumptionMeter::new(kind == MeterKind::Fuel),
-            execution_time: ExecutionTimeMeter::new(kind == MeterKind::Epoch),
+            invocation: InvocationMeter::new(kind.records()),
+            fuel_consumption: FuelConsumptionMeter::new(kind.consumes_fuel()),
             meters: Default::default(),
         };
-        // First host with metering on wins. A second one in the same process
+        // First host that measures wins. A second one in the same process
         // (tests, an embedder running two) records into the first's histogram,
         // which is the same instrument OTel would have handed it anyway.
-        // Skipping the disabled ones matters: a host built with metering off
-        // would otherwise claim the slot and silence every pooled call after
-        // it, including calls on a later host that did ask for metrics.
-        if kind == MeterKind::Epoch {
-            let _ = EXECUTION_TIME.set(meters.execution_time.clone());
+        // Skipping the ones that measure nothing matters: a host built with
+        // metering off would otherwise claim the slot and silence every call
+        // after it, including calls on a later host that did ask.
+        if kind.records() {
+            let _ = INVOCATION.set(meters.invocation.clone());
         }
         meters
     }
@@ -367,22 +429,26 @@ pub struct FuelConsumptionMeter {
 /// [`MeterKind::Epoch`] universal: every path that measures at all can measure
 /// by epoch, including the ones that used to count fuel and nothing else.
 ///
-/// The reverse does not hold. A pooled call runs under an `Accessor` with no
-/// `&mut Store` anywhere, so it cannot be wrapped like this and samples the
-/// epoch counter directly instead (`ExecutionSample` in the instance driver).
-/// [`MeterKind::Fuel`] therefore covers only the paths below, which is the one
-/// asymmetry between the two choices.
+/// Fuel is the only kind that has to wrap the call: it is read off the store
+/// either side of it. Epoch execution is credited from the callback that
+/// observes it, and duration is timed here for every kind, so a path that
+/// measures through this gets rate, errors and duration whichever kind the host
+/// chose.
 #[derive(Clone, Default)]
 pub struct GuestMeter {
     fuel: FuelConsumptionMeter,
-    execution_time: ExecutionTimeMeter,
+    /// Carried rather than read from the global: this is built from the
+    /// [`Meters`] a host owns, so it can use that host's instrument instead of
+    /// whichever one happened to publish itself first.
+    invocation: InvocationMeter,
 }
 
 impl GuestMeter {
-    /// Measure one call, by whichever meter this host was built with.
+    /// Measure one call: its duration always, and its fuel when the host asked
+    /// for fuel.
     ///
-    /// Falls through to the call itself when neither is on, so a path never has
-    /// to ask whether metering is enabled.
+    /// Falls through to the call itself when nothing is metering, so a path
+    /// never has to ask whether metering is enabled.
     pub async fn observe<F, R>(
         &self,
         attributes: &[KeyValue],
@@ -392,11 +458,25 @@ impl GuestMeter {
     where
         F: AsyncFnOnce(&mut wasmtime::Store<crate::engine::ctx::SharedCtx>) -> anyhow::Result<R>,
     {
-        if self.fuel.is_enabled() {
+        if !self.invocation.is_enabled() {
+            return if self.fuel.is_enabled() {
+                self.fuel.observe(attributes, store, func).await
+            } else {
+                func(store).await
+            };
+        }
+        let started = std::time::Instant::now();
+        let result = if self.fuel.is_enabled() {
             self.fuel.observe(attributes, store, func).await
         } else {
-            self.execution_time.observe(attributes, store, func).await
-        }
+            func(store).await
+        };
+        // A host failure is all this layer can see; a guest that ran and
+        // returned its own error is a success here and named by whoever reads
+        // that error.
+        let error = result.is_err().then_some("host");
+        self.invocation.record(attributes, started.elapsed(), error);
+        result
     }
 }
 
@@ -442,110 +522,6 @@ impl FuelConsumptionMeter {
     }
 }
 
-/// Reports how long a call ran guest code, in milliseconds.
-///
-/// The alternative to [`FuelConsumptionMeter`], and what the `wasmcloud:nats`
-/// plugin measures its handlers with. Sampled by the epoch callback every store
-/// arms anyway ([`crate::engine::abandon::GuestExecution`]), so it costs the
-/// guest nothing at run time, where fuel's per-block counters are compiled into
-/// the guest and slow it down whether or not anyone is watching. Fuel stays the
-/// default everywhere it already was.
-///
-/// The trade is resolution, and it only ever undercounts: a call whose guest
-/// runs for less than one sampling window is never sampled and records **0**.
-/// Read the histogram as "calls that burned at least a window of guest
-/// execution", not as a CPU total — a host serving nothing but short calls
-/// reports zero and is not idle. `GuestExecution`'s docs have the rest,
-/// including why a store serving concurrent calls attributes their execution
-/// to each other.
-#[derive(Clone, Default)]
-pub struct ExecutionTimeMeter {
-    hist: Option<opentelemetry::metrics::Histogram<u64>>,
-}
-
-impl ExecutionTimeMeter {
-    pub(crate) fn new(enabled: bool) -> Self {
-        let hist = enabled.then(|| {
-            opentelemetry::global::meter("wash-runtime")
-                .u64_histogram("guest.execution.time")
-                .with_description(
-                    "Guest execution time for components that export host plugin interfaces, \
-                     sampled from the engine's epoch callback",
-                )
-                .with_unit("ms")
-                .with_boundaries(execution_time_histogram_boundaries())
-                .build()
-        });
-        Self { hist }
-    }
-
-    /// Records the guest execution one call added, measured by the caller.
-    ///
-    /// The store-taking [`Self::observe`] cannot be used from inside a pooled
-    /// call: the driver owns the store for the instance's whole life and calls
-    /// arrive as tasks on it, so nobody down there has a `&mut Store`. Read
-    /// `SharedCtx::executed` through the accessor either side of the call and
-    /// hand the delta here instead. Same counter, same caveats — read
-    /// [`crate::engine::abandon::GuestExecution`] before reading the number,
-    /// and note that on an instance serving several calls at once the delta
-    /// includes its neighbours'.
-    pub fn record(&self, attributes: &[KeyValue], millis: u64) {
-        if let Some(hist) = &self.hist {
-            hist.record(millis, attributes);
-        }
-    }
-
-    pub async fn observe<F, R>(
-        &self,
-        attributes: &[KeyValue],
-        store: &mut wasmtime::Store<crate::engine::ctx::SharedCtx>,
-        func: F,
-    ) -> anyhow::Result<R>
-    where
-        F: AsyncFnOnce(&mut wasmtime::Store<crate::engine::ctx::SharedCtx>) -> anyhow::Result<R>,
-    {
-        let Some(hist) = &self.hist else {
-            return func(store).await;
-        };
-        // Cloned out rather than re-read after the call: `func` takes the
-        // store, and the counter is shared with the callback either way.
-        let executed = Arc::clone(&store.data().executed);
-        let before = executed.millis();
-        // Recorded before the `?`: a call that traps or errors still consumed
-        // the time it ran for, and dropping those samples biases the histogram
-        // toward the calls that succeeded.
-        let result = func(store).await;
-        hist.record(executed.millis().saturating_sub(before), attributes);
-        result
-    }
-}
-
-/// Generate histogram boundaries for guest execution time, in milliseconds.
-///
-/// Produces boundaries following multipliers [1, 2.5, 5, 7.5] per decade,
-/// starting at one sampling window — below which every call records zero, so
-/// finer buckets would only split the zero bucket — up to an hour.
-fn execution_time_histogram_boundaries() -> Vec<f64> {
-    const MAX: f64 = 3_600_000.0;
-    const MULTIPLIERS: [f64; 4] = [1.0, 2.5, 5.0, 7.5];
-
-    let mut boundaries = vec![0.0];
-    // Floored at 1ms: a sub-millisecond window truncates to zero, and a zero
-    // base stays zero through `base *= 10.0`, so the loop would never reach
-    // `MAX` and would push boundaries until it ran out of memory.
-    let mut base = (crate::engine::abandon::sampling_window().as_millis() as f64).max(1.0);
-    loop {
-        for &m in &MULTIPLIERS {
-            let value = base * m;
-            if value > MAX {
-                return boundaries;
-            }
-            boundaries.push(value);
-        }
-        base *= 10.0;
-    }
-}
-
 /// Generate histogram boundaries for fuel consumption metrics.
 ///
 /// Produces boundaries following multipliers [1, 2.5, 5, 7.5] per decade,
@@ -565,5 +541,91 @@ fn fuel_histogram_boundaries() -> Vec<f64> {
             boundaries.push(value);
         }
         base *= 10.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys_and_values(attributes: &[KeyValue]) -> Vec<(String, String)> {
+        attributes
+            .iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect()
+    }
+
+    /// The scheme every guest-execution measurement shares, pinned by key.
+    ///
+    /// A rename here silently splits a dashboard's series in two, and nothing
+    /// else in the crate asserts these names.
+    #[test]
+    fn the_attribute_set_is_the_documented_scheme() {
+        let identity = WorkloadIdentity::new("shop", "checkout", "api");
+        assert_eq!(
+            keys_and_values(&identity.attributes("wasi-http", "wasi:http/handler#handle")),
+            vec![
+                ("plugin".to_string(), "wasi-http".to_string()),
+                (
+                    "operation".to_string(),
+                    "wasi:http/handler#handle".to_string()
+                ),
+                ("workload.namespace".to_string(), "shop".to_string()),
+                ("workload.name".to_string(), "checkout".to_string()),
+                ("component".to_string(), "api".to_string()),
+            ]
+        );
+    }
+
+    /// A surface's own bounded dimension appends, and does not displace.
+    ///
+    /// Spelled the way HTTP spells it: the semconv key, so the histogram and
+    /// the spans that already carry `http.request.method` join on it.
+    #[test]
+    fn an_extra_dimension_appends_to_the_shared_set() {
+        let identity = WorkloadIdentity::new("shop", "checkout", "api");
+        let attributes = identity.attributes_with(
+            "wasi-http",
+            "wasi:http/handler#handle",
+            KeyValue::new(
+                opentelemetry_semantic_conventions::attribute::HTTP_REQUEST_METHOD,
+                "GET",
+            ),
+        );
+        assert_eq!(attributes.len(), 6);
+        assert_eq!(
+            keys_and_values(&attributes).last().cloned(),
+            Some(("http.request.method".to_string(), "GET".to_string()))
+        );
+    }
+
+    /// Only the meter that was chosen is built. The other stays inert rather
+    /// than recording into a histogram nobody asked for.
+    #[test]
+    fn a_meter_kind_builds_only_its_own_histogram() {
+        // Fuel is the one that costs the guest, so only `fuel` builds it.
+        assert!(!Meters::new(MeterKind::Off).fuel_consumption.is_enabled());
+        assert!(
+            !Meters::new(MeterKind::Duration)
+                .fuel_consumption
+                .is_enabled()
+        );
+        assert!(Meters::new(MeterKind::Fuel).fuel_consumption.is_enabled());
+        // Duration is what an operator asks for first, so anything but `off`
+        // records it — including `fuel`.
+        assert!(!Meters::new(MeterKind::Off).invocation.is_enabled());
+        assert!(Meters::new(MeterKind::Duration).invocation.is_enabled());
+        assert!(Meters::new(MeterKind::Fuel).invocation.is_enabled());
+    }
+
+    #[test]
+    fn meter_kinds_parse_from_their_flag_spelling() {
+        assert_eq!("off".parse::<MeterKind>(), Ok(MeterKind::Off));
+        assert_eq!("duration".parse::<MeterKind>(), Ok(MeterKind::Duration));
+        assert_eq!("fuel".parse::<MeterKind>(), Ok(MeterKind::Fuel));
+        assert!("durations".parse::<MeterKind>().is_err());
+        // The default is what a serverless host should run: rate, errors and
+        // duration, which cost the guest two clock reads.
+        assert_eq!(MeterKind::default(), MeterKind::Duration);
     }
 }

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -7,7 +7,6 @@ use crate::observability::Meters;
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::wit::{WitInterface, WitWorld};
 use anyhow::Context;
-use opentelemetry::KeyValue;
 use tokio::sync::{Notify, RwLock, oneshot};
 use tracing::{Instrument, debug, instrument, trace, warn};
 
@@ -652,12 +651,12 @@ impl HostPlugin for InMemoryMessaging {
         // Spawn the message processing task
         let task_component_id = component_id.clone();
         let guest_meter = self.meters.read().await.guest();
-        // As in the NATS backend: bounded labels only, so the subject stays
-        // on the span rather than minting a time series per value.
-        let attributes = vec![
-            KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
-            KeyValue::new("operation", super::MESSAGING_OPERATION),
-        ];
+        // The identity every message on this component is measured under,
+        // resolved once here rather than per delivery.
+        let attributes = workload
+            .component_identity(&component_id)
+            .await
+            .attributes(PLUGIN_MESSAGING_MEMORY_ID, super::MESSAGING_OPERATION);
 
         let handle = tokio::spawn(async move {
             // Labelled so the inner drain below can end the whole task on
@@ -843,6 +842,7 @@ impl HostPlugin for InMemoryMessaging {
                         let abandoned = store.data().abandoned.watch(call.flag());
                         let deadline = call.arm_on_timer();
 
+                        let attributes = std::sync::Arc::clone(&attributes);
                         tokio::spawn(async move {
                             // Released on completion, trap or not — which is
                             // what frees the instance slot this message holds.
@@ -850,10 +850,7 @@ impl HostPlugin for InMemoryMessaging {
                             let _abandoned = abandoned;
                             let _deadline = deadline;
                             let result = guest_meter.observe(
-                                &[
-                                    KeyValue::new("plugin", PLUGIN_MESSAGING_MEMORY_ID),
-                                    KeyValue::new("subject", msg.subject.to_string()),
-                                ],
+                                &attributes,
                                 &mut store,
                                 async move |store| {
                                     proxy

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -270,7 +270,7 @@ pub(crate) async fn deliver_pooled(
     pre: &wasmtime::component::InstancePre<crate::engine::ctx::SharedCtx>,
     pool: &Arc<crate::engine::instance_pool::InstancePool>,
     msg: crate::host::trigger_service::BrokerMessage,
-    attributes: Vec<KeyValue>,
+    attributes: std::sync::Arc<[KeyValue]>,
 ) -> anyhow::Result<Result<(), String>> {
     use crate::engine::instance_driver::InstanceJob;
     use crate::engine::instance_pool::{ComponentInstance, Dispatch};

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use async_nats::Subscriber;
 use futures::stream::StreamExt;
-use opentelemetry::KeyValue;
 use tokio::sync::RwLock;
 use tracing::{Instrument, debug, instrument, trace, warn};
 use wasmtime::error::Context as _;
@@ -573,13 +572,12 @@ impl HostPlugin for NatsMessaging {
 
         let mut messages = futures::stream::select_all(subscriptions);
         let guest_meter = self.meters.read().await.guest();
-        // What a pooled delivery is measured under, built once here rather
-        // than per message. Both are bounded by what is deployed; the subject a
-        // message carries is not, so it stays on the span and the log line.
-        let attributes = vec![
-            KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
-            KeyValue::new("operation", super::MESSAGING_OPERATION),
-        ];
+        // The identity every message on this component is measured under,
+        // resolved once here rather than per delivery.
+        let attributes = workload
+            .component_identity(&component_id)
+            .await
+            .attributes(PLUGIN_MESSAGING_ID, super::MESSAGING_OPERATION);
 
         let span = tracing::Span::current();
         let handle = tokio::spawn(async move {
@@ -789,6 +787,7 @@ impl HostPlugin for NatsMessaging {
                         let abandoned = store.data().abandoned.watch(call.flag());
                         let deadline = call.arm_on_timer();
 
+                        let attributes = std::sync::Arc::clone(&attributes);
                         tokio::spawn(async move {
                             // Released on completion, trap or not — which is
                             // what frees the instance slot this message holds.
@@ -797,10 +796,7 @@ impl HostPlugin for NatsMessaging {
                             let _abandoned = abandoned;
                             let _deadline = deadline;
                             let result = guest_meter.observe(
-                                &[
-                                    KeyValue::new("plugin", PLUGIN_MESSAGING_ID),
-                                    KeyValue::new("subject", msg.subject.to_string()),
-                                ],
+                                &attributes,
                                 &mut store,
                                 async move |store| {
                                     proxy

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
@@ -419,7 +419,7 @@ impl WasmcloudNats {
         kv_watches: Vec<KvWatchConfig>,
         cancel_token: tokio_util::sync::CancellationToken,
         execution_meter: crate::observability::ExecutionTimeMeter,
-        warm_sets: Arc<subscriber::WarmSets>,
+        warm_set: Arc<subscriber::JetStreamWarmSet>,
     ) -> anyhow::Result<()> {
         let workload_id = workload.id();
         let Some(handle) = self.connections.get_named(workload_id, binding).await else {
@@ -514,7 +514,7 @@ impl WasmcloudNats {
                 execution_meter.clone(),
                 failure_sink.clone(),
                 workload_id,
-                warm_sets.clone(),
+                warm_set.clone(),
             )
             .await?;
         }
@@ -1005,7 +1005,7 @@ impl HostPlugin for WasmcloudNats {
 
         // Per component, not per binding: `poolSize` is the component's, and
         // the parked stores are interchangeable across its bindings.
-        let warm_sets = subscriber::WarmSets::for_component(workload, component_id).await;
+        let warm_set = subscriber::jetstream_warm_set(workload, component_id).await;
 
         for binding in bindings {
             let jetstream_subs: Vec<_> = jetstream_subs
@@ -1032,7 +1032,7 @@ impl HostPlugin for WasmcloudNats {
                 kv_watches,
                 cancel_token.clone(),
                 execution_meter.clone(),
-                warm_sets.clone(),
+                warm_set.clone(),
             )
             .await?;
         }

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/plugin.rs
@@ -418,7 +418,7 @@ impl WasmcloudNats {
         core_subs: Vec<CoreSubscriptionConfig>,
         kv_watches: Vec<KvWatchConfig>,
         cancel_token: tokio_util::sync::CancellationToken,
-        execution_meter: crate::observability::ExecutionTimeMeter,
+        guest_meter: crate::observability::GuestMeter,
         warm_set: Arc<subscriber::JetStreamWarmSet>,
     ) -> anyhow::Result<()> {
         let workload_id = workload.id();
@@ -511,7 +511,7 @@ impl WasmcloudNats {
                 handle.clone(),
                 jetstream_subs,
                 cancel_token.clone(),
-                execution_meter.clone(),
+                guest_meter.clone(),
                 failure_sink.clone(),
                 workload_id,
                 warm_set.clone(),
@@ -989,7 +989,7 @@ impl HostPlugin for WasmcloudNats {
             return Ok(());
         }
 
-        let execution_meter = self.meters.read().await.execution_time.clone();
+        let guest_meter = self.meters.read().await.guest();
 
         // Subscriptions run on the binding they were declared on: two named
         // bindings mean two connections, two grants, and two sets of loops
@@ -1006,6 +1006,24 @@ impl HostPlugin for WasmcloudNats {
         // Per component, not per binding: `poolSize` is the component's, and
         // the parked stores are interchangeable across its bindings.
         let warm_set = subscriber::jetstream_warm_set(workload, component_id).await;
+        // Reported here rather than from the subscription loop, which runs once
+        // per binding: the set is the component's, and a component bridging two
+        // clusters would otherwise be told about it twice. Only JetStream parks
+        // instances, so a component with only core subscriptions or KV watches
+        // is not told about a path it does not take.
+        if !jetstream_subs.is_empty() && warm_set.keeps_instances() {
+            // Resolved out of the macro: holding its `Arguments` across an
+            // await makes the whole hook's future non-`Send`.
+            let policy = workload.warm_instance_policy(component_id).await;
+            debug!(
+                component_id,
+                ?policy,
+                "wasmcloud:nats JetStream deliveries will reuse warm instances; note that on \
+                 this path `maxConcurrency` above 1 is served by additional one-shot stores \
+                 rather than by concurrent calls on one instance. Core and KV deliveries go \
+                 through the engine's pool and do honour it."
+            );
+        }
 
         for binding in bindings {
             let jetstream_subs: Vec<_> = jetstream_subs
@@ -1031,7 +1049,7 @@ impl HostPlugin for WasmcloudNats {
                 core_subs,
                 kv_watches,
                 cancel_token.clone(),
-                execution_meter.clone(),
+                guest_meter.clone(),
                 warm_set.clone(),
             )
             .await?;

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -16,7 +16,6 @@ use tracing::{Instrument, debug, error, warn};
 use crate::engine::instance_driver::InstanceJob;
 use crate::engine::instance_pool::{ComponentInstance, Dispatch};
 use crate::engine::workload::ResolvedWorkload;
-use crate::observability::ExecutionTimeMeter;
 use crate::wasmtime::component::{Accessor, InstancePre, Resource};
 
 use super::config::{AckMode, CoreSubscriptionConfig, JetStreamSubscriptionConfig, KvWatchConfig};
@@ -126,11 +125,12 @@ fn kv_entry_to_kv_handler_wit(e: &jetstream::kv::Entry) -> kv_bindings::wasmclou
 struct HandlerTarget {
     component_id: Arc<str>,
     pre: InstancePre<SharedCtx>,
-    /// Built once per subscription rather than per delivery: neither the
-    /// identity nor the operation can change under a resolved workload, and
-    /// resolving the identity costs a read lock.
-    core_attributes: Arc<[opentelemetry::KeyValue]>,
-    kv_attributes: Arc<[opentelemetry::KeyValue]>,
+    /// What every delivery through this target is measured under, built once
+    /// per subscription rather than per delivery: neither the identity nor the
+    /// operation can change under a resolved workload, and resolving the
+    /// identity costs a read lock. Whichever spawner built the target filled
+    /// this with its own operation.
+    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 /// The outcome channel every delivery job replies on: the handler's own
@@ -205,8 +205,7 @@ impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
             // the workload. Retiring is what ends it — the driver stops
             // admitting, drains, and the store's teardown takes the stalled
             // work with it. The same contract [`LinkedTask`] follows.
-            let _sample =
-                crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
+            let mut sample = crate::engine::instance_driver::InvocationSample::start(attributes);
             let outcome = tokio::time::timeout(
                 crate::timeouts::ephemeral_call(),
                 crate::engine::abandon::watch_until_abandoned(
@@ -219,15 +218,24 @@ impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
             )
             .await;
             let _ = reply.send(match outcome {
-                Ok(Ok(inner)) => Ok(inner),
+                Ok(Ok(inner)) => {
+                    // The guest's own `result<_, string>`: it ran and said no,
+                    // which is a failed delivery even though nothing trapped.
+                    if inner.is_err() {
+                        sample.failed("handler");
+                    }
+                    Ok(inner)
+                }
                 // A host failure mid-call leaves guest state indeterminate.
                 Ok(Err(e)) => {
+                    sample.failed("trap");
                     if let Some(slot) = slot {
                         slot.retire_instance();
                     }
                     Err(anyhow::anyhow!("{e:#}"))
                 }
                 Err(e) => {
+                    sample.failed("timeout");
                     if let Some(slot) = slot {
                         slot.retire_instance();
                     }
@@ -288,8 +296,7 @@ impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
             // the workload. Retiring is what ends it — the driver stops
             // admitting, drains, and the store's teardown takes the stalled
             // work with it. The same contract [`LinkedTask`] follows.
-            let _sample =
-                crate::engine::instance_driver::ExecutionSample::start(accessor, attributes);
+            let mut sample = crate::engine::instance_driver::InvocationSample::start(attributes);
             let outcome = tokio::time::timeout(
                 crate::timeouts::ephemeral_call(),
                 crate::engine::abandon::watch_until_abandoned(
@@ -302,15 +309,24 @@ impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
             )
             .await;
             let _ = reply.send(match outcome {
-                Ok(Ok(inner)) => Ok(inner),
+                Ok(Ok(inner)) => {
+                    // The guest's own `result<_, string>`: it ran and said no,
+                    // which is a failed delivery even though nothing trapped.
+                    if inner.is_err() {
+                        sample.failed("handler");
+                    }
+                    Ok(inner)
+                }
                 // A host failure mid-call leaves guest state indeterminate.
                 Ok(Err(e)) => {
+                    sample.failed("trap");
                     if let Some(slot) = slot {
                         slot.retire_instance();
                     }
                     Err(anyhow::anyhow!("{e:#}"))
                 }
                 Err(e) => {
+                    sample.failed("timeout");
                     if let Some(slot) = slot {
                         slot.retire_instance();
                     }
@@ -713,22 +729,13 @@ pub(super) async fn spawn_jetstream_subscriptions(
     conn: Arc<ConnHandle>,
     subs: Vec<JetStreamSubscriptionConfig>,
     cancel_token: CancellationToken,
-    execution_meter: ExecutionTimeMeter,
+    guest_meter: crate::observability::GuestMeter,
     failure_sink: Option<crate::plugin::WorkloadFailureSink>,
     workload_id: impl Into<String>,
     warm_set: Arc<JetStreamWarmSet>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
     let pre = JsHandlerPre::new(instance_pre)?;
-    if warm_set.keeps_instances() {
-        debug!(
-            component_id,
-            "wasmcloud:nats JetStream deliveries will reuse warm instances; note that on \
-             this path `maxConcurrency` above 1 is served by additional one-shot stores \
-             rather than by concurrent calls on one instance. Core and KV deliveries go \
-             through the engine's pool and do honour it."
-        );
-    }
     // Built once for the whole subscription set: the same attributes every
     // JetStream delivery on this component is measured under.
     let attributes = workload
@@ -750,7 +757,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
         let component_id = component_id.to_string();
         let pre = pre.clone();
         let cancel_token = cancel_token.clone();
-        let execution_meter = execution_meter.clone();
+        let guest_meter = guest_meter.clone();
         let failure_sink = failure_sink.clone();
         let workload_id = workload_id.clone();
         let scope = scope.clone();
@@ -1427,7 +1434,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
                             // Kept so the handle can be cleared before the
                             // store is parked; see the delete below.
                             let handle_rep = resource.rep();
-                            let execution_meter = execution_meter.clone();
+                            let guest_meter = guest_meter.clone();
                             let attributes = Arc::clone(&attributes);
                             let warm_set = warm_set.clone();
                             tokio::spawn(async move {
@@ -1435,7 +1442,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
                                 // mutably while the proxy that drives it is
                                 // read from the same struct.
                                 let (store, proxy) = (&mut warmed.handler.0, &warmed.handler.1);
-                                let result = execution_meter.observe(
+                                let result = guest_meter.observe(
                                     &attributes,
                                     store,
                                     async move |store| {
@@ -1995,8 +2002,7 @@ pub(super) async fn spawn_core_subscriptions(
     let target = HandlerTarget {
         component_id: Arc::from(component_id),
         pre: instance_pre,
-        core_attributes: identity.attributes(PLUGIN_NATS_ID, CORE_OPERATION),
-        kv_attributes: identity.attributes(PLUGIN_NATS_ID, KV_OPERATION),
+        attributes: identity.attributes(PLUGIN_NATS_ID, CORE_OPERATION),
     };
     let workload_id = workload_id.into();
 
@@ -2111,7 +2117,7 @@ pub(super) async fn spawn_core_subscriptions(
                                 msg,
                                 abandoned: call.flag(),
                                 reply,
-                                attributes: Arc::clone(&target.core_attributes),
+                                attributes: Arc::clone(&target.attributes),
                             });
                         let span = tracing::span!(
                             tracing::Level::INFO,
@@ -2193,8 +2199,7 @@ pub(super) async fn spawn_kv_watches(
     let target = HandlerTarget {
         component_id: Arc::from(component_id),
         pre: instance_pre,
-        core_attributes: identity.attributes(PLUGIN_NATS_ID, CORE_OPERATION),
-        kv_attributes: identity.attributes(PLUGIN_NATS_ID, KV_OPERATION),
+        attributes: identity.attributes(PLUGIN_NATS_ID, KV_OPERATION),
     };
 
     for watch in watches {
@@ -2395,7 +2400,7 @@ pub(super) async fn spawn_kv_watches(
                                     entry: kv_entry_to_kv_handler_wit(&entry),
                                     abandoned: call.flag(),
                                     reply,
-                                    attributes: Arc::clone(&target.kv_attributes),
+                                    attributes: Arc::clone(&target.attributes),
                                 });
                             let span = tracing::span!(
                                 tracing::Level::INFO,

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -18,7 +18,6 @@ use crate::engine::instance_pool::{ComponentInstance, Dispatch};
 use crate::engine::workload::ResolvedWorkload;
 use crate::observability::ExecutionTimeMeter;
 use crate::wasmtime::component::{Accessor, InstancePre, Resource};
-use opentelemetry::KeyValue;
 
 use super::config::{AckMode, CoreSubscriptionConfig, JetStreamSubscriptionConfig, KvWatchConfig};
 use super::conn::ConnHandle;
@@ -126,6 +125,11 @@ fn kv_entry_to_kv_handler_wit(e: &jetstream::kv::Entry) -> kv_bindings::wasmclou
 struct HandlerTarget {
     component_id: Arc<str>,
     pre: InstancePre<SharedCtx>,
+    /// Built once per subscription rather than per delivery: neither the
+    /// identity nor the operation can change under a resolved workload, and
+    /// resolving the identity costs a read lock.
+    core_attributes: Arc<[opentelemetry::KeyValue]>,
+    kv_attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 /// The outcome channel every delivery job replies on: the handler's own
@@ -142,9 +146,11 @@ fn call_guard(accessor: &Accessor<SharedCtx>) -> Arc<crate::engine::abandon::Aba
     })
 }
 
-/// How each delivery flavour names itself in a driver log line.
+/// The WIT export each delivery flavour invokes, and what its measurements are
+/// grouped by. Bounded by the interface set, so it is safe as an attribute.
 const CORE_OPERATION: &str = "wasmcloud:nats/core-handler#handle-message";
 const KV_OPERATION: &str = "wasmcloud:nats/kv-handler#handle-event";
+const JETSTREAM_OPERATION: &str = "wasmcloud:nats/jetstream-handler#handle-message";
 
 /// One core NATS delivery, run on whichever instance the pool picks.
 ///
@@ -156,7 +162,7 @@ struct CoreDeliveryJob {
     msg: core_bindings::wasmcloud::nats::types::NatsMessage,
     abandoned: Arc<crate::engine::abandon::AbandonFlag>,
     reply: DeliveryReply,
-    attributes: Vec<opentelemetry::KeyValue>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
@@ -238,7 +244,7 @@ struct KvDeliveryJob {
     entry: kv_bindings::wasmcloud::nats::kv::Entry,
     abandoned: Arc<crate::engine::abandon::AbandonFlag>,
     reply: DeliveryReply,
-    attributes: Vec<opentelemetry::KeyValue>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
@@ -727,6 +733,12 @@ pub(super) async fn spawn_jetstream_subscriptions(
     let instance_pre = workload.instantiate_pre(component_id).await?;
     let pre = JsHandlerPre::new(instance_pre)?;
     let warm_set = warm_sets.jetstream.clone();
+    // Built once for the whole subscription set: the same attributes every
+    // JetStream delivery on this component is measured under.
+    let attributes = workload
+        .component_identity(component_id)
+        .await
+        .attributes(PLUGIN_NATS_ID, JETSTREAM_OPERATION);
     let workload_id = workload_id.into();
     // Namespace only: both the workload id and the workload *name* are
     // per-replica, and replicas must converge on one durable. See
@@ -747,6 +759,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
         let workload_id = workload_id.clone();
         let scope = scope.clone();
         let warm_set = warm_set.clone();
+        let attributes = Arc::clone(&attributes);
 
         tokio::spawn(async move {
             // Mark the current generation as seen, so the connect that opened
@@ -1419,7 +1432,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
                             // store is parked; see the delete below.
                             let handle_rep = resource.rep();
                             let execution_meter = execution_meter.clone();
-                            let subject_label = subject_str.clone();
+                            let attributes = Arc::clone(&attributes);
                             let warm_set = warm_set.clone();
                             tokio::spawn(async move {
                                 // Split borrows: the call takes the store
@@ -1427,10 +1440,7 @@ pub(super) async fn spawn_jetstream_subscriptions(
                                 // read from the same struct.
                                 let (store, proxy) = (&mut warmed.handler.0, &warmed.handler.1);
                                 let result = execution_meter.observe(
-                                    &[
-                                        KeyValue::new("plugin", PLUGIN_NATS_ID),
-                                        KeyValue::new("subject", subject_label),
-                                    ],
+                                    &attributes,
                                     store,
                                     async move |store| {
                                         proxy
@@ -1985,9 +1995,12 @@ pub(super) async fn spawn_core_subscriptions(
     host_budget: Arc<HostBacklogBudget>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
+    let identity = workload.component_identity(component_id).await;
     let target = HandlerTarget {
         component_id: Arc::from(component_id),
         pre: instance_pre,
+        core_attributes: identity.attributes(PLUGIN_NATS_ID, CORE_OPERATION),
+        kv_attributes: identity.attributes(PLUGIN_NATS_ID, KV_OPERATION),
     };
     let workload_id = workload_id.into();
 
@@ -2102,10 +2115,7 @@ pub(super) async fn spawn_core_subscriptions(
                                 msg,
                                 abandoned: call.flag(),
                                 reply,
-                                attributes: vec![
-                                    KeyValue::new("plugin", PLUGIN_NATS_ID),
-                                    KeyValue::new("subject", subject_label.clone()),
-                                ],
+                                attributes: Arc::clone(&target.core_attributes),
                             });
                         let span = tracing::span!(
                             tracing::Level::INFO,
@@ -2183,9 +2193,12 @@ pub(super) async fn spawn_kv_watches(
     _workload_id: impl Into<String>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
+    let identity = workload.component_identity(component_id).await;
     let target = HandlerTarget {
         component_id: Arc::from(component_id),
         pre: instance_pre,
+        core_attributes: identity.attributes(PLUGIN_NATS_ID, CORE_OPERATION),
+        kv_attributes: identity.attributes(PLUGIN_NATS_ID, KV_OPERATION),
     };
 
     for watch in watches {
@@ -2386,10 +2399,7 @@ pub(super) async fn spawn_kv_watches(
                                     entry: kv_entry_to_kv_handler_wit(&entry),
                                     abandoned: call.flag(),
                                     reply,
-                                    attributes: vec![
-                                        KeyValue::new("plugin", PLUGIN_NATS_ID),
-                                        KeyValue::new("bucket", bucket_for_label.clone()),
-                                    ],
+                                    attributes: Arc::clone(&target.kv_attributes),
                                 });
                             let span = tracing::span!(
                                 tracing::Level::INFO,

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -37,7 +37,8 @@ macro_rules! handler_pre {
     ($name:ident, $proxy:ident, $pre:ty, $instance:ty) => {
         struct $name($pre);
 
-        struct $proxy($instance);
+        // As visible as the warm set that names it in its type.
+        pub(super) struct $proxy($instance);
 
         impl Clone for $name {
             fn clone(&self) -> Self {
@@ -443,47 +444,34 @@ async fn run_delivery(
         .map_err(|_| anyhow::anyhow!("delivery task dropped the reply"))?
 }
 
-/// The warm sets a component's handlers serve their deliveries from, built from
-/// the instance policy the component declared.
+/// The warm instances a component's JetStream deliveries are served from,
+/// built from the instance policy the component declared.
 ///
 /// The same `poolSize` / `maxInvocations` knobs that feed the engine's
-/// [`InstanceJob`] pool, honoured here because a *JetStream* delivery cannot
-/// take that path — its call carries a typed resource that must live in the very
+/// [`InstanceJob`] pool, honoured here because a JetStream delivery cannot take
+/// that path — its call carries a typed resource that must live in the very
 /// store that runs it, and its ack ownership lives in the subscription loop.
-/// See [`super::warm`] for what is and is not honoured.
+/// Core and KV deliveries do take the pool. See [`super::warm`] for what is and
+/// is not honoured.
 ///
-/// One set per handler flavour, built once per *component* rather than once per
-/// binding: `poolSize` is the component's, and the stores are interchangeable
-/// across the bindings it serves. Per binding, a component bridging two
-/// clusters with `(implements hub)` and `(implements leaf)` at `poolSize: 8`
-/// parked up to 16 live stores on a host sized for 8.
+/// Built once per *component* rather than once per binding: `poolSize` is the
+/// component's, and the stores are interchangeable across the bindings it
+/// serves. Per binding, a component bridging two clusters with
+/// `(implements hub)` and `(implements leaf)` at `poolSize: 8` parked up to 16
+/// live stores on a host sized for 8.
 ///
 /// [`InstanceJob`]: crate::engine::instance_driver::InstanceJob
-pub(super) struct WarmSets {
-    jetstream: Arc<super::warm::WarmSet<(crate::wasmtime::Store<SharedCtx>, JsProxy)>>,
-}
+pub(super) type JetStreamWarmSet =
+    super::warm::WarmSet<(crate::wasmtime::Store<SharedCtx>, JsProxy)>;
 
-impl WarmSets {
-    pub(super) async fn for_component(
-        workload: &ResolvedWorkload,
-        component_id: &str,
-    ) -> Arc<Self> {
-        let policy = workload.warm_instance_policy(component_id).await;
-        let sets = Self {
-            jetstream: Arc::new(super::warm::WarmSet::new(policy)),
-        };
-        if sets.jetstream.keeps_instances() {
-            debug!(
-                component_id,
-                ?policy,
-                "wasmcloud:nats JetStream deliveries will reuse warm instances; note \
-                 that on this path `maxConcurrency` above 1 is served by additional \
-                 one-shot stores rather than by concurrent calls on one instance. Core \
-                 and KV deliveries go through the engine's pool and do honour it."
-            );
-        }
-        Arc::new(sets)
-    }
+/// The warm set a component's JetStream deliveries share.
+pub(super) async fn jetstream_warm_set(
+    workload: &ResolvedWorkload,
+    component_id: &str,
+) -> Arc<JetStreamWarmSet> {
+    Arc::new(super::warm::WarmSet::new(
+        workload.warm_instance_policy(component_id).await,
+    ))
 }
 
 /// How long an unsettled sequence holds a rebuild back before the loop stops
@@ -728,11 +716,19 @@ pub(super) async fn spawn_jetstream_subscriptions(
     execution_meter: ExecutionTimeMeter,
     failure_sink: Option<crate::plugin::WorkloadFailureSink>,
     workload_id: impl Into<String>,
-    warm_sets: Arc<WarmSets>,
+    warm_set: Arc<JetStreamWarmSet>,
 ) -> anyhow::Result<()> {
     let instance_pre = workload.instantiate_pre(component_id).await?;
     let pre = JsHandlerPre::new(instance_pre)?;
-    let warm_set = warm_sets.jetstream.clone();
+    if warm_set.keeps_instances() {
+        debug!(
+            component_id,
+            "wasmcloud:nats JetStream deliveries will reuse warm instances; note that on \
+             this path `maxConcurrency` above 1 is served by additional one-shot stores \
+             rather than by concurrent calls on one instance. Core and KV deliveries go \
+             through the engine's pool and do honour it."
+        );
+    }
     // Built once for the whole subscription set: the same attributes every
     // JetStream delivery on this component is measured under.
     let attributes = workload

--- a/crates/wash-runtime/tests/integration_abandoned_calls.rs
+++ b/crates/wash-runtime/tests/integration_abandoned_calls.rs
@@ -545,7 +545,7 @@ async fn deliver(
                 body: b"hi".to_vec(),
                 reply_to: None,
             },
-            Vec::new(),
+            std::sync::Arc::from([]),
         )
         .await
 }

--- a/crates/wash-runtime/tests/integration_fuel_metering.rs
+++ b/crates/wash-runtime/tests/integration_fuel_metering.rs
@@ -58,23 +58,23 @@ fn a_default_engine_does_not_meter_fuel() -> Result<()> {
     Ok(())
 }
 
-/// Asking for epoch timing must not quietly turn fuel on.
+/// Asking for duration must not quietly turn fuel on.
 ///
-/// This is the point of the choice: `guest.execution.time` is sampled from the
-/// epoch callback every store arms anyway, so it costs the guest nothing at run
-/// time. A host that picked it must not also pay fuel's per-block counters.
+/// This is the point of the choice: timing a call costs two clock reads, so a
+/// host that wants latency must not also pay fuel's per-block counters, which
+/// are compiled into every block of guest code.
 #[test]
-fn epoch_metering_does_not_meter_fuel() -> Result<()> {
+fn duration_metering_does_not_meter_fuel() -> Result<()> {
     assert!(
-        !meters_fuel(&engine_for(MeterKind::Epoch)?),
-        "`epoch` must not compile fuel counters into guests"
+        !meters_fuel(&engine_for(MeterKind::Duration)?),
+        "`duration` must not compile fuel counters into guests"
     );
     // Meters are host state: building them decides which histograms exist,
     // never how guests are compiled.
-    let _meters = Meters::new(MeterKind::Epoch);
+    let _meters = Meters::new(MeterKind::Duration);
     assert!(
         !meters_fuel(&Engine::builder().build()?),
-        "building epoch meters must not turn fuel on for an engine that did not ask"
+        "building duration meters must not turn fuel on for an engine that did not ask"
     );
     Ok(())
 }

--- a/crates/wash-runtime/tests/integration_meter_selection.rs
+++ b/crates/wash-runtime/tests/integration_meter_selection.rs
@@ -64,34 +64,39 @@ async fn record_one(kind: MeterKind) -> Result<Vec<String>> {
 /// One test, sequentially, because the meter provider each case installs is
 /// process-global.
 #[tokio::test]
-async fn each_meter_records_its_own_histogram() -> Result<()> {
-    let epoch = record_one(MeterKind::Epoch).await?;
+async fn a_meter_kind_records_duration_and_only_its_own_cpu_metric() -> Result<()> {
+    // Duration is not the choice: it is what an operator asks for first, it
+    // costs the guest two clock reads, and it is recorded under either kind.
+    for kind in [MeterKind::Duration, MeterKind::Fuel] {
+        let recorded = record_one(kind).await?;
+        assert!(
+            recorded
+                .iter()
+                .any(|name| name == "guest.invocation.duration"),
+            "{kind:?} recorded no invocation duration; got {recorded:?}"
+        );
+    }
+
+    // Fuel is the one that costs the guest, so only `fuel` records it.
+    let duration = record_one(MeterKind::Duration).await?;
     assert!(
-        epoch.iter().any(|name| name == "guest.execution.time"),
-        "epoch metering recorded no execution time; got {epoch:?}"
-    );
-    assert!(
-        !epoch.iter().any(|name| name == "fuel.consumption"),
-        "epoch metering must not record fuel; got {epoch:?}"
+        !duration.iter().any(|name| name == "fuel.consumption"),
+        "`duration` must not record fuel; got {duration:?}"
     );
 
     let fuel = record_one(MeterKind::Fuel).await?;
     assert!(
         fuel.iter().any(|name| name == "fuel.consumption"),
-        "fuel metering recorded no consumption; got {fuel:?}"
-    );
-    assert!(
-        !fuel.iter().any(|name| name == "guest.execution.time"),
-        "fuel metering must not record execution time; got {fuel:?}"
+        "`fuel` recorded no consumption; got {fuel:?}"
     );
 
     // `off` is about these two only: the engine's own memory instruments are
-    // not guest-execution metering and are recorded regardless.
+    // not guest metering and are recorded regardless.
     let off = record_one(MeterKind::Off).await?;
     assert!(
         !off.iter()
-            .any(|name| name == "guest.execution.time" || name == "fuel.consumption"),
-        "a host metering nothing recorded a guest-execution metric; got {off:?}"
+            .any(|name| { name == "guest.invocation.duration" || name == "fuel.consumption" }),
+        "a host metering nothing recorded a guest metric; got {off:?}"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
+++ b/crates/wash-runtime/tests/integration_trigger_service_messaging.rs
@@ -93,7 +93,7 @@ async fn deliver(
     };
     timeout(
         Duration::from_secs(10),
-        ingress.deliver_trigger_service_message(workload_id, msg, Vec::new()),
+        ingress.deliver_trigger_service_message(workload_id, msg, std::sync::Arc::from([])),
     )
     .await
     .context("deliver_trigger_service_message timed out")?

--- a/crates/wash/src/main.rs
+++ b/crates/wash/src/main.rs
@@ -51,12 +51,14 @@ struct Cli {
     #[arg(short = 'C', default_value = find_project_root().into_os_string())]
     project_path: PathBuf,
 
-    /// Which guest-execution meter to run: `off`, `epoch`, or `fuel`.
+    /// What to measure about guests: `off`, `duration`, or `fuel`.
     ///
-    /// `epoch` samples the clock the host already arms, so guests pay nothing
-    /// for it. `fuel` counts exactly, at the price of a counter compiled into
-    /// every block of guest code.
-    #[arg(long = "meters", global = true, default_value = "off")]
+    /// `duration` reports how many invocations there were, how many failed and
+    /// how long they took, for two clock reads a call — the default, because it
+    /// is what an operator needs first and costs the guest nothing. `fuel` adds
+    /// an exact count of the operations a guest executed, at the price of a
+    /// counter compiled into every block of its code.
+    #[arg(long = "meters", global = true, default_value = "duration")]
     meters: wash_runtime::observability::MeterKind,
 
     /// Deprecated spelling of `--meters fuel`.
@@ -391,13 +393,16 @@ mod tests {
 
     #[test]
     fn meters_flag_stands_alone() {
-        let cli = Cli::try_parse_from(["wash", "--meters", "epoch", "inspect", "component.wasm"])
+        let cli = Cli::try_parse_from(["wash", "--meters", "off", "inspect", "component.wasm"])
             .expect("--meters should parse");
-        assert_eq!(cli.meters(), MeterKind::Epoch);
+        assert_eq!(cli.meters(), MeterKind::Off);
 
+        // Rate, errors and duration without being asked: they cost the guest
+        // two clock reads, and a host nobody can see is worse than one that is
+        // marginally slower.
         let cli = Cli::try_parse_from(["wash", "inspect", "component.wasm"])
             .expect("no meter flag should parse");
-        assert_eq!(cli.meters(), MeterKind::Off);
+        assert_eq!(cli.meters(), MeterKind::Duration);
     }
 
     #[test]


### PR DESCRIPTION
`guest.execution.time` and `fuel.consumption` were attributed five different ways depending on which surface drove the call, and three of those carried a label a caller can invent. A histogram keeps a counter per bucket per distinct label set, so a subject or URI as an attribute mints a permanent time series per distinct value. That will result in growth that arrives during a flood the metric exists to report and outlives it by the retention window.

Every guest measurement now carries the same set:

`plugin, operation, workload.namespace, workload.name, component`

Manifest names, not ids. Both ids are a fresh UUID per workload construction, so attributing a series with one mints a new series on every restart, rolling update and replica.

**Dropped, all caller-invented fields:** the delivered `subject` from NATS core/KV/JetStream and both messaging backends; `uri` and `host` from HTTP. Each stays on the span and the logs that already carry it.  `hyper::Method` accepts arbitrary extension tokens, so it was caller-invented too, recorded under `http.request.method` (matches the same semconv key the spans use) so a histogram and a trace join without a relabel.

### Replaced `guest.execution.time` with `guest.invocation.duration`

`guest.execution.time` differenced the store-wide CPU counter across one call. That difference is the call's own only when no other call shared the store. So samples were dropped as concurrency rose. A latency dashboard built on it would have shown the host's idle behavior under load.

This is replaced by a new instrument `guest.invocation.duration`. Its count is the rate, and `error.type` (present only on failure) separates errors out of the same series. The value is wall clock duration.

### Gaps closed along the way

- Every trigger service was measured as `component="unknown"`. A workload's service lives outside the component map, and both messaging backends pass a service id whenever one is running.
- Linked calls served from their own store, and p3 HTTP requests past a saturated pool, were unmeasured. This covers the default paths for a component that declared no `poolSize`.
- `invoke_ephemeral_relocated` was unmeasured, so a linked import returning `stream<u8>` was invisible while the identical `list<u8>` version wasn't.
- Inbound HTTP on the pooled path had no metric

### Performance

The default host (`--meters off`) does *less* work than before: the sample takes one `OnceLock` load, finds nothing and skips the clock, where the removed machinery did a store borrow, an `Arc` clone and two atomics unconditionally. With metering on it's two `Instant::now()` plus one histogram record per call. Attribute sets are built once per subscription or route and shared as `Arc<[KeyValue]>`, so a call clones a pointer; the error path's allocation only happens on errors.

### Breaking

- `guest.execution.time` is removed, with no store-level replacement. Use `guest.invocation.duration` for latency, rate and errors; `fuel.consumption` under `--meters fuel` for exact guest work.
- `--meters` defaults to `duration` rather than `off`. `--enable-meters` still works as an alias for `fuel`.
- `HostHandler::deliver_trigger_service_message` changed signature
