### PR TITLE
fix(wash-runtime): wasmtime feature declaration

### DIFF
--- a/.github/scripts/wasmtime-features.mjs
+++ b/.github/scripts/wasmtime-features.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Holds the host's wasmtime feature set to what wash-runtime declares, on
+// every target we ship a binary for.
+//
+// Cargo features are additive and unify across the whole graph, so a
+// dependency that takes `wasmtime` with default features turns those defaults
+// on for everyone. `wasi-webgpu-wasmtime` does exactly that — and it is
+// target-gated off Windows and s390x (wgpu-hal does not build there), so any
+// feature only it supplies is present in six release binaries and missing from
+// two. That is invisible in a normal build: the host still compiles and runs,
+// it just compiles Wasm on one thread, or picks the null garbage collector
+// that never reclaims, on the two targets nobody builds locally.
+//
+// Two invariants, both cheap — `cargo tree` resolves without compiling:
+//
+//   1. Everything in REQUIRED is declared by wash-runtime itself, not
+//      inherited. This is what stops a dependency from owning our feature set:
+//      if webgpu is the only reason a feature is on, this fails.
+//   2. Everything in REQUIRED actually resolves on every release target. This
+//      catches target-gating and any other resolution surprise.
+//
+// Features a target picks up beyond REQUIRED are reported, not failed —
+// webgpu legitimately adds a dozen on the targets it builds for.
+//
+// Adding a feature to the manifest means adding it here with its reason.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const MANIFEST = 'crates/wash-runtime/Cargo.toml';
+// The release matrix is the authority on what we ship; reading it back means a
+// new target is covered here the moment it is added there.
+const WORKFLOW = '.github/workflows/wash.yml';
+// The package whose resolved graph decides what a released binary contains.
+const PACKAGE = 'wash';
+
+// Why each one is load-bearing. A reader who wants to drop one should have to
+// argue with the reason first.
+const REQUIRED = new Map([
+  ['addr2line', 'turns a trapping address back into guest source file and line'],
+  ['anyhow', 'wasmtime errors interoperate with the host error type'],
+  ['backtrace', 'host Rust backtrace on a wasmtime::Error'],
+  ['component-model', 'the host runs components, not core modules'],
+  ['component-model-async', "WASIP3's async ABI"],
+  ['cranelift', 'components are compiled on the host, not loaded precompiled'],
+  ['demangle', 'readable symbol names in trap frames'],
+  ['gc', 'wasm_gc is on by default in wasmtime, so guests can use GC types'],
+  ['gc-copying', 'the collector Collector::Auto resolves to first'],
+  ['gc-drc', 'the collector Auto falls back to; without both, Auto reaches gc-null, which collects nothing'],
+  ['gc-null', 'keeps the no-op collector explicitly selectable'],
+  ['parallel-compilation', 'Cranelift compiles a component across rayon’s pool'],
+  ['pooling-allocator', 'the engine installs a PoolingAllocationConfig'],
+  ['threads', 'shared memories'],
+]);
+
+// The `features = [...]` array on wash-runtime's own `wasmtime` dependency.
+function declaredFeatures() {
+  const manifest = readFileSync(MANIFEST, 'utf8');
+  const dep = manifest.match(/^wasmtime = \{[^}]*\}/m);
+  if (!dep) {
+    console.error(`could not find the \`wasmtime\` dependency line in ${MANIFEST}`);
+    process.exit(1);
+  }
+  const features = dep[0].match(/features = \[([^\]]*)\]/);
+  if (!features) {
+    console.error(`the \`wasmtime\` dependency in ${MANIFEST} declares no feature list`);
+    process.exit(1);
+  }
+  return new Set([...features[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+function releaseTargets() {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const targets = [...workflow.matchAll(/^\s+- target: (\S+)$/gm)].map((m) => m[1]);
+  if (targets.length === 0) {
+    console.error(`found no \`- target:\` entries in ${WORKFLOW}`);
+    process.exit(1);
+  }
+  return [...new Set(targets)];
+}
+
+// `-i wasmtime` inverts the tree onto wasmtime, so every enabled feature of it
+// appears as its own node. `--prefix none` drops the tree drawing, leaving one
+// `wasmtime feature "x"` per line (repeated once per enabling edge).
+function resolvedFeatures(target) {
+  const out = execFileSync(
+    'cargo',
+    ['tree', '--target', target, '-p', PACKAGE, '-e', 'features', '-i', 'wasmtime', '--prefix', 'none'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return new Set([...out.matchAll(/^wasmtime feature "([^"]+)"$/gm)].map((m) => m[1]));
+}
+
+let failed = false;
+
+const declared = declaredFeatures();
+const undeclared = [...REQUIRED.keys()].filter((f) => !declared.has(f));
+if (undeclared.length > 0) {
+  failed = true;
+  console.error(
+    `::error::${MANIFEST} does not declare ${undeclared.join(', ')} on its \`wasmtime\` ` +
+      `dependency. A transitive dependency may be supplying it today, which means the ` +
+      `targets that dependency is gated off silently lose it. Declare it here.`,
+  );
+}
+for (const feature of declared) {
+  if (!REQUIRED.has(feature)) {
+    console.log(`${MANIFEST} declares "${feature}", which this check does not know about`);
+  }
+}
+
+for (const target of releaseTargets()) {
+  const resolved = resolvedFeatures(target);
+  const missing = [...REQUIRED.keys()].filter((f) => !resolved.has(f));
+  if (missing.length > 0) {
+    failed = true;
+    for (const feature of missing) {
+      console.error(
+        `::error::${target} resolves without wasmtime's "${feature}" feature — ${REQUIRED.get(feature)}`,
+      );
+    }
+  } else {
+    const extra = [...resolved].filter((f) => !REQUIRED.has(f)).sort();
+    console.log(`${target}: all ${REQUIRED.size} required present${extra.length > 0 ? `, plus ${extra.join(', ')}` : ''}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -55,6 +55,7 @@ jobs:
             relevant:
               - '.github/workflows/wash.yml'
               - '.github/tool-versions.env'
+              - '.github/scripts/wasmtime-features.mjs'
               - 'crates/**'
               - 'src/**'
               - 'tests/**'
@@ -201,6 +202,12 @@ jobs:
       - name: Check for unused dependencies
         run: |
           cargo machete
+      # Resolves only, no compiling, so it belongs with the other cheap checks
+      # rather than in a build job. It reads the release matrix below for the
+      # targets it covers.
+      - name: Check wasmtime feature set across release targets
+        run: |
+          node .github/scripts/wasmtime-features.mjs
 
   # Build the shipped wash runtime image (DEFAULT features) on arm64 — the
   # primary arch for the e2e gate and one leg of the canary multi-arch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,12 +681,12 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
- "cap-primitives 4.0.2",
- "cap-std 4.0.2",
+ "cap-primitives 4.0.3",
+ "cap-std 4.0.3",
  "io-lifetimes 3.0.1",
  "windows-sys 0.61.2",
 ]
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -753,11 +753,11 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
- "cap-primitives 4.0.2",
+ "cap-primitives 4.0.3",
  "io-extras 0.19.0",
  "io-lifetimes 3.0.1",
  "rustix",
@@ -1054,27 +1054,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1137,24 +1137,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1177,15 +1177,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc32fast"
@@ -4161,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4173,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6676,9 +6676,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -6730,9 +6730,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -6761,9 +6761,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "ede02ba77442cab88a2ddd5d16373e8bc450b55e05de8be039b024987a53d5a7"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -6781,9 +6781,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
+checksum = "c5bba4eff4804620bae04d7793308d97a0c5a8a97ea19e635452518f84560f84"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6796,15 +6796,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -6814,9 +6814,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6841,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if",
@@ -6856,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
  "object",
@@ -6868,9 +6868,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6880,9 +6880,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6893,9 +6893,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6904,9 +6904,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
+checksum = "bfdbdd9d6fab1ecb67a7dc189e32c9e341444945fb709437bf8aab25d9a88459"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6917,15 +6917,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
+checksum = "b373095a6dc8382da56882ad16d7ea16771dd6927dd480b1ce3fe7c4b816d2cf"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
- "cap-std 4.0.2",
+ "cap-std 4.0.3",
  "cfg-if",
  "futures",
  "io-lifetimes 3.0.1",
@@ -6943,9 +6943,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a499879061ee9f724342d5f5009754b723ae53c7932161ee063a9fe19395e915"
+checksum = "372fc7845f26cd8f69bcbf6e4234fcc032f718480c7722fa20a28eb74d58998e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6967,9 +6967,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
+checksum = "51b3c9b39b1a1b3029f80e614623e182f165133dfaca8610f156450343f080a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6980,9 +6980,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93457dcdadaf414b1c7319846c70c70617d88bbf1dbc62b680de1d32f9aa1da"
+checksum = "631b9fb7b7c7be669dc90b62114b0af5d7d0f6d788a2ebaa5b1c1a42b9443ec7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -7234,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
+checksum = "8c08bd1d66a10c7d4deaeb746cb1c5b5c62fb631907f18dfe058ecba71c99002"
 dependencies = [
  "bitflags",
  "thiserror 2.0.19",
@@ -7248,9 +7248,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
+checksum = "19eb81a4ceda41cc6fa2adc8e865473fc2e85630149ed7f5d95356b0010f0ed3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7262,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "47.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
+checksum = "c0e0d7c6d28846ffa438e421976734a2057f13a7e20af9f2a8607a6714e1e358"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,11 +126,11 @@ wasm-pkg-client = { version = "0.16.1", default-features = false }
 wasm-pkg-core = { version = "0.16.1", default-features = false }
 wasm-metadata = { version = "0.254.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
-wasmtime = { version = "47.0.3", default-features = false }
-wasmtime-wasi = { version = "47.0.3", default-features = false }
-wasmtime-wasi-io = { version = "47.0.3", default-features = false }
-wasmtime-wasi-http = { version = "47.0.3", default-features = false }
-wasmtime-wasi-tls = { version = "47.0.3", default-features = false }
+wasmtime = { version = "47.0.4", default-features = false }
+wasmtime-wasi = { version = "47.0.4", default-features = false }
+wasmtime-wasi-io = { version = "47.0.4", default-features = false }
+wasmtime-wasi-http = { version = "47.0.4", default-features = false }
+wasmtime-wasi-tls = { version = "47.0.4", default-features = false }
 wit-component = { version = "0.254.0", default-features = false }
 wash-runtime = { path = "crates/wash-runtime", default-features = false }
 wat = { version = "1.254.0", default-features = false }

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -372,13 +372,16 @@ runtime:
     # by overriding `WASH_HOST_MAX_GUEST_MEMORY` below it via `runtime.env`.
     guestMemoryMode: ""
     # -- How many workloads a host pulls and compiles at once. Each start it
-    # admits ends in a single-threaded compile, so this is how many cores a
-    # burst of starts takes from the ones serving HTTP and NATS — a host that
-    # stops accepting connections for long enough fails its liveness probe and
-    # is restarted, taking every workload on it with it. Set it to `1` on a
-    # host that must keep serving through a large redeploy, bearing in mind
-    # that the same permit covers the image pull, so a lower number serializes
-    # network waiting along with the compiling.
+    # admits ends in a compile that spreads over every core the host can see,
+    # so this is a floor on what a burst of starts takes from the cores serving
+    # HTTP and NATS, not a ceiling — a host that stops accepting connections
+    # for long enough fails its liveness probe and is restarted, taking every
+    # workload on it with it. Set it to `1` on a host that must keep serving
+    # through a large redeploy, bearing in mind that the same permit covers the
+    # image pull, so a lower number serializes network waiting along with the
+    # compiling. To bound the compiles themselves, set `RAYON_NUM_THREADS` (how
+    # wide one compile goes) or `WASMTIME_PARALLEL_COMPILATION=false` (one
+    # thread per compile) under `runtime.env`.
     #
     # Empty leaves the host to size itself: one fewer than the cores it can
     # see, at most 4. Note what it sees — the count comes from the cgroup, so

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -88,7 +88,12 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "macros"] }
 tracing = { workspace = true }
 zeroize = { workspace = true }
-wasmtime = { workspace = true, features = ["anyhow", "component-model", "component-model-async", "cranelift", "pooling-allocator", "gc", "gc-null", "threads"] }
+# Every wasmtime feature this host relies on is named here rather than left to
+# a transitive dependency's defaults. `wasi-webgpu-wasmtime` takes `wasmtime`
+# with default features, but it is target-gated off Windows and s390x, so
+# anything only it supplies is absent from those two release binaries.
+# `.github/scripts/wasmtime-features.mjs` holds this list to that rule.
+wasmtime = { workspace = true, features = ["addr2line", "anyhow", "backtrace", "component-model", "component-model-async", "cranelift", "demangle", "gc", "gc-copying", "gc-drc", "gc-null", "parallel-compilation", "pooling-allocator", "threads"] }
 wasmtime-wasi = { workspace = true, features = ["p3"] }
 wasmtime-wasi-io = { workspace = true }
 wasmtime-wasi-http = { workspace = true, features = ["default-send-request", "p2", "p3", "component-model-async"] }

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -98,6 +98,7 @@ pub(crate) enum InstanceJob {
     /// plugin keeps its own payload and makes its own typed call. That is what
     /// lets a delivery carry, say, a NATS message's bytes rather than the one
     /// 48-byte [`Val`] per byte a store-independent lowering would cost.
+    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     Plugin(Box<dyn PluginJob>),
 }
 
@@ -110,6 +111,7 @@ pub(crate) enum InstanceJob {
 /// `max_concurrency`.
 pub(crate) trait PluginJob: Send + 'static {
     /// Names this job in a driver log line.
+    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     fn describe(&self) -> &str;
 
     /// Runs the call. Owns replying to whoever is waiting for it, and may

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -543,6 +543,7 @@ impl InstancePool {
     /// The policy this pool was built with, for a dispatch path that keeps its
     /// own warm set (the `wasmcloud:nats` subscriber) but must honour the same
     /// declaration.
+    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     pub(crate) fn policy(&self) -> InstancePolicy {
         self.policy
     }

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -1250,6 +1250,13 @@ impl EngineBuilder {
         self.proposals
             .insert(WasmProposal::WasmComponentModelImplements);
 
+        // Name the collector rather than taking `Collector::Auto`. `wasm_gc` is
+        // on by default, so a guest can allocate GC objects on any build, and
+        // `Auto` resolves to whichever collector was compiled in — reaching the
+        // null one, which reclaims nothing, when it is all that is left. Naming
+        // it turns that into an `Engine::new` error naming the missing feature.
+        config.collector(wasmtime::Collector::Copying);
+
         // Compile a deadline check into every guest's loop back-edges, so guest
         // work that never yields can still be ended. Every store must then set a
         // deadline of its own — see [`crate::engine::abandon::arm_epoch_deadline`],

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -959,6 +959,7 @@ pub struct EngineBuilder {
     compilation_cache_size: Option<u64>,
     compilation_cache_ttl: Option<Duration>,
     fuel_consumption: Option<bool>,
+    parallel_compilation: Option<bool>,
     socket_policy: Option<Arc<crate::sockets::policy::SocketPolicy>>,
     host_memory: Option<host_memory::HostMemoryBudgets>,
     guest_memory_mode: guest_memory::GuestMemoryMode,
@@ -1056,6 +1057,19 @@ impl EngineBuilder {
     /// specifies, rather than being forced off.
     pub fn with_fuel_consumption(mut self, enable: bool) -> Self {
         self.fuel_consumption = Some(enable);
+        self
+    }
+
+    /// Whether Cranelift compiles a component's functions on several threads.
+    ///
+    /// Enabled unless this or `WASMTIME_PARALLEL_COMPILATION` turns it off.
+    /// The threads come from rayon's process-wide pool, which sizes itself to
+    /// every core the process can see — not to `max_concurrent_starts`, and
+    /// not to the CPU a container is requested at. Two ways to hold a host
+    /// down: `RAYON_NUM_THREADS` caps how wide one compile goes, and this
+    /// makes it single-threaded again.
+    pub fn with_parallel_compilation(mut self, enable: bool) -> Self {
+        self.parallel_compilation = Some(enable);
         self
     }
 
@@ -1209,6 +1223,15 @@ impl EngineBuilder {
         // custom base config's setting is otherwise preserved.
         if let Some(fuel) = self.fuel_consumption {
             config.consume_fuel(fuel);
+        }
+
+        // Compiling in parallel is wasmtime's own default, so this only has to
+        // carry an explicit "off" through to the config.
+        if let Some(parallel) = self
+            .parallel_compilation
+            .or_else(|| getenv::<bool>("WASMTIME_PARALLEL_COMPILATION"))
+        {
+            config.parallel_compilation(parallel);
         }
 
         // WASIP3's async ABI requires the component-model async proposal.
@@ -1537,6 +1560,20 @@ mod tests {
         let raw = wasmtime::Error::msg("expected a WebAssembly component");
         let explained = format!("{:#}", explain_compile_failure(raw, 1024 * 1024));
         assert_eq!(explained, "expected a WebAssembly component");
+    }
+
+    // Compiling is parallel unless a host says otherwise, and saying so
+    // reaches the engine rather than being dropped on the builder.
+    #[test]
+    fn parallel_compilation_is_on_and_can_be_turned_off() {
+        let engine = Engine::builder().build().expect("default should build");
+        assert!(engine.inner().get_parallel_compilation());
+
+        let engine = Engine::builder()
+            .with_parallel_compilation(false)
+            .build()
+            .expect("serial compilation should build");
+        assert!(!engine.inner().get_parallel_compilation());
     }
 
     // A custom base config can now be combined with the pooling allocator and

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1624,6 +1624,7 @@ impl ResolvedWorkload {
     /// whose calls carry typed resources no [`InstanceJob`] can).
     ///
     /// [`InstanceJob`]: crate::engine::instance_driver::InstanceJob
+    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     pub(crate) async fn warm_instance_policy(&self, component_id: &str) -> InstancePolicy {
         match self.instance_pool_for_component(component_id).await {
             Some(pool) => pool.policy(),

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -188,6 +188,7 @@ pub(crate) trait WorkloadReservation {
     /// Give back an id claimed by [`WorkloadReservation::workload_reserve`]
     /// whose start never began. Does nothing if the id has moved on to another
     /// owner.
+    #[cfg_attr(not(feature = "washlet"), allow(dead_code))]
     fn workload_release(
         &self,
         workload_id: &str,
@@ -1492,7 +1493,9 @@ impl HostBuilder {
         // Trust roots first, before anything this host builds can pull: the
         // host pulls on behalf of every workload, and a bundle that cannot be
         // read is a startup failure rather than a registry that rejects every
-        // pull much later.
+        // pull much later. A host built without `oci` has no registry client
+        // for them to apply to.
+        #[cfg(feature = "oci")]
         crate::oci::set_extra_ca_certificates(&config.oci_ca_paths)
             .context("failed to load the OCI CA certificates in the host config")?;
 
@@ -1581,6 +1584,7 @@ mod tests {
     /// configured once and used much later, so accepting it here would surface
     /// as every pull from that registry failing to verify, far from the typo
     /// that caused it.
+    #[cfg(feature = "oci")]
     #[test]
     fn an_unreadable_oci_ca_bundle_fails_the_build() {
         let err = Host::builder()

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -48,7 +48,9 @@ pub fn init_crypto() {
     });
 }
 
-#[cfg(test)]
+// The one test here starts a host around the `wasi:config` plugin, so it only
+// exists in a build that has one.
+#[cfg(all(test, feature = "wasi-config"))]
 mod test {
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -29,12 +29,13 @@ pub const COMMAND_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How many starts a host runs at once when nothing sets it.
 ///
-/// Each permitted start ends in a Cranelift compile, and compilation here is
-/// single-threaded, so a permit is a core's worth of work for as long as the
-/// compile runs. `available_parallelism` reads the cgroup quota a container is
-/// limited to, and one core is left out of the count: a host that cannot poll
-/// its HTTP accept loop or drain its NATS socket while it compiles is one
-/// Kubernetes restarts out from under its workloads.
+/// Each permitted start ends in a Cranelift compile, and one compile spreads
+/// itself over rayon's pool, so a permit is a floor on the cores it takes for
+/// as long as it runs, not a ceiling — the pool's own size is what bounds the
+/// rest. `available_parallelism` reads the cgroup quota a container is limited to,
+/// and one core is left out of the count: a host that cannot poll its HTTP
+/// accept loop or drain its NATS socket while it compiles is one Kubernetes
+/// restarts out from under its workloads.
 fn default_max_concurrent_starts() -> usize {
     std::thread::available_parallelism().map_or(1, |cores| starts_for_cores(cores.get()))
 }


### PR DESCRIPTION
`crates/wash-runtime/Cargo.toml` pins `wasmtime` with `default-features = false` and an explicit feature list. That list was missing most of what the host actually relies on, and nothing caught it because `wasi-webgpu-wasmtime` takes `wasmtime` with **default** features and quietly put them back:

```
wash (default) → wash-runtime/wasi-webgpu → wasi-webgpu-wasmtime
               → wasmtime with DEFAULT features → parallel-compilation, gc-copying, …
```

That crate is **target-gated off Windows and s390x** (wgpu-hal does not build there). Both are release targets. So those two binaries resolved **15** wasmtime features against **32** everywhere else:

| | Linux / macOS | Windows / s390x |
|---|---|---|
| `parallel-compilation` | on | **off** one thread per compile |
| GC collector (`Collector::Auto`) | `Copying` | **`Null`** reclaims nothing |
| `addr2line`, `demangle`, `backtrace` | on | **off** |

`wasm_gc` is `true` by default in wasmtime 47, so GC guests are accepted on every target and on two of them they ran on the collector wasmtime's own docs list as "Collects Garbage: No."

## Changes

**1. Declare the full feature set, and keep it declared.** Adds `addr2line`, `backtrace`, `demangle`, `gc-copying`, `gc-drc`, `parallel-compilation`. `.github/scripts/wasmtime-features.mjs` (in `lint`) then holds two invariants:

- everything required is declared in wash-runtime's own manifest. This is what stops a dependency from owning the feature set
- everything required resolves on every target in the release matrix, read back out of that matrix.

**2. An off-switch for parallel compilation.** Measured on ten cores, release:

| component | parallel | serial | speedup | peak RSS |
|---|---|---|---|---|
| 1.9 MB / 3k fns | 0.118 s | 0.604 s | 5.1x | +7.7% |
| 19 MB / 12k fns | 0.880 s | 4.755 s | 5.4x | +2.5% |

The real cost is CPU: rayon sizes its pool to every core the process can see, which follows a cgroup quota only when `limits.cpu` is set and the chart sets `requests.cpu: 250m` with no limit. `EngineBuilder::with_parallel_compilation(false)` and `WASMTIME_PARALLEL_COMPILATION` turn it off; `RAYON_NUM_THREADS` caps width without serializing. Both reach a host group via `runtime.env`.

**3. `--no-default-features` builds again.** `HostBuilder::build` called `crate::oci::set_extra_ca_certificates` unguarded while the module is behind the `oci` feature, so the library did not compile at all without it.

Integration tests still need default features. `tests/common` builds its host from four optional plugins and 23 of the files using it carry no feature gate. I plan to pick this up in a follow-up.

**4. wasmtime 47.0.4.** Clears RUSTSEC-2026-0269 and RUSTSEC-2026-0268 Patch bump, no API or feature-set change.
