### PR TITLE
fix(wash-runtime): deliver wasi:config to every component of a workload

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -3397,6 +3397,59 @@ mod tests {
         );
     }
 
+    /// A workload that both publishes and handles names both interfaces on its
+    /// one unnamed `wasmcloud:messaging` entry, which is the only shape a
+    /// manifest can give a package. Each component uses half of it and both
+    /// bind the messaging plugin, so the publisher gets `consumer` in its
+    /// linker and the handler's export is subscribed.
+    ///
+    /// Uses the real plugin, whose world is the split this turns on: `consumer`
+    /// and `types` served, `handler` called back on the workload.
+    #[tokio::test]
+    async fn a_publisher_and_a_handler_share_one_messaging_entry() {
+        let publisher = component_from_wat(
+            "publisher",
+            r#"(component (import "wasmcloud:messaging/consumer@0.2.0" (instance)))"#,
+        );
+        let handler = component_from_wat(
+            "handler",
+            r#"(component
+                 (instance $handler)
+                 (export "wasmcloud:messaging/handler@0.2.0" (instance $handler)))"#,
+        );
+        let publisher_id = publisher.id().to_string();
+        let handler_id = handler.id().to_string();
+
+        let plugin =
+            Arc::new(crate::plugin::wasmcloud_messaging::in_memory::InMemoryMessaging::new());
+        let plugins = HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "messaging",
+            "messaging",
+            "test-namespace",
+            None,
+            vec![publisher, handler],
+            vec![WitInterface::from(
+                "wasmcloud:messaging/consumer,handler,types@0.2.0",
+            )],
+        );
+        let bound = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .expect("both halves of the entry are served");
+        let bound_ids = bound_component_ids(&bound);
+
+        assert!(
+            bound_ids.contains(&publisher_id),
+            "the publisher needs `consumer` in its linker"
+        );
+        assert!(
+            bound_ids.contains(&handler_id),
+            "nothing subscribes the handler's export unless the plugin binds it"
+        );
+    }
+
     /// A component importing a subset of an entry — the ordinary shape of a
     /// multi-component workload, since one entry covers them all — binds the
     /// plugin serving that entry.

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1,7 +1,7 @@
 //! This module is primarily concerned with converting an [`UnresolvedWorkload`] into a [`ResolvedWorkload`] by
 //! resolving all components and their dependencies.
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::{Deref, DerefMut},
     path::PathBuf,
     sync::Arc,
@@ -2202,9 +2202,11 @@ impl UnresolvedWorkload {
             let world = service.world();
 
             trace!(?world, "comparing service world to host interfaces");
+            // An entry this item uses any of, not every name on it: the entry
+            // covers what the whole workload uses (see [`WitWorld::uses`]).
             let required_interfaces: HashSet<WitInterface> = host_interfaces
                 .iter()
-                .filter(|wit_interface| world.includes_bidirectional(wit_interface))
+                .filter(|wit_interface| world.uses(wit_interface))
                 .filter(|wit_interface| {
                     !served_within_workload(wit_interface, service.id(), &world, &component_worlds)
                 })
@@ -2223,7 +2225,7 @@ impl UnresolvedWorkload {
             trace!(?world, "comparing component world to host interfaces");
             let required_interfaces: HashSet<WitInterface> = host_interfaces
                 .iter()
-                .filter(|wit_interface| world.includes_bidirectional(wit_interface))
+                .filter(|wit_interface| world.uses(wit_interface))
                 .filter(|wit_interface| {
                     !served_within_workload(wit_interface, id, world, &component_worlds)
                 })
@@ -2358,28 +2360,42 @@ impl UnresolvedWorkload {
                     .flat_map(Clone::clone)
                     .collect();
 
-                // Validate: if multiple named entries of the same namespace:package
-                // are matched to this plugin, the plugin must support named instances
-                let mut ns_pkg_named: HashMap<(&str, &str), Vec<&str>> = HashMap::new();
+                // A name selects one backend of a package, so two bindings for
+                // one package need two backends to route between. A plugin
+                // serving a single instance has one, and collapsing them into
+                // it delivers one binding's configuration under both names.
+                //
+                // A label equal to the plugin's own id addresses the plugin
+                // rather than a backend, and reads as unnamed here exactly as
+                // it does in [`crate::plugin::PluginBindingSet`].
+                let mut ns_pkg_bindings: BTreeMap<(&str, &str), BTreeSet<&str>> = BTreeMap::new();
                 for iface in &plugin_matched_interfaces {
-                    if let Some(name) = &iface.name {
-                        ns_pkg_named
-                            .entry((iface.namespace.as_str(), iface.package.as_str()))
-                            .or_default()
-                            .push(name.as_str());
-                    }
+                    let binding = match iface.name.as_deref() {
+                        Some(name) if name != *plugin_id => name,
+                        _ => "",
+                    };
+                    ns_pkg_bindings
+                        .entry((iface.namespace.as_str(), iface.package.as_str()))
+                        .or_default()
+                        .insert(binding);
                 }
-                for ((ns, pkg), mut names) in ns_pkg_named {
-                    if names.len() > 1 && !p.supports_named_instances() {
-                        names.sort_unstable();
+                for ((ns, pkg), bindings) in ns_pkg_bindings {
+                    if bindings.len() > 1 && !p.supports_named_instances() {
+                        let named: Vec<&str> =
+                            bindings.iter().copied().filter(|b| !b.is_empty()).collect();
+                        // Plugins bind in id order, so earlier ones are already
+                        // holding state — a connection, a subscription — for a
+                        // workload that is not going to deploy.
+                        unbind_all(self.id(), &bound_plugins_with_interfaces, "binding policy")
+                            .await;
                         bail!(
-                            "plugin '{}' does not support named instances, but workload \
-                             requires {} named entries for {ns}:{pkg} (names: {}). \
-                             The plugin must implement supports_named_instances() to \
-                             handle multiplexed interfaces.",
-                            plugin_id,
-                            names.len(),
-                            names.join(", ")
+                            "plugin '{plugin_id}' does not support named instances, but the \
+                             workload declares {} bindings for {ns}:{pkg} (named: {}). Each \
+                             name routes to its own backend and this plugin serves one, so \
+                             give those entries a single binding, or register a plugin that \
+                             implements supports_named_instances().",
+                            bindings.len(),
+                            named.join(", "),
                         );
                     }
                 }
@@ -2798,14 +2814,28 @@ fn served_within_workload(
     if entry.interfaces.is_empty() {
         return false;
     }
-    entry.interfaces.iter().all(|interface| {
-        let imported = item_world
+    // An item exporting any of the entry's interfaces keeps the entry, so the
+    // host can reach that export.
+    if entry.interfaces.iter().any(|interface| {
+        item_world
+            .exports
+            .iter()
+            .any(|ex| entry.same_package(ex) && ex.interfaces.contains(interface))
+    }) {
+        return false;
+    }
+    // Of the names left, only the ones this item imports are its to answer: the
+    // entry covers what the whole workload uses (see [`WitWorld::uses`]).
+    let imported = entry.interfaces.iter().filter(|interface| {
+        item_world
             .imports
             .iter()
-            .any(|im| entry.same_package(im) && im.interfaces.contains(interface));
-        if !imported {
-            return false;
-        }
+            .any(|im| entry.same_package(im) && im.interfaces.contains(*interface))
+    });
+
+    let mut imports_any = false;
+    for interface in imported {
+        imports_any = true;
         let exporters = component_worlds
             .iter()
             .filter(|(id, world)| {
@@ -2816,8 +2846,11 @@ fn served_within_workload(
                         .any(|ex| entry.same_package(ex) && ex.interfaces.contains(interface))
             })
             .count();
-        exporters == 1
-    })
+        if exporters != 1 {
+            return false;
+        }
+    }
+    imports_any
 }
 
 /// Unbind every plugin already bound for `workload_id`, newest first.
@@ -3361,6 +3394,193 @@ mod tests {
         assert!(
             bound_component_ids(&bound).contains(&importer_id),
             "an ambiguous sibling export is not a provider, so the plugin keeps the import"
+        );
+    }
+
+    /// A component importing a subset of an entry — the ordinary shape of a
+    /// multi-component workload, since one entry covers them all — binds the
+    /// plugin serving that entry.
+    #[tokio::test]
+    async fn a_component_using_part_of_an_entry_still_binds() {
+        const PROBE: &str = "test:probe/alpha,beta@0.1.0";
+
+        let both = component_from_wat(
+            "both",
+            r#"(component
+                 (import "test:probe/alpha@0.1.0" (instance))
+                 (import "test:probe/beta@0.1.0" (instance)))"#,
+        );
+        let alpha_only = component_from_wat(
+            "alpha-only",
+            r#"(component (import "test:probe/alpha@0.1.0" (instance)))"#,
+        );
+        let both_id = both.id().to_string();
+        let alpha_only_id = alpha_only.id().to_string();
+
+        let plugin = Arc::new(MockPlugin::new(
+            "probe-plugin",
+            vec![WitInterface::from(PROBE)],
+            vec![],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "subset",
+            "subset",
+            "test-namespace",
+            None,
+            vec![both, alpha_only],
+            vec![WitInterface::from(PROBE)],
+        );
+        let bound = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .unwrap();
+        let bound_ids = bound_component_ids(&bound);
+
+        assert!(bound_ids.contains(&both_id));
+        assert!(
+            bound_ids.contains(&alpha_only_id),
+            "a component importing one interface of the entry still needs the plugin serving it"
+        );
+    }
+
+    /// A workload still serves itself first when the entry names more than the
+    /// importer uses: the interfaces an item imports are the ones a sibling can
+    /// answer for it, so the link survives and the plugin does not install a
+    /// shim over it. The sibling that *exports* the interface still binds,
+    /// because an export is how the host reaches into a workload.
+    #[tokio::test]
+    async fn a_sibling_export_still_wins_for_part_of_an_entry() {
+        const PROBE: &str = "test:probe/alpha,beta@0.1.0";
+
+        let importer = component_from_wat(
+            "importer",
+            r#"(component (import "test:probe/alpha@0.1.0" (instance)))"#,
+        );
+        let exporter = component_from_wat(
+            "exporter",
+            r#"(component
+                 (instance $alpha)
+                 (export "test:probe/alpha@0.1.0" (instance $alpha)))"#,
+        );
+        let importer_id = importer.id().to_string();
+        let exporter_id = exporter.id().to_string();
+
+        let plugin = Arc::new(MockPlugin::new(
+            "probe-plugin",
+            vec![WitInterface::from(PROBE)],
+            vec![],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "subset",
+            "subset",
+            "test-namespace",
+            None,
+            vec![importer, exporter],
+            vec![WitInterface::from(PROBE)],
+        );
+        let bound = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .unwrap();
+        let bound_ids = bound_component_ids(&bound);
+
+        assert!(
+            !bound_ids.contains(&importer_id),
+            "the importer links to its sibling, so the plugin must not take its import"
+        );
+        assert!(bound_ids.contains(&exporter_id));
+    }
+
+    /// An item that exports one of the entry's interfaces binds the plugin even
+    /// when a sibling answers its imports: an export is how the host reaches
+    /// into a workload, which is a separate question from where imports point.
+    #[tokio::test]
+    async fn an_exporter_binds_even_when_a_sibling_answers_its_imports() {
+        const PROBE: &str = "test:probe/alpha,beta@0.1.0";
+
+        let both_ways = component_from_wat(
+            "both-ways",
+            r#"(component
+                 (import "test:probe/alpha@0.1.0" (instance))
+                 (instance $beta)
+                 (export "test:probe/beta@0.1.0" (instance $beta)))"#,
+        );
+        let exporter = component_from_wat(
+            "exporter",
+            r#"(component
+                 (instance $alpha)
+                 (export "test:probe/alpha@0.1.0" (instance $alpha)))"#,
+        );
+        let both_ways_id = both_ways.id().to_string();
+
+        let plugin = Arc::new(MockPlugin::new(
+            "probe-plugin",
+            vec![WitInterface::from(PROBE)],
+            vec![],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "subset",
+            "subset",
+            "test-namespace",
+            None,
+            vec![both_ways, exporter],
+            vec![WitInterface::from(PROBE)],
+        );
+        let bound = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .unwrap();
+
+        assert!(
+            bound_component_ids(&bound).contains(&both_ways_id),
+            "nothing else can reach the export this component serves"
+        );
+    }
+
+    /// The provider side keeps asking for the whole entry: a plugin serving
+    /// part of one must not claim it, or the rest is left bound by nobody —
+    /// here the interface goes unmatched and the workload is refused, rather
+    /// than deploying with an import nothing serves.
+    #[tokio::test]
+    async fn a_plugin_serving_part_of_an_entry_does_not_claim_it() {
+        let importer = component_from_wat(
+            "importer",
+            r#"(component
+                 (import "test:probe/alpha@0.1.0" (instance))
+                 (import "test:probe/beta@0.1.0" (instance)))"#,
+        );
+
+        let plugin = Arc::new(MockPlugin::new(
+            "alpha-only-plugin",
+            vec![WitInterface::from("test:probe/alpha@0.1.0")],
+            vec![],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "subset",
+            "subset",
+            "test-namespace",
+            None,
+            vec![importer],
+            vec![WitInterface::from("test:probe/alpha,beta@0.1.0")],
+        );
+        let err = match workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+        {
+            Ok(_) => panic!("a partially served entry has no provider"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            err.contains("not available on this host"),
+            "expected an unmatched-interface refusal, got: {err}"
         );
     }
 
@@ -4564,8 +4784,12 @@ mod tests {
         );
     }
 
+    /// A component exporting the handler half of a `consumer,handler` entry
+    /// binds the messaging plugin, so its handler is subscribed. That entry is
+    /// how a workload which both publishes and handles is written, often with
+    /// the two halves in different components.
     #[tokio::test]
-    async fn test_host_interface_redundancy() {
+    async fn a_component_exporting_half_an_entry_binds_the_plugin() {
         let messaging_handler = WitInterface {
             namespace: "wasmcloud".to_string(),
             package: "messaging".to_string(),
@@ -4646,20 +4870,17 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify plugin was called once for workload binding
+        // The component imports `wasi:logging`, so the logging plugin binds it.
         assert_eq!(logging_plugin.get_call_count("on_workload_bind"), 1);
-
-        // Verify plugin was called once for component binding
         assert_eq!(logging_plugin.get_call_count("on_workload_item_bind"), 1);
 
-        // Verify plugin was called once for workload binding
-        assert_eq!(messaging_plugin.get_call_count("on_workload_bind"), 0);
+        // It exports `wasmcloud:messaging/handler`, one of the two interfaces
+        // the messaging entry names, so the messaging plugin binds it too —
+        // without that bind nothing subscribes and the handler never runs.
+        assert_eq!(messaging_plugin.get_call_count("on_workload_bind"), 1);
+        assert_eq!(messaging_plugin.get_call_count("on_workload_item_bind"), 1);
 
-        // Verify plugin was called once for component binding
-        assert_eq!(messaging_plugin.get_call_count("on_workload_item_bind"), 0);
-
-        // Verify bound_plugins contains our plugin with the component
-        assert_eq!(bound_plugins.len(), 1);
+        assert_eq!(bound_plugins.len(), 2);
     }
 
     #[tokio::test]
@@ -4759,6 +4980,115 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A named entry beside an unnamed one is two bindings for one package, so
+    /// a plugin serving a single instance has nowhere to route the second.
+    #[tokio::test]
+    async fn test_a_named_entry_beside_an_unnamed_one_is_refused() {
+        let plugin = Arc::new(MockPlugin::new(
+            "keyvalue-plugin",
+            vec![],
+            vec![keyvalue_interface(None)],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin.clone() as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![keyvalue_interface(None), keyvalue_interface(Some("cache"))],
+        );
+
+        let err = match workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+        {
+            Ok(_) => panic!("two bindings cannot share one instance"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            err.contains("does not support named instances") && err.contains("cache"),
+            "the refusal must name the binding that has nowhere to go, got: {err}"
+        );
+    }
+
+    /// Plugins bind in id order, so a refusal partway through leaves earlier
+    /// ones holding state — a connection, a subscription — for a workload that
+    /// never deploys.
+    #[tokio::test]
+    async fn test_a_refused_binding_rolls_back_the_plugins_already_bound() {
+        let earlier = Arc::new(RollbackPlugin::new(None));
+        let later = Arc::new(MockPlugin::new(
+            "zz-keyvalue-plugin",
+            vec![],
+            vec![keyvalue_interface(None)],
+        ));
+        let mut plugins = earlier.registered();
+        plugins.insert(later.id(), later.clone() as Arc<dyn HostPlugin>);
+
+        let importer = component_from_wat(
+            "importer",
+            &format!(
+                r#"(component
+                     (import "{MARKER}" (instance))
+                     (import "wasi:keyvalue/store@0.2.0-draft" (instance)))"#
+            ),
+        );
+        let mut workload = UnresolvedWorkload::new(
+            "rollback",
+            "rollback",
+            "test-namespace",
+            None,
+            vec![importer],
+            vec![
+                WitInterface::from(MARKER),
+                keyvalue_interface(None),
+                keyvalue_interface(Some("cache")),
+            ],
+        );
+
+        assert!(
+            workload
+                .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+                .await
+                .is_err(),
+            "two bindings cannot share one instance"
+        );
+        assert_eq!(
+            earlier.unbind_count(),
+            1,
+            "the plugin bound before the refusal must be unbound"
+        );
+    }
+
+    /// A lone name is one binding: it selects the operator's declaration for
+    /// this plugin and is delivered to it, which a single instance can serve.
+    #[tokio::test]
+    async fn test_a_lone_named_entry_binds_a_single_instance_plugin() {
+        let plugin = Arc::new(MockPlugin::new(
+            "keyvalue-plugin",
+            vec![],
+            vec![keyvalue_interface(None)],
+        ));
+        let plugins = HashMap::from([(plugin.id(), plugin.clone() as Arc<dyn HostPlugin>)]);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![keyvalue_interface(Some("cache"))],
+        );
+
+        let bound = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .expect("one binding needs no routing");
+        assert_eq!(bound.len(), 1);
     }
 
     /// Same setup but plugin returns `supports_named_instances() == true` -> succeeds

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -522,6 +522,13 @@ impl ComponentHostPlugin {
             if !interfaces.contains(&called.wit.namespace, &called.wit.package, &iface_names) {
                 continue;
             }
+            // An entry naming its package alone matches every interface in it,
+            // this one included, so an item may be here without touching the
+            // interface at all. Only an item that does has anything to answer
+            // for below.
+            if !item.world().uses(&called.wit) {
+                continue;
+            }
             anyhow::ensure!(
                 item.world()
                     .exports

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -221,24 +221,91 @@ impl<'a> WitInterfaces<'a> {
         self.inner.iter()
     }
 
-    /// Returns the [`crate::wit::WitInterface`] that matches the given namespace, package, and set of interfaces, if one exists.
+    /// Every entry matching the given namespace, package, and set of
+    /// interfaces, ordered by [`entry_order`].
+    ///
+    /// A workload may declare one package across several entries, and all of
+    /// them were matched to this plugin. What a plugin leaves unread here is
+    /// config a workload declared and no component ever sees, so a plugin
+    /// serving one instance folds the whole set rather than picking from it.
+    pub fn matching(
+        &self,
+        namespace: &str,
+        package: &str,
+        interfaces: &[&str],
+    ) -> Vec<&'a crate::wit::WitInterface> {
+        let mut matched: Vec<&crate::wit::WitInterface> = self
+            .inner
+            .iter()
+            .filter(|interface| entry_matches(interface, namespace, package, interfaces))
+            .collect();
+        matched.sort_by_cached_key(|interface| entry_order(interface));
+        matched
+    }
+
+    /// The first entry matching the given namespace, package, and set of
+    /// interfaces — the unnamed entry, a package's default route, when there is
+    /// one.
+    ///
+    /// For a plugin that reads a single entry; one that must see everything a
+    /// workload declared for its package wants [`Self::matching`].
     pub fn get(
         &self,
         namespace: &str,
         package: &str,
         interfaces: &[&str],
-    ) -> Option<&crate::wit::WitInterface> {
-        self.inner.iter().find(|interface| {
-            interface.namespace == namespace
-                && interface.package == package
-                && interfaces.iter().all(|i| interface.interfaces.contains(*i))
-        })
+    ) -> Option<&'a crate::wit::WitInterface> {
+        self.inner
+            .iter()
+            .filter(|interface| entry_matches(interface, namespace, package, interfaces))
+            .min_by_key(|interface| entry_order(interface))
     }
 
     /// Returns `true` if the given namespace, package, and set of interfaces are contained within this collection of [`crate::wit::WitInterface`]s.
     pub fn contains(&self, namespace: &str, package: &str, interfaces: &[&str]) -> bool {
-        self.get(namespace, package, interfaces).is_some()
+        self.inner
+            .iter()
+            .any(|interface| entry_matches(interface, namespace, package, interfaces))
     }
+}
+
+/// Whether one entry answers for `namespace:package` and covers `interfaces`.
+///
+/// An entry naming no interfaces covers its whole package, the rule
+/// [`crate::wit::WitWorld::uses`] matched it to the plugin under. Reading it
+/// more strictly here leaves the plugin bound and its interface unserved.
+fn entry_matches(
+    interface: &crate::wit::WitInterface,
+    namespace: &str,
+    package: &str,
+    interfaces: &[&str],
+) -> bool {
+    interface.namespace == namespace
+        && interface.package == package
+        && (interface.interfaces.is_empty()
+            || interfaces.iter().all(|i| interface.interfaces.contains(*i)))
+}
+
+/// Orders the entries of one package: the unnamed entry — a package's default
+/// route — first, then by name, instance, interfaces, and the keys each entry
+/// configures. Two entries alike in all of those carry the same resolved
+/// config, so their order between themselves does not change what a plugin
+/// reads.
+///
+/// Keys, never values: once bindings resolve, an entry's config carries
+/// whatever `secretFrom` produced.
+fn entry_order(interface: &crate::wit::WitInterface) -> (Option<&str>, String, String, String) {
+    let sorted = |mut items: Vec<&str>| {
+        items.sort_unstable();
+        items.join(",")
+    };
+    (
+        // `None` sorts before `Some`, putting the unnamed entry first.
+        interface.name.as_deref(),
+        interface.instance(),
+        sorted(interface.interfaces.iter().map(String::as_str).collect()),
+        sorted(interface.config.keys().map(String::as_str).collect()),
+    )
 }
 
 /// A workload a plugin has failed out of band (after it was already running),

--- a/crates/wash-runtime/src/plugin/wasi_config/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config/mod.rs
@@ -18,7 +18,7 @@
 //! to retrieve configuration values that are set by the host environment.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     sync::Arc,
 };
 use tokio::sync::RwLock;
@@ -42,7 +42,15 @@ mod bindings {
 
 pub(crate) const WASI_CONFIG_ID: &str = "wasi-config";
 
-type ConfigMap = HashMap<Arc<str>, HashMap<String, String>>;
+/// One component's `wasi:config/store` view. Ordered, so `get-all` hands a
+/// guest the same sequence on every call and every start.
+type ComponentConfig = BTreeMap<String, String>;
+
+/// Every bound component's view, keyed by workload then by component, so a
+/// workload's configuration leaves with it — see
+/// [`HostPlugin::on_workload_unbind`], which has only a workload id to work
+/// from. Matches [`crate::plugin::wasmcloud_secrets`]'s shape.
+type ConfigMap = BTreeMap<Arc<str>, BTreeMap<Arc<str>, ComponentConfig>>;
 
 /// WASI configuration plugin that provides access to configuration data.
 ///
@@ -70,8 +78,8 @@ pub struct DynamicConfig {
     /// config entries without further plumbing.
     #[builder(default)]
     copy_environment: bool,
-    /// Per-component-id key-value store. Always starts empty; not part of
-    /// the builder surface.
+    /// Each bound component's view, by workload then component (see
+    /// [`ConfigMap`]). Always starts empty; not part of the builder surface.
     #[builder(skip)]
     config: Arc<RwLock<ConfigMap>>,
 }
@@ -86,7 +94,8 @@ impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
 
         let config_guard = plugin.config.read().await;
         config_guard
-            .get(&*self.component_id)
+            .get(&*self.workload_id)
+            .and_then(|components| components.get(&*self.component_id))
             .and_then(|map| map.get(&key).cloned())
             .map_or(Ok(Ok(None)), |v| Ok(Ok(Some(v))))
     }
@@ -99,7 +108,8 @@ impl<'a> bindings::wasi::config::store::Host for ActiveCtx<'a> {
 
         let config_guard = plugin.config.read().await;
         let entries = config_guard
-            .get(&*self.component_id)
+            .get(&*self.workload_id)
+            .and_then(|components| components.get(&*self.component_id))
             .map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
             .unwrap_or_default();
         Ok(Ok(entries))
@@ -123,15 +133,18 @@ impl HostPlugin for DynamicConfig {
         component_handle: &mut WorkloadItem<'a>,
         interfaces: WitInterfaces<'_>,
     ) -> anyhow::Result<()> {
-        // Find the "wasi:config/store" interface, if present
-        let Some(interface) = interfaces.get("wasi", "config", &["store"]) else {
+        // This plugin serves one store per component
+        // (`supports_named_instances` is false), so every `wasi:config` entry
+        // the workload declared feeds that one store.
+        let entries = interfaces.matching("wasi", "config", &["store"]);
+        if entries.is_empty() {
             // Log a warning if the requested interfaces are not wasi:config/store
             tracing::warn!(
                 "WasiConfig plugin requested for non-wasi:config/store interface(s): {:?}",
                 interfaces
             );
             return Ok(());
-        };
+        }
 
         // Add `wasi:config/store` to the workload's linker
         bindings::wasi::config::store::add_to_linker::<_, SharedCtx>(
@@ -139,11 +152,26 @@ impl HostPlugin for DynamicConfig {
             extract_active_ctx,
         )?;
 
-        // Per-component view, later wins on key conflicts: interface
-        // config, then `LocalResources.config`, then (with
+        // Per-component view, later wins on key conflicts: the workload's
+        // interface entries in order, then `LocalResources.config`, then (with
         // `copy_environment`) the environment.
         let component_config = {
-            let mut config_map = interface.config.clone();
+            let mut config_map = ComponentConfig::new();
+
+            for entry in entries {
+                for (key, value) in entry.config.iter() {
+                    if let Some(previous) = config_map.insert(key.clone(), value.clone())
+                        && &previous != value
+                    {
+                        tracing::warn!(
+                            key,
+                            component_id = component_handle.id(),
+                            "two wasi:config entries set the same key to different values; \
+                             the workload's entries are one store, so the later entry wins"
+                        );
+                    }
+                }
+            }
 
             for (key, value) in component_handle.local_resources().config.iter() {
                 config_map.insert(key.clone(), value.clone());
@@ -162,8 +190,288 @@ impl HostPlugin for DynamicConfig {
         self.config
             .write()
             .await
+            .entry(Arc::from(component_handle.workload_id()))
+            .or_default()
             .insert(Arc::from(component_handle.id()), component_config);
 
         Ok(())
+    }
+
+    async fn on_workload_unbind(
+        &self,
+        workload_id: &str,
+        _interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        // The engine calls this once per component bound to this plugin, each
+        // carrying the same workload id, and a workload's components stop
+        // together — so dropping them on the first call is correct and the rest
+        // are no-ops. Component ids are fresh per start, so without this a
+        // restart leaves the old ids behind for as long as the host runs,
+        // holding whatever `secretFrom` resolved into them.
+        let mut config = self.config.write().await;
+        let Some(components) = config.get_mut(workload_id) else {
+            return Ok(());
+        };
+        // A host component plugin's own bind-time config is filed under its
+        // plugin id as both ids (`component_host::link_native_imports`), and
+        // workload ids come from the caller. A workload that happens to carry a
+        // plugin's id stops without taking that plugin's config with it.
+        components.retain(|component_id, _| component_id.as_ref() == workload_id);
+        if components.is_empty() {
+            config.remove(workload_id);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{
+        InstancePolicy, workload::UnresolvedWorkload, workload::WorkloadComponent,
+    };
+    use crate::types::LocalResources;
+    use std::collections::HashMap;
+    use wasmtime::component::{Component, Linker};
+
+    fn config_importer(name: &str, config: &[(&str, &str)]) -> WorkloadComponent {
+        component_from_wat(
+            name,
+            r#"(component (import "wasi:config/store@0.2.0-rc.1" (instance)))"#,
+            config,
+        )
+    }
+
+    fn component_from_wat(name: &str, wat: &str, config: &[(&str, &str)]) -> WorkloadComponent {
+        let engine = wasmtime::Engine::default();
+        let linker = Linker::new(&engine);
+        let wasm = wat::parse_str(wat).expect("failed to parse WAT");
+        let component = Component::new(&engine, &wasm).expect("failed to compile");
+        let local_resources = LocalResources {
+            config: config
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            ..Default::default()
+        };
+        WorkloadComponent::new(
+            "workload-config",
+            "test-workload",
+            "test-namespace",
+            name,
+            component,
+            linker,
+            Vec::new(),
+            local_resources,
+            Arc::default(),
+            InstancePolicy::Ephemeral,
+        )
+    }
+
+    async fn bind(
+        components: Vec<WorkloadComponent>,
+        host_interfaces: Vec<WitInterface>,
+    ) -> (Arc<DynamicConfig>, anyhow::Result<()>) {
+        let plugin = Arc::new(DynamicConfig::default());
+        let plugins: std::collections::HashMap<&'static str, Arc<dyn HostPlugin>> =
+            std::collections::HashMap::from([(
+                plugin.id(),
+                Arc::clone(&plugin) as Arc<dyn HostPlugin>,
+            )]);
+        let mut workload = UnresolvedWorkload::new(
+            "workload-config",
+            "test-workload",
+            "test-namespace",
+            None,
+            components,
+            host_interfaces,
+        );
+        let res = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .map(|_| ());
+        (plugin, res)
+    }
+
+    const WORKLOAD: &str = "workload-config";
+
+    /// One component's view out of the workload it was bound under.
+    fn view<'a>(stored: &'a ConfigMap, component_id: &str) -> &'a ComponentConfig {
+        stored
+            .get(WORKLOAD)
+            .and_then(|components| components.get(component_id))
+            .unwrap_or_else(|| panic!("no config view for component {component_id}"))
+    }
+
+    fn shared(entry: &str) -> WitInterface {
+        let mut interface = WitInterface::from(entry);
+        interface.config = HashMap::from([("shared".to_string(), "yes".to_string())]);
+        interface
+    }
+
+    #[tokio::test]
+    async fn every_component_that_imports_wasi_config_gets_its_own_view() {
+        let a = config_importer("a", &[("own", "a")]);
+        let b = config_importer("b", &[("own", "b")]);
+        let a_id = a.id().to_string();
+        let b_id = b.id().to_string();
+
+        let (plugin, res) = bind(vec![a, b], vec![shared("wasi:config/store@0.2.0-rc.1")]).await;
+        res.expect("bind should succeed");
+
+        let stored = plugin.config.read().await;
+        for (id, own) in [(&a_id, "a"), (&b_id, "b")] {
+            let view = view(&stored, id);
+            assert_eq!(view.get("shared").map(String::as_str), Some("yes"));
+            assert_eq!(view.get("own").map(String::as_str), Some(own));
+        }
+    }
+
+    /// A workload may spread one binding over several entries, and they are one
+    /// store: every component reads all of them.
+    #[tokio::test]
+    async fn every_matching_entry_lands_in_one_view() {
+        let mut package_only = WitInterface::from("wasi:config");
+        package_only.config = HashMap::from([("extra".to_string(), "1".to_string())]);
+
+        // Repeated because the order under test comes from a `HashSet`: one
+        // run proves nothing.
+        for _ in 0..16 {
+            let a = config_importer("a", &[("own", "a")]);
+            let b = config_importer("b", &[("own", "b")]);
+            let a_id = a.id().to_string();
+            let b_id = b.id().to_string();
+
+            let (plugin, res) = bind(
+                vec![a, b],
+                vec![shared("wasi:config/store@0.2.0-rc.1"), package_only.clone()],
+            )
+            .await;
+            res.expect("bind should succeed");
+
+            let stored = plugin.config.read().await;
+            for (id, own) in [(&a_id, "a"), (&b_id, "b")] {
+                let view = view(&stored, id);
+                assert_eq!(view.get("shared").map(String::as_str), Some("yes"));
+                assert_eq!(view.get("extra").map(String::as_str), Some("1"));
+                assert_eq!(view.get("own").map(String::as_str), Some(own));
+            }
+        }
+    }
+
+    /// An entry naming the package alone covers every interface in it, the rule
+    /// it was matched to this plugin under, so it configures the component and
+    /// puts `wasi:config/store` in its linker.
+    #[tokio::test]
+    async fn a_package_only_entry_is_still_a_config_entry() {
+        let a = config_importer("a", &[("own", "a")]);
+        let a_id = a.id().to_string();
+
+        let (plugin, res) = bind(vec![a], vec![shared("wasi:config")]).await;
+        res.expect("bind should succeed");
+
+        let stored = plugin.config.read().await;
+        let view = view(&stored, &a_id);
+        assert_eq!(view.get("shared").map(String::as_str), Some("yes"));
+        assert_eq!(view.get("own").map(String::as_str), Some("a"));
+    }
+
+    /// A component that also imports a sibling's export is bound the same way:
+    /// intra-workload linking is a separate question from host config.
+    #[tokio::test]
+    async fn a_linked_component_gets_its_own_view() {
+        let a = component_from_wat(
+            "a",
+            r#"(component
+                 (import "wasi:config/store@0.2.0-rc.1" (instance))
+                 (import "test:probe/marker@0.1.0" (instance)))"#,
+            &[("own", "a")],
+        );
+        let b = component_from_wat(
+            "b",
+            r#"(component
+                 (import "wasi:config/store@0.2.0-rc.1" (instance))
+                 (instance $m)
+                 (export "test:probe/marker@0.1.0" (instance $m)))"#,
+            &[("own", "b")],
+        );
+        let a_id = a.id().to_string();
+        let b_id = b.id().to_string();
+
+        let (plugin, res) = bind(vec![a, b], vec![shared("wasi:config/store@0.2.0-rc.1")]).await;
+        res.expect("bind should succeed");
+
+        let stored = plugin.config.read().await;
+        for (id, own) in [(&a_id, "a"), (&b_id, "b")] {
+            assert_eq!(view(&stored, id).get("own").map(String::as_str), Some(own));
+        }
+    }
+
+    /// A workload's configuration leaves with the workload. Component ids are
+    /// fresh per start, so what a stopped workload leaves behind is never read
+    /// again — and it holds whatever `secretFrom` resolved into it.
+    #[tokio::test]
+    async fn unbinding_a_workload_drops_its_config() {
+        let a = config_importer("a", &[("own", "a")]);
+        let a_id = a.id().to_string();
+
+        let (plugin, res) = bind(vec![a], vec![shared("wasi:config/store@0.2.0-rc.1")]).await;
+        res.expect("bind should succeed");
+        {
+            let stored = plugin.config.read().await;
+            assert_eq!(
+                view(&stored, &a_id).get("own").map(String::as_str),
+                Some("a")
+            );
+        }
+
+        // Another workload's configuration is untouched by the unbind.
+        let empty = HashSet::new();
+        plugin
+            .on_workload_unbind("some-other-workload", WitInterfaces::new(&empty))
+            .await
+            .expect("unbinding an unrelated workload is a no-op");
+        assert!(plugin.config.read().await.contains_key(WORKLOAD));
+
+        plugin
+            .on_workload_unbind(WORKLOAD, WitInterfaces::new(&empty))
+            .await
+            .expect("unbind should succeed");
+        assert!(
+            plugin.config.read().await.is_empty(),
+            "the workload's config outlived it"
+        );
+    }
+
+    /// A host component plugin's own config is filed under its plugin id as
+    /// both the workload and the component id, and workload ids come from the
+    /// caller: a workload carrying that id stops without taking it away.
+    #[tokio::test]
+    async fn a_plugin_keeps_its_own_config_when_a_workload_shares_its_id() {
+        let plugin = DynamicConfig::default();
+        let id: Arc<str> = Arc::from("acme-kv");
+        {
+            let mut config = plugin.config.write().await;
+            let components = config.entry(Arc::clone(&id)).or_default();
+            components.insert(
+                Arc::clone(&id),
+                ComponentConfig::from([("who".to_string(), "the plugin".to_string())]),
+            );
+            components.insert(
+                Arc::from("a-workload-component"),
+                ComponentConfig::from([("who".to_string(), "the workload".to_string())]),
+            );
+        }
+
+        let empty = HashSet::new();
+        plugin
+            .on_workload_unbind(&id, WitInterfaces::new(&empty))
+            .await
+            .expect("unbind should succeed");
+
+        let config = plugin.config.read().await;
+        let components = config.get(&id).expect("the plugin's own config survives");
+        assert!(components.contains_key(&id));
+        assert!(!components.contains_key("a-workload-component"));
     }
 }

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -46,9 +46,49 @@ impl WitWorld {
             || self.exports.iter().any(|e| e.contains(interface))
     }
 
+    /// Whether this world imports or exports anything of `interface`'s package
+    /// at a compatible version.
+    fn mentions_package(&self, interface: &WitInterface) -> bool {
+        self.imports.iter().any(|im| interface.same_package(im))
+            || self.exports.iter().any(|ex| interface.same_package(ex))
+    }
+
+    /// Whether this world *uses* `interface` — imports or exports at least one
+    /// of the interfaces the entry names.
+    ///
+    /// The question a workload item asks of a host interface entry. One entry
+    /// is shared by every item, and a manifest may give a package only one
+    /// unnamed entry, so an entry names what the workload *collectively* uses
+    /// and an item that uses a subset of it still needs the plugin serving it.
+    ///
+    /// The provider side asks [`WitWorld::includes_bidirectional`] instead: a
+    /// plugin that serves part of an entry must not claim it, or the rest is
+    /// left bound by nobody.
+    pub fn uses(&self, interface: &WitInterface) -> bool {
+        // An entry naming no interface stands for its whole package, so a world
+        // uses it by using the package at all — never by saying nothing about
+        // it, which would make such an entry everyone's.
+        if interface.interfaces.is_empty() {
+            return self.mentions_package(interface);
+        }
+        interface.interfaces.iter().any(|i| {
+            self.imports
+                .iter()
+                .any(|im| interface.same_package(im) && im.interfaces.contains(i))
+                || self
+                    .exports
+                    .iter()
+                    .any(|ex| interface.same_package(ex) && ex.interfaces.contains(i))
+        })
+    }
+
     /// This function checks if the world includes a specific interface. This is
     /// different than [`WitWorld::includes`] because it considers that in one
     /// [`WitInterface`] there may be both imports and exports.
+    ///
+    /// Every interface the entry names has to be covered. Asked of a plugin's
+    /// world, that is "can this plugin serve the whole entry"; asked of a
+    /// workload item's world it is too strict — see [`WitWorld::uses`].
     pub fn includes_bidirectional(&self, interface: &WitInterface) -> bool {
         // Each requested interface must be covered by *some* import or export of
         // the same package (see [`WitInterface::same_package`]). The label/name
@@ -58,6 +98,13 @@ impl WitWorld {
         // multiple entries (e.g. `wasmcloud:postgres` imports `types` unnamed and
         // `query` under several labels), so check every entry per interface
         // rather than binding to the first package match.
+        //
+        // An entry naming no interface still has to be a package this world
+        // knows: covering everything vacuously would match every plugin, and
+        // the first by id would claim a package it does not serve.
+        if interface.interfaces.is_empty() {
+            return self.mentions_package(interface);
+        }
         interface.interfaces.iter().all(|i| {
             self.imports
                 .iter()
@@ -976,5 +1023,44 @@ mod tests {
         let prepared =
             create_interface_with_version("wasmcloud", "postgres", &["prepared"], "0.1.1");
         assert!(!world.includes_bidirectional(&prepared));
+    }
+
+    /// A host entry names what a whole workload uses, so a component using one
+    /// of its interfaces uses the entry — while a plugin has to serve all of
+    /// them to claim it.
+    #[test]
+    fn uses_asks_for_any_interface_and_includes_asks_for_all() {
+        let component = WitWorld {
+            imports: HashSet::from([create_interface("wasi", "keyvalue", &["store"])]),
+            exports: HashSet::new(),
+        };
+        let entry = create_interface("wasi", "keyvalue", &["store", "atomics"]);
+
+        assert!(
+            component.uses(&entry),
+            "the component imports one of the entry's interfaces"
+        );
+        assert!(
+            !component.includes_bidirectional(&entry),
+            "it does not cover the whole entry, which is what a provider must do"
+        );
+
+        // A package the world never mentions is neither used nor covered.
+        let unrelated = create_interface("wasi", "blobstore", &["blobstore"]);
+        assert!(!component.uses(&unrelated));
+        assert!(!component.includes_bidirectional(&unrelated));
+
+        // An entry naming no interface stands for its whole package.
+        let package_only = create_interface("wasi", "keyvalue", &[]);
+        assert!(component.uses(&package_only));
+
+        // It is still that package's, not everyone's: a world saying nothing
+        // about it neither uses nor covers it. Otherwise such an entry matches
+        // every world it is offered to — every plugin included, where the first
+        // by id would claim a package it does not serve.
+        let elsewhere = create_interface("wasi", "blobstore", &[]);
+        assert!(!component.uses(&elsewhere));
+        assert!(!component.includes_bidirectional(&elsewhere));
+        assert!(component.includes_bidirectional(&package_only));
     }
 }

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -93,6 +93,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "config-callee"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
+name = "config-caller"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "cpu-usage-service"
 version = "0.1.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "inter-component-call-caller",
     "inter-component-call-callee",
     "inter-component-call-middleware",
+    "config-caller",
+    "config-callee",
     "http-allowed-hosts",
     "http-egress-pool",
     "http-ip-name-lookup",

--- a/crates/wash-runtime/tests/fixtures/config-callee/.gitignore
+++ b/crates/wash-runtime/tests/fixtures/config-callee/.gitignore
@@ -1,0 +1,2 @@
+# Rust build artifacts
+target/

--- a/crates/wash-runtime/tests/fixtures/config-callee/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/config-callee/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip2 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip2 --release
+  component_path: ../target/wasm32-wasip2/release/config_callee.wasm

--- a/crates/wash-runtime/tests/fixtures/config-callee/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/config-callee/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "config-callee"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/config-callee/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/config-callee/src/lib.rs
@@ -1,0 +1,29 @@
+mod bindings {
+    wit_bindgen::generate!({
+        world: "component",
+        generate_all
+    });
+}
+
+use bindings::exports::wasmcloud::example::reader::Guest;
+use bindings::wasi::config::store;
+
+struct Component;
+
+impl Guest for Component {
+    fn read() -> String {
+        match store::get_all() {
+            Ok(mut entries) => {
+                entries.sort();
+                entries
+                    .into_iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<_>>()
+                    .join(";")
+            }
+            Err(e) => format!("error:{e:?}"),
+        }
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/config-callee/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/config-callee/wit/world.wit
@@ -1,0 +1,12 @@
+package wasmcloud:example@0.0.1;
+
+interface reader {
+    /// This component's own `wasi:config/store` view, rendered as a sorted
+    /// `key=value;key=value` string.
+    read: func() -> string;
+}
+
+world component {
+    import wasi:config/store@0.2.0-rc.1;
+    export reader;
+}

--- a/crates/wash-runtime/tests/fixtures/config-callee/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/config-callee/wkg.toml
@@ -1,0 +1,6 @@
+[overrides]
+"wasi:cli" = { path = "../p2-wit-deps/wasi-cli-0.2.2" }
+"wasi:clocks" = { path = "../p2-wit-deps/wasi-clocks-0.2.2" }
+"wasi:config" = { path = "../p2-wit-deps/wasi-config-0.2.0-rc.1" }
+"wasi:io" = { path = "../p2-wit-deps/wasi-io-0.2.2" }
+"wasi:random" = { path = "../p2-wit-deps/wasi-random-0.2.2" }

--- a/crates/wash-runtime/tests/fixtures/config-caller/.gitignore
+++ b/crates/wash-runtime/tests/fixtures/config-caller/.gitignore
@@ -1,0 +1,2 @@
+# Rust build artifacts
+target/

--- a/crates/wash-runtime/tests/fixtures/config-caller/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/config-caller/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip2 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip2 --release
+  component_path: ../target/wasm32-wasip2/release/config_caller.wasm

--- a/crates/wash-runtime/tests/fixtures/config-caller/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/config-caller/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "config-caller"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }

--- a/crates/wash-runtime/tests/fixtures/config-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/config-caller/src/lib.rs
@@ -1,0 +1,49 @@
+mod bindings {
+    wit_bindgen::generate!({
+        world: "component",
+        generate_all
+    });
+}
+
+use bindings::{
+    exports::wasi::http::incoming_handler::Guest,
+    wasi::config::store,
+    wasi::http::types::{
+        Fields, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+    },
+    wasmcloud::example::reader,
+};
+
+struct Component;
+
+fn own_config() -> String {
+    match store::get_all() {
+        Ok(mut entries) => {
+            entries.sort();
+            entries
+                .into_iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(";")
+        }
+        Err(e) => format!("error:{e:?}"),
+    }
+}
+
+impl Guest for Component {
+    fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
+        let payload = format!("caller[{}] callee[{}]", own_config(), reader::read());
+
+        let response = OutgoingResponse::new(Fields::new());
+        response.set_status_code(200).unwrap();
+        let body = response.body().unwrap();
+        ResponseOutparam::set(response_out, Ok(response));
+
+        let stream = body.write().unwrap();
+        stream.blocking_write_and_flush(payload.as_bytes()).unwrap();
+        drop(stream);
+        OutgoingBody::finish(body, None).unwrap();
+    }
+}
+
+bindings::export!(Component with_types_in bindings);

--- a/crates/wash-runtime/tests/fixtures/config-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/config-caller/wit/world.wit
@@ -1,0 +1,13 @@
+package wasmcloud:example@0.0.1;
+
+interface reader {
+    /// This component's own `wasi:config/store` view, rendered as a sorted
+    /// `key=value;key=value` string.
+    read: func() -> string;
+}
+
+world component {
+    import wasi:config/store@0.2.0-rc.1;
+    import reader;
+    export wasi:http/incoming-handler@0.2.2;
+}

--- a/crates/wash-runtime/tests/fixtures/config-caller/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/config-caller/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p2-wit-deps/wasi-cli-0.2.2" }
+"wasi:clocks" = { path = "../p2-wit-deps/wasi-clocks-0.2.2" }
+"wasi:config" = { path = "../p2-wit-deps/wasi-config-0.2.0-rc.1" }
+"wasi:http" = { path = "../p2-wit-deps/wasi-http-0.2.2" }
+"wasi:io" = { path = "../p2-wit-deps/wasi-io-0.2.2" }
+"wasi:random" = { path = "../p2-wit-deps/wasi-random-0.2.2" }

--- a/crates/wash-runtime/tests/integration_multi_component_config.rs
+++ b/crates/wash-runtime/tests/integration_multi_component_config.rs
@@ -1,0 +1,242 @@
+//! A workload with several components that each import `wasi:config/store`.
+//!
+//! Every component of a workload reads the same workload-scoped interface
+//! config layered with its own `LocalResources.config`, so a two-component
+//! workload has to deliver two different views. The caller reports its own
+//! view and the linked callee's in one response, which is what makes a
+//! component reading someone else's config (or nothing at all) visible.
+
+use anyhow::{Context, Result};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+use wash_runtime::{
+    engine::Engine,
+    host::{
+        HostApi, HostBuilder,
+        http::{DevRouter, Ingress},
+    },
+    plugin::wasi_config::DynamicConfig,
+    types::{Component, LocalResources, Workload, WorkloadStartRequest},
+    wit::WitInterface,
+};
+
+const CALLER_WASM: &[u8] = include_bytes!("wasm/config_caller.wasm");
+const CALLEE_WASM: &[u8] = include_bytes!("wasm/config_callee.wasm");
+
+/// Each component's own `LocalResources.config` (`who`) over the shared
+/// workload-scoped entry.
+const EXPECTED: &str = "caller[shared=yes;who=caller] callee[shared=yes;who=callee]";
+
+fn config(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+/// A component carrying its own `LocalResources.config`. `warm` parks its
+/// instances in a pool between calls instead of building a store per request.
+fn component(name: &str, bytes: &'static [u8], own: &[(&str, &str)], warm: bool) -> Component {
+    let (pool_size, max_invocations) = if warm { (2, 10_000) } else { (-1, -1) };
+    Component {
+        name: name.to_string(),
+        digest: None,
+        bytes: bytes::Bytes::from_static(bytes),
+        local_resources: LocalResources {
+            config: config(own),
+            ..Default::default()
+        },
+        pool_size,
+        max_invocations,
+        ..Default::default()
+    }
+}
+
+/// Runs the two-component workload with `host_interfaces` and returns the
+/// caller's response body.
+async fn run(host_interfaces: Vec<WitInterface>) -> Result<String> {
+    run_with(host_interfaces, false, 1)
+        .await
+        .map(|mut bodies| bodies.remove(0))
+}
+
+/// Runs the workload and issues `requests` concurrent requests.
+async fn run_with(
+    host_interfaces: Vec<WitInterface>,
+    warm: bool,
+    requests: usize,
+) -> Result<Vec<String>> {
+    let engine = Engine::builder().build()?;
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = ingress.addr();
+
+    let host = HostBuilder::new()
+        .with_engine(engine)
+        .with_http_handler(Arc::new(ingress))
+        .with_plugin(Arc::new(DynamicConfig::default()))?
+        .build()?
+        .start()
+        .await
+        .context("failed to start host")?;
+
+    let started = host
+        .workload_start(WorkloadStartRequest {
+            workload_id: uuid::Uuid::new_v4().to_string(),
+            workload: Workload {
+                namespace: "test".to_string(),
+                name: "multi-config".to_string(),
+                annotations: HashMap::new(),
+                service: None,
+                components: vec![
+                    component("caller", CALLER_WASM, &[("who", "caller")], warm),
+                    component("callee", CALLEE_WASM, &[("who", "callee")], warm),
+                ],
+                host_interfaces,
+                volumes: vec![],
+            },
+        })
+        .await
+        .context("failed to start workload")?;
+    anyhow::ensure!(
+        started.workload_status.message.contains("started"),
+        "workload did not start: {:?}",
+        started.workload_status
+    );
+
+    let client = reqwest::Client::new();
+    let mut tasks = Vec::with_capacity(requests);
+    for _ in 0..requests {
+        let client = client.clone();
+        let url = format!("http://{addr}/");
+        tasks.push(tokio::spawn(async move {
+            let response = timeout(
+                Duration::from_secs(30),
+                client.get(url).header("HOST", "test").send(),
+            )
+            .await
+            .context("request timed out")?
+            .context("request failed")?;
+            let status = response.status();
+            let body = response.text().await.context("failed to read body")?;
+            anyhow::ensure!(status.is_success(), "request failed: {status} — {body}");
+            Ok::<_, anyhow::Error>(body)
+        }));
+    }
+
+    let mut bodies = Vec::with_capacity(requests);
+    for task in tasks {
+        bodies.push(task.await.context("request task panicked")??);
+    }
+    Ok(bodies)
+}
+
+fn http_interface() -> WitInterface {
+    WitInterface {
+        namespace: "wasi".to_string(),
+        package: "http".to_string(),
+        interfaces: ["incoming-handler".to_string()].into_iter().collect(),
+        version: None,
+        config: config(&[("host", "test")]),
+        name: None,
+    }
+}
+
+/// Both components read the same workload-scoped `wasi:config` entry, each
+/// layered with its own `LocalResources.config`.
+#[tokio::test]
+async fn each_component_reads_its_own_config() -> Result<()> {
+    let mut wasi_config = WitInterface::from("wasi:config/store@0.2.0-rc.1");
+    wasi_config.config = config(&[("shared", "yes")]);
+
+    let body = run(vec![http_interface(), wasi_config]).await?;
+    assert_eq!(body, EXPECTED);
+    Ok(())
+}
+
+/// The same workload with the `wasi:config` entry written as the package
+/// alone — the form a manifest takes when it declares config without naming
+/// the interface.
+#[tokio::test]
+async fn a_package_only_entry_still_delivers_config() -> Result<()> {
+    let mut wasi_config = WitInterface::from("wasi:config");
+    wasi_config.config = config(&[("shared", "yes")]);
+
+    let body = run(vec![http_interface(), wasi_config]).await?;
+    assert_eq!(body, EXPECTED);
+    Ok(())
+}
+
+/// A versionless entry, as a hand-written manifest tends to spell it.
+#[tokio::test]
+async fn a_versionless_entry_delivers_config() -> Result<()> {
+    let mut wasi_config = WitInterface::from("wasi:config/store");
+    wasi_config.config = config(&[("shared", "yes")]);
+
+    let body = run(vec![http_interface(), wasi_config]).await?;
+    assert_eq!(body, EXPECTED);
+    Ok(())
+}
+
+/// A workload that spreads one binding across two entries: both components read
+/// one store holding both entries' keys, on every start.
+#[tokio::test]
+async fn config_spread_across_entries_reaches_every_component() -> Result<()> {
+    let mut versioned = WitInterface::from("wasi:config/store@0.2.0-rc.1");
+    versioned.config = config(&[("shared", "yes")]);
+    let mut package_only = WitInterface::from("wasi:config");
+    package_only.config = config(&[("extra", "1")]);
+
+    // Repeated because the order under test comes from a `HashSet`: one run
+    // proves nothing.
+    for _ in 0..8 {
+        let body = run(vec![
+            http_interface(),
+            versioned.clone(),
+            package_only.clone(),
+        ])
+        .await?;
+        assert_eq!(
+            body,
+            "caller[extra=1;shared=yes;who=caller] callee[extra=1;shared=yes;who=callee]"
+        );
+    }
+    Ok(())
+}
+
+/// A name asks for one backend of a package. `wasi:config` serves a single
+/// store, so a named entry beside the unnamed one is refused rather than
+/// delivering one of the two under both names.
+#[tokio::test]
+async fn a_named_entry_beside_an_unnamed_one_is_refused() -> Result<()> {
+    let mut unnamed = WitInterface::from("wasi:config/store@0.2.0-rc.1");
+    unnamed.config = config(&[("shared", "yes")]);
+    let mut named = WitInterface::from("wasi:config/store@0.2.0-rc.1");
+    named.name = Some("extra".to_string());
+    named.config = config(&[("other", "no")]);
+
+    let err = match run(vec![http_interface(), unnamed, named]).await {
+        Ok(body) => panic!("two bindings cannot share one store, got: {body}"),
+        Err(e) => format!("{e:#}"),
+    };
+    assert!(
+        err.contains("does not support named instances") && err.contains("extra"),
+        "the refusal must name the binding that has nowhere to go, got: {err}"
+    );
+    Ok(())
+}
+
+/// Concurrent requests over warm, pooled instances keep each component's view
+/// its own: the caller and the callee it links to share one store.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_requests_keep_each_view_its_own() -> Result<()> {
+    let mut wasi_config = WitInterface::from("wasi:config/store@0.2.0-rc.1");
+    wasi_config.config = config(&[("shared", "yes")]);
+
+    let bodies = run_with(vec![http_interface(), wasi_config], true, 100).await?;
+    assert_eq!(bodies.len(), 100);
+    for body in bodies {
+        assert_eq!(body, EXPECTED);
+    }
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -94,6 +94,8 @@ const P2_FIXTURES: &[&str] = &[
     "inter-component-call-caller",
     "inter-component-call-callee",
     "inter-component-call-middleware",
+    "config-caller",
+    "config-callee",
     "http-allowed-hosts",
     "http-egress-pool",
     "http-ip-name-lookup",


### PR DESCRIPTION
A workload with several components that use `wasi:config` could give each component a different configuration, and a different one on every start.

## What was happening

`WitInterfaces::get` was `HashSet::iter().find(..)` an arbitrary pick and `DynamicConfig` read only that one entry's `config`. `on_workload_item_bind` runs once per component, so each component drew its own coin flip. Reproduced end to end against the old code, same workload, consecutive runs:

```
caller[shared=yes;who=caller] callee[other=no;who=callee]   <- callee lost `shared`
caller[other=no;who=caller]   callee[other=no;who=callee]
caller[shared=yes;who=caller] callee[shared=yes;who=callee]
```

## What changed

- **`WitInterfaces::matching`** returns every entry of a package in a stable order; `get`/`contains` share one predicate instead of picking arbitrarily. `DynamicConfig` folds every entry it is handed into the single store it serves, and treats a package-only entry as the entry it was matched as.
- **`WitWorld::uses`** is the item-side question: does this component or service import or export *any* interface the entry names. The provider side keeps `includes_bidirectional` (all of them), because a plugin serving part of an entry must not claim the rest. `served_within_workload` judges an item on the entry interfaces it imports, while an item that *exports* one of them keeps the entry so the host can reach that export.
- **`bind_plugins` refuses more than one binding per `namespace:package`** for plugin that serves a single instance. Each name routes to its own backend, and collapsing two into one instance delivers one binding's configuration under both names. A lone name still binds: it selects the operator's declaration and reaches a host component plugin's lifecycle hook. This replaces the previous "more than one *named* entry" rule, which let the named-plus-unnamed case through to be resolved by hash order.
- **`DynamicConfig` keys its views by workload** and drops them on `on_workload_unbind`. Component ids are fresh per start, so a restart used to leave the old ids behind for the life of the host.

A workload that declares both a named and an unnamed entry of one package for a single-instance plugin is now refused at deploy, naming the binding that has nowhere to go. Previously it deployed and served one of the two arbitrarily.

## Follow-ups, not in this PR

`wash dev`'s `build_workload_host_interfaces` merges on `namespace:package` alone, so `wasmcloud:messaging@0.2.0` and `@0.3.0` collapse into one entry at `0.2.0` naming both interfaces, and the 0.3.0 component then fails `same_package`. Fixing it means emitting two unnamed entries for one package, which the CRD's admission rule rejects today see #5467.
