### PR TITLE
fix ingress descriptor exhaustion

### DIFF
--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1615,6 +1615,25 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
     }
 }
 
+/// How many `accept` failures within [`ACCEPT_FAILURE_WINDOW`] mean the loop is
+/// spinning rather than meeting the occasional bad connection.
+///
+/// Counted per window rather than consecutively: descriptor exhaustion under
+/// churn lets the odd `accept` succeed, and a consecutive count resets on each
+/// one and never notices. A busy server sheds a handful of half-open
+/// connections a second; a spinning one reaches this in milliseconds.
+const ACCEPT_FAILURES_PER_WINDOW: u32 = 1024;
+const ACCEPT_FAILURE_WINDOW: Duration = Duration::from_secs(1);
+
+/// How long the loop pauses once `accept` is failing persistently, and how far
+/// that grows. The cap bounds how long the listener leaves its backlog alone.
+const ACCEPT_RETRY_MIN: Duration = Duration::from_millis(5);
+const ACCEPT_RETRY_MAX: Duration = Duration::from_secs(1);
+
+/// How long a peer has to finish a TLS handshake before its connection is
+/// dropped. A handshake nobody finishes otherwise holds its socket forever.
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Configure a freshly accepted connection before it is served.
 ///
 /// Disables Nagle's algorithm. Responses are written as a head segment followed
@@ -1638,7 +1657,25 @@ async fn run_http_server<T: Router>(
     tls_acceptor: Option<TlsAcceptor>,
     guest_meter: GuestMeter,
 ) -> anyhow::Result<()> {
+    let mut failures: u32 = 0;
+    let mut window = std::time::Instant::now();
+    let mut retry_delay = ACCEPT_RETRY_MIN;
     loop {
+        // A window that ends without tripping the threshold is the loop working
+        // again, and is the only thing that clears the pause.
+        if window.elapsed() >= ACCEPT_FAILURE_WINDOW {
+            window = std::time::Instant::now();
+            failures = 0;
+            retry_delay = ACCEPT_RETRY_MIN;
+        }
+        // Taken before the select rather than inside it, so the pause races the
+        // shutdown branch instead of needing a second copy of it. Doubling here
+        // rather than on the failure is what makes the first pause the minimum.
+        let pause = (failures > ACCEPT_FAILURES_PER_WINDOW).then(|| {
+            let taken = retry_delay;
+            retry_delay = (retry_delay * 2).min(ACCEPT_RETRY_MAX);
+            taken
+        });
         tokio::select! {
             // Handle shutdown signal
             _ = shutdown_rx.recv() => {
@@ -1646,7 +1683,12 @@ async fn run_http_server<T: Router>(
                 break;
             }
             // Accept new connections
-            result = listener.accept() => {
+            result = async {
+                if let Some(pause) = pause {
+                    tokio::time::sleep(pause).await;
+                }
+                listener.accept().await
+            } => {
                 match result {
                     Ok((client, client_addr)) => {
                         debug!(addr = ?client_addr, "new HTTP client connection");
@@ -1674,8 +1716,13 @@ async fn run_http_server<T: Router>(
                             });
 
                             let mut builder = auto::Builder::new(TokioExecutor::new());
+                            // The timer is what arms hyper's header-read
+                            // timeout; without one a peer that opens a
+                            // connection and sends nothing holds it for as
+                            // long as it likes.
                             builder
                                 .http1()
+                                .timer(TokioTimer::new())
                                 .keep_alive(true);
                             builder
                                 .http2()
@@ -1683,14 +1730,24 @@ async fn run_http_server<T: Router>(
                                 .keep_alive_interval(Some(Duration::from_secs(20)));
 
                             let result = if let Some(acceptor) = tls_acceptor_clone {
-                                // Handle HTTPS connection
-                                match acceptor.accept(client).await {
-                                    Ok(tls_stream) => {
+                                // Handle HTTPS connection. Bounded, because a
+                                // handshake nobody finishes holds a socket no
+                                // request will ever release.
+                                let handshake = tokio::time::timeout(
+                                    TLS_HANDSHAKE_TIMEOUT,
+                                    acceptor.accept(client),
+                                );
+                                match handshake.await {
+                                    Err(_) => {
+                                        warn!(addr = ?client_addr, "TLS handshake timed out");
+                                        return;
+                                    }
+                                    Ok(Ok(tls_stream)) => {
                                         builder
                                             .serve_connection_with_upgrades(TokioIo::new(tls_stream), service)
                                             .await
                                     }
-                                    Err(e) => {
+                                    Ok(Err(e)) => {
                                         error!(addr = ?client_addr, err = ?e, "TLS handshake failed");
                                         return;
                                     }
@@ -1708,7 +1765,12 @@ async fn run_http_server<T: Router>(
                         });
                     }
                     Err(e) => {
-                        error!(err = ?e, "failed to accept HTTP connection");
+                        failures = failures.saturating_add(1);
+                        if failures <= ACCEPT_FAILURES_PER_WINDOW {
+                            debug!(err = ?e, "failed to accept HTTP connection");
+                        } else {
+                            error!(err = ?e, failures, "HTTP ingress cannot accept connections");
+                        }
                     }
                 }
             }
@@ -2858,6 +2920,33 @@ mod tests {
         assert!(
             server.nodelay().unwrap(),
             "run_http_server must set TCP_NODELAY on accepted connections"
+        );
+    }
+
+    /// The backoff triggers on a rate of failure, not on a kind of failure and
+    /// not on a run of them.
+    ///
+    /// `accept` also reports errors belonging to the single connection it
+    /// dequeued, so pausing the listener for one would be the bug in reverse —
+    /// and descriptor exhaustion under churn lets the odd call through, which a
+    /// consecutive count would keep resetting on.
+    #[test]
+    fn the_pause_is_paced_by_the_failure_rate() {
+        // The sequence the loop walks: the pause is taken, then doubled, so the
+        // first one it sleeps is the minimum rather than twice it.
+        let mut delay = ACCEPT_RETRY_MIN;
+        let mut steps = 0;
+        while delay < ACCEPT_RETRY_MAX && steps < 64 {
+            delay = (delay * 2).min(ACCEPT_RETRY_MAX);
+            steps += 1;
+        }
+        assert_eq!(
+            delay, ACCEPT_RETRY_MAX,
+            "the delay has to reach its cap and stop there"
+        );
+        assert!(
+            ACCEPT_FAILURES_PER_WINDOW > 1,
+            "one dequeued-connection error must not pause the listener"
         );
     }
 

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -40,10 +40,11 @@ use hyper_util::{
     rt::{TokioExecutor, TokioTimer},
     server::conn::auto,
 };
+use opentelemetry::KeyValue;
 use opentelemetry::context::FutureExt;
 use opentelemetry_semantic_conventions::attribute::{
-    HTTP_REQUEST_METHOD, HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_STATUS_CODE, OTEL_STATUS_CODE,
-    RPC_GRPC_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_PATH,
+    ERROR_TYPE, HTTP_REQUEST_METHOD, HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_STATUS_CODE,
+    OTEL_STATUS_CODE, RPC_GRPC_STATUS_CODE, SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_PATH,
 };
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
@@ -63,7 +64,7 @@ use wasmtime_wasi_http::{
 
 use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, Semaphore, mpsc};
 use tokio_rustls::TlsAcceptor;
 
 /// Validates a hostname according to RFC 1123.
@@ -1139,6 +1140,11 @@ pub struct Ingress<T: Router, O: OutgoingHandler = DefaultOutgoingHandler> {
     shutdown_tx: Arc<RwLock<Option<mpsc::Sender<()>>>>,
     tls_acceptor: Option<TlsAcceptor>,
     listener: Arc<tokio::sync::Mutex<Option<TcpListener>>>,
+    /// Ceiling on the TCP connections this ingress holds at once, and the
+    /// permits enforcing it. Sized from the process's descriptor budget unless
+    /// the operator names a number: see
+    /// [`crate::host::quota::default_max_http_ingress_connections`].
+    connections: ConnectionLimit,
     meters: RwLock<Meters>,
     /// h2 (ALPN) variant of the outgoing handler's client TLS configuration,
     /// derived once on the first gRPC request; see [`Ingress::grpc_tls`].
@@ -1205,6 +1211,7 @@ pub struct IngressBuilder<T: Router, O: OutgoingHandler = DefaultOutgoingHandler
     outgoing_handler: O,
     addr: SocketAddr,
     tls: Option<TlsConfig>,
+    max_connections: Option<usize>,
 }
 
 impl<T: Router> IngressBuilder<T, DefaultOutgoingHandler> {
@@ -1214,6 +1221,7 @@ impl<T: Router> IngressBuilder<T, DefaultOutgoingHandler> {
             outgoing_handler: DefaultOutgoingHandler::default(),
             addr,
             tls: None,
+            max_connections: None,
         }
     }
 }
@@ -1227,12 +1235,20 @@ impl<T: Router, O: OutgoingHandler> IngressBuilder<T, O> {
             outgoing_handler: handler,
             addr: self.addr,
             tls: self.tls,
+            max_connections: self.max_connections,
         }
     }
 
     /// Enable TLS using the given [`TlsConfig`].
     pub fn tls(mut self, tls: TlsConfig) -> Self {
         self.tls = Some(tls);
+        self
+    }
+
+    /// Cap the TCP connections this ingress holds at once, in place of the
+    /// ceiling derived from the process's descriptor budget.
+    pub fn max_connections(mut self, max: usize) -> Self {
+        self.max_connections = Some(max.clamp(1, Semaphore::MAX_PERMITS));
         self
     }
 
@@ -1250,6 +1266,9 @@ impl<T: Router, O: OutgoingHandler> IngressBuilder<T, O> {
 
         let listener = TcpListener::bind(self.addr).await?;
         let addr = listener.local_addr()?;
+        let max_connections = self
+            .max_connections
+            .unwrap_or_else(crate::host::quota::default_max_http_ingress_connections);
 
         Ok(Ingress {
             router: Arc::new(self.router),
@@ -1261,6 +1280,7 @@ impl<T: Router, O: OutgoingHandler> IngressBuilder<T, O> {
             shutdown_tx: Arc::new(RwLock::new(None)),
             tls_acceptor,
             listener: Arc::new(tokio::sync::Mutex::new(Some(listener))),
+            connections: ConnectionLimit::new(max_connections),
             meters: Default::default(),
             grpc_tls: OnceLock::new(),
         })
@@ -1348,6 +1368,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         // to the workload based on host header.
         let handler = self.router.clone();
         let guest_meter = self.meters.read().await.guest();
+        let connections = self.connections.clone();
         tokio::spawn(async move {
             if let Err(e) = run_http_server(
                 listener,
@@ -1357,6 +1378,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
                 &mut shutdown_rx,
                 tls_acceptor,
                 guest_meter,
+                connections,
             )
             .await
             {
@@ -1630,9 +1652,64 @@ const ACCEPT_FAILURE_WINDOW: Duration = Duration::from_secs(1);
 const ACCEPT_RETRY_MIN: Duration = Duration::from_millis(5);
 const ACCEPT_RETRY_MAX: Duration = Duration::from_secs(1);
 
-/// How long a peer has to finish a TLS handshake before its connection is
-/// dropped. A handshake nobody finishes otherwise holds its socket forever.
+/// How often a saturated ingress says so. Reporting each shed connection would
+/// make the log the load problem.
+const SHED_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a peer has to finish a TLS handshake before its connection slot is
+/// taken back.
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The ingress connection ceiling, the permits enforcing it, and the counter
+/// reporting it.
+///
+/// Together rather than separately because a refusal has to be counted where it
+/// is decided: the accept loop is the only place that knows a connection was
+/// offered and turned away.
+#[derive(Clone)]
+pub(crate) struct ConnectionLimit {
+    max: usize,
+    permits: Arc<Semaphore>,
+    offered: opentelemetry::metrics::Counter<u64>,
+    /// Built once. `error.type` marks the refusals inside the one series, so a
+    /// shed rate is a filter on it rather than a second counter to keep in step.
+    shed: Arc<[KeyValue]>,
+}
+
+impl ConnectionLimit {
+    pub(crate) fn new(max: usize) -> Self {
+        Self {
+            max,
+            permits: Arc::new(Semaphore::new(max)),
+            offered: opentelemetry::global::meter("wash-runtime")
+                .u64_counter("http.ingress.connections")
+                .with_description(
+                    "Connections offered to the host's HTTP ingress, whether held or shed",
+                )
+                .build(),
+            shed: Arc::from(vec![KeyValue::new(ERROR_TYPE, "no_capacity")]),
+        }
+    }
+
+    /// Take a slot for an accepted connection, or `None` at the ceiling.
+    ///
+    /// Counted either way, and with no attribute naming who was refused: a
+    /// connection is turned away before its first request names a workload, and
+    /// its peer address is invented by traffic — so there is nothing bounded to
+    /// split the series by.
+    fn take(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        match Arc::clone(&self.permits).try_acquire_owned() {
+            Ok(permit) => {
+                self.offered.add(1, &[]);
+                Some(permit)
+            }
+            Err(_) => {
+                self.offered.add(1, &self.shed);
+                None
+            }
+        }
+    }
+}
 
 /// Configure a freshly accepted connection before it is served.
 ///
@@ -1648,6 +1725,7 @@ fn prepare_accepted_conn(stream: &TcpStream) {
 }
 
 /// HTTP server implementation that routes to workload components
+#[allow(clippy::too_many_arguments)]
 async fn run_http_server<T: Router>(
     listener: TcpListener,
     handler: Arc<T>,
@@ -1656,10 +1734,13 @@ async fn run_http_server<T: Router>(
     shutdown_rx: &mut mpsc::Receiver<()>,
     tls_acceptor: Option<TlsAcceptor>,
     guest_meter: GuestMeter,
+    connections: ConnectionLimit,
 ) -> anyhow::Result<()> {
     let mut failures: u32 = 0;
     let mut window = std::time::Instant::now();
     let mut retry_delay = ACCEPT_RETRY_MIN;
+    let mut shed = 0u64;
+    let mut shed_reported: Option<std::time::Instant> = None;
     loop {
         // A window that ends without tripping the threshold is the loop working
         // again, and is the only thing that clears the pause.
@@ -1691,6 +1772,25 @@ async fn run_http_server<T: Router>(
             } => {
                 match result {
                     Ok((client, client_addr)) => {
+                        // A connection there is no descriptor budget to hold is
+                        // closed now, while closing it is cheap. Holding it
+                        // instead is what exhausts the process's descriptors,
+                        // and a host that cannot accept is a host nothing can
+                        // reach — including its own liveness probe.
+                        let Some(slot) = connections.take() else {
+                            shed += 1;
+                            if shed_reported.is_none_or(|at| at.elapsed() >= SHED_LOG_INTERVAL) {
+                                warn!(
+                                    max_connections = connections.max, shed,
+                                    "HTTP ingress is at its connection ceiling; shedding new connections"
+                                );
+                                shed_reported = Some(std::time::Instant::now());
+                                shed = 0;
+                            }
+                            drop(client);
+                            continue;
+                        };
+
                         debug!(addr = ?client_addr, "new HTTP client connection");
 
                         prepare_accepted_conn(&client);
@@ -1701,6 +1801,9 @@ async fn run_http_server<T: Router>(
                         let handler_clone = handler.clone();
                         let guest_meter = guest_meter.clone();
                         tokio::spawn(async move {
+                            // Held for the connection's life: its descriptor is
+                            // only given back once hyper is done with it.
+                            let _slot = slot;
                             let service = hyper::service::service_fn(move |req| {
                                 let handles = handles_clone.clone();
                                 let service_handlers = service_handlers_clone.clone();
@@ -1718,8 +1821,8 @@ async fn run_http_server<T: Router>(
                             let mut builder = auto::Builder::new(TokioExecutor::new());
                             // The timer is what arms hyper's header-read
                             // timeout; without one a peer that opens a
-                            // connection and sends nothing holds it for as
-                            // long as it likes.
+                            // connection and sends nothing holds its slot for
+                            // as long as it likes.
                             builder
                                 .http1()
                                 .timer(TokioTimer::new())
@@ -1731,8 +1834,8 @@ async fn run_http_server<T: Router>(
 
                             let result = if let Some(acceptor) = tls_acceptor_clone {
                                 // Handle HTTPS connection. Bounded, because a
-                                // handshake nobody finishes holds a socket no
-                                // request will ever release.
+                                // handshake nobody finishes holds a connection
+                                // slot that no request will ever release.
                                 let handshake = tokio::time::timeout(
                                     TLS_HANDSHAKE_TIMEOUT,
                                     acceptor.accept(client),
@@ -2948,6 +3051,55 @@ mod tests {
             ACCEPT_FAILURES_PER_WINDOW > 1,
             "one dequeued-connection error must not pause the listener"
         );
+    }
+
+    /// A host at its ingress ceiling has to keep accepting and close what it
+    /// cannot serve. Leaving the connections queued instead fills the listen
+    /// backlog, and once that is full the kernel drops new handshakes — so a TCP
+    /// liveness probe times out and a running host is killed as unreachable.
+    #[tokio::test]
+    async fn a_saturated_ingress_keeps_accepting() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
+
+        let server = tokio::spawn(async move {
+            run_http_server(
+                listener,
+                Arc::new(DevRouter::default()),
+                WorkloadHandles::default(),
+                ServiceHandlers::default(),
+                &mut shutdown_rx,
+                None,
+                Meters::default().guest(),
+                ConnectionLimit::new(1),
+            )
+            .await
+        });
+
+        // Takes the only permit and holds it: nothing reads or writes, so the
+        // server keeps the connection open.
+        let _held = TcpStream::connect(addr).await.unwrap();
+
+        // A real client has its request in flight by the time the ceiling is
+        // checked, so the shed path has to survive unread bytes.
+        let mut shed = TcpStream::connect(addr).await.unwrap();
+        let _ = shed.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").await;
+        let closed = tokio::time::timeout(Duration::from_secs(5), shed.read(&mut [0u8; 64])).await;
+        match closed.expect("a connection past the ceiling must be closed, not left hanging") {
+            Ok(0) => {}
+            // The kernel answers unread bytes with an RST rather than a FIN.
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+            Ok(n) => {
+                panic!("the ceiling was not enforced: the shed connection was served {n} bytes")
+            }
+            Err(e) => panic!("expected the server to close the shed connection, got {e:?}"),
+        }
+
+        let _ = shutdown_tx.send(()).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), server).await;
     }
 
     // --- check_allowed_hosts tests ---

--- a/crates/wash-runtime/src/host/quota.rs
+++ b/crates/wash-runtime/src/host/quota.rs
@@ -59,8 +59,8 @@ const QUOTA_IDLE: Duration = Duration::from_secs(300);
 /// classifiable connect timeout instead of a long hang.
 const DEFAULT_HTTP_WAIT: Duration = Duration::from_secs(5);
 
-/// What the host-wide ceiling falls back to when the real descriptor limit
-/// cannot be read. Half of the 1024 soft limit common on Linux.
+/// What the host-wide ceiling falls back to on a platform with no descriptor
+/// limit to read — Windows. Half of the 1024 soft limit common on Linux.
 const ASSUMED_MAX_CONNECTIONS: usize = 512;
 
 /// Share of the process's file-descriptor budget guest connections may hold.
@@ -77,6 +77,14 @@ const FD_BUDGET_DENOMINATOR: usize = 2;
 const MIN_DERIVED_MAX_CONNECTIONS: usize = 64;
 const MAX_DERIVED_MAX_CONNECTIONS: usize = 32_768;
 
+/// Ceiling on the raise [`raise_descriptor_limit`] performs.
+///
+/// Linux's own default `fs.nr_open`, and the point past which more descriptors
+/// buy nothing. An unlimited soft limit is worse than a large one: it leaves no
+/// number for the ceilings below to take a share of.
+#[cfg(any(unix, test))]
+const MAX_RAISED_DESCRIPTORS: u64 = 1_048_576;
+
 /// Host-wide ceiling on live connections when the operator names none.
 ///
 /// Derived from `RLIMIT_NOFILE` rather than assumed, because the number that
@@ -89,20 +97,39 @@ const MAX_DERIVED_MAX_CONNECTIONS: usize = 32_768;
 /// This is a *bound*, not a reservation: nothing is preallocated, so a generous
 /// limit costs nothing until connections are actually opened.
 pub fn default_max_connections() -> usize {
-    let Some(soft) = descriptor_soft_limit() else {
+    descriptor_share(FD_BUDGET_NUMERATOR, FD_BUDGET_DENOMINATOR)
+}
+
+/// `numerator/denominator` of the process's descriptor budget, bounded.
+fn descriptor_share(numerator: usize, denominator: usize) -> usize {
+    share_of(descriptor_soft_limit(), numerator, denominator)
+}
+
+/// The share arithmetic on its own, so the ceilings can be checked against a
+/// limit this process does not have to be running under.
+fn share_of(soft: Option<usize>, numerator: usize, denominator: usize) -> usize {
+    let Some(soft) = soft else {
         return ASSUMED_MAX_CONNECTIONS;
     };
-    soft.saturating_mul(FD_BUDGET_NUMERATOR)
-        .saturating_div(FD_BUDGET_DENOMINATOR)
+    soft.saturating_mul(numerator)
+        .saturating_div(denominator)
         .clamp(MIN_DERIVED_MAX_CONNECTIONS, MAX_DERIVED_MAX_CONNECTIONS)
 }
 
-/// The process's soft `RLIMIT_NOFILE`, or `None` if it cannot be read or is
-/// unlimited — in which case there is no budget to take a share of.
+/// A soft `RLIMIT_NOFILE` as a budget, given what `getrlimit` reported.
+///
+/// `None` there means unlimited, which reads as [`MAX_RAISED_DESCRIPTORS`]
+/// rather than as no answer: no bound at all is a larger budget than any finite
+/// one, and calling it unknown would hand out the smallest share of all.
+#[cfg(any(unix, test))]
+fn soft_limit_as_budget(reported: Option<u64>) -> Option<usize> {
+    usize::try_from(reported.unwrap_or(MAX_RAISED_DESCRIPTORS)).ok()
+}
+
+/// The process's soft `RLIMIT_NOFILE` as a budget.
 #[cfg(unix)]
 fn descriptor_soft_limit() -> Option<usize> {
-    let limits = rustix::process::getrlimit(rustix::process::Resource::Nofile);
-    usize::try_from(limits.current?).ok()
+    soft_limit_as_budget(rustix::process::getrlimit(rustix::process::Resource::Nofile).current)
 }
 
 /// Windows has no `RLIMIT_NOFILE` to derive from: sockets are handles bounded
@@ -111,6 +138,64 @@ fn descriptor_soft_limit() -> Option<usize> {
 /// [`ASSUMED_MAX_CONNECTIONS`].
 #[cfg(not(unix))]
 fn descriptor_soft_limit() -> Option<usize> {
+    None
+}
+
+/// The soft descriptor limits worth asking for, largest first, for a process
+/// currently at `soft` with a ceiling of `hard`. Empty when there is nothing
+/// worth asking for.
+///
+/// A hard limit of "unlimited" (`None`) is not a number any kernel will take —
+/// Linux refuses anything over `fs.nr_open`, macOS over `kern.maxfilesperproc`
+/// — and neither reports what it *would* take. So this is a sequence to try
+/// rather than one number, halving until the ask is one the process already
+/// has.
+#[cfg(any(unix, test))]
+fn raise_plan(soft: Option<u64>, hard: Option<u64>) -> Vec<u64> {
+    let have = soft.unwrap_or(u64::MAX);
+    let mut target = hard
+        .unwrap_or(MAX_RAISED_DESCRIPTORS)
+        .min(MAX_RAISED_DESCRIPTORS);
+    let mut plan = Vec::new();
+    while target > have {
+        plan.push(target);
+        target /= 2;
+    }
+    plan
+}
+
+/// Raise the process's soft descriptor limit as far as the kernel allows, and
+/// report the limit in force afterwards.
+///
+/// **An embedder's to call, never the runtime's.** The soft limit is
+/// process-global: a library that moved it would be reaching outside the host
+/// it was handed, and an embedder with its own opinion could not opt out. What
+/// lives here is the policy — how high is worth asking for, and what to do when
+/// the kernel says no ([`raise_plan`]); a `wash host`, a `wash dev` or a
+/// third-party embedder decides whether to apply it.
+///
+/// Apply it before deriving any ceiling above, since each is a share of
+/// whatever this leaves in place.
+#[cfg(unix)]
+pub fn raise_descriptor_limit() -> Option<usize> {
+    let limits = rustix::process::getrlimit(rustix::process::Resource::Nofile);
+    for target in raise_plan(limits.current, limits.maximum) {
+        let ask = rustix::process::Rlimit {
+            current: Some(target),
+            maximum: limits.maximum,
+        };
+        if rustix::process::setrlimit(rustix::process::Resource::Nofile, ask).is_ok() {
+            return descriptor_soft_limit();
+        }
+    }
+    // Not fatal: the host runs on whatever it was given, and every derived
+    // ceiling is sized from that same number.
+    tracing::debug!(soft = ?limits.current, "left the descriptor limit where it was");
+    descriptor_soft_limit()
+}
+
+#[cfg(not(unix))]
+pub fn raise_descriptor_limit() -> Option<usize> {
     None
 }
 
@@ -439,6 +524,55 @@ mod tests {
                 "half the budget is left for listeners, pulls, and open files"
             );
         }
+    }
+
+    /// What the raise asks for, without asking the kernel for anything.
+    ///
+    /// The step-down exists because an unlimited hard limit is not a number any
+    /// kernel takes, and none reports what it would take — so a single ask that
+    /// is refused must not be the end of it, or the raise silently does nothing
+    /// on exactly the hosts it was written for.
+    #[test]
+    fn the_raise_asks_lower_until_it_reaches_what_it_already_has() {
+        // Nothing to ask for: already at the ceiling, or above what is useful.
+        assert!(super::raise_plan(Some(1_048_576), Some(1_048_576)).is_empty());
+        assert!(super::raise_plan(None, None).is_empty());
+
+        // The ordinary container: soft 1024, hard far above it.
+        let plan = super::raise_plan(Some(1024), Some(1_048_576));
+        assert_eq!(plan.first(), Some(&1_048_576), "ask for the most first");
+        assert!(
+            plan.last().is_some_and(|last| *last > 1024),
+            "never ask for less than the process already has"
+        );
+        assert!(
+            plan.windows(2).all(|w| w[0] > w[1]),
+            "each ask is smaller than the last"
+        );
+
+        // An unlimited hard limit is capped, not taken literally.
+        assert_eq!(
+            super::raise_plan(Some(256), None).first(),
+            Some(&super::MAX_RAISED_DESCRIPTORS)
+        );
+    }
+
+    /// An unlimited `RLIMIT_NOFILE` is the largest budget there is, so it must
+    /// not read as the smallest. Reported as no answer it would hand out the
+    /// fallback share — a *sixty-fourth* of what the same host gets when its
+    /// limit is a large number rather than "no limit".
+    #[test]
+    fn an_unlimited_descriptor_limit_is_a_generous_budget() {
+        let unlimited = super::share_of(super::soft_limit_as_budget(None), 1, 2);
+        assert!(
+            unlimited > super::ASSUMED_MAX_CONNECTIONS,
+            "an unlimited limit gave {unlimited}, no better than not reading it at all"
+        );
+        assert_eq!(
+            unlimited,
+            super::share_of(super::soft_limit_as_budget(Some(1_048_576)), 1, 2),
+            "unlimited and the largest finite limit are the same budget"
+        );
     }
     use super::*;
 

--- a/crates/wash-runtime/src/host/quota.rs
+++ b/crates/wash-runtime/src/host/quota.rs
@@ -77,6 +77,21 @@ const FD_BUDGET_DENOMINATOR: usize = 2;
 const MIN_DERIVED_MAX_CONNECTIONS: usize = 64;
 const MAX_DERIVED_MAX_CONNECTIONS: usize = 32_768;
 
+/// Share of the descriptor budget the host's own HTTP ingress may hold in
+/// accepted connections.
+///
+/// Its own share rather than the guest one above, because the two fail
+/// differently: a guest refused a connection gets an error it can report, while
+/// ingress out of descriptors cannot accept at all — and an accept loop with
+/// nothing to accept is what makes a live host look dead to a TCP probe.
+const INGRESS_BUDGET_NUMERATOR: usize = 1;
+const INGRESS_BUDGET_DENOMINATOR: usize = 4;
+
+/// Floor under the ingress share, above the one guests get. A share of a small
+/// desktop limit lands near 64, and a server that can hold 64 connections is
+/// not usefully a server — a `wash dev` or a benchmark would sit at the ceiling.
+const MIN_INGRESS_CONNECTIONS: usize = 256;
+
 /// Ceiling on the raise [`raise_descriptor_limit`] performs.
 ///
 /// Linux's own default `fs.nr_open`, and the point past which more descriptors
@@ -98,6 +113,20 @@ const MAX_RAISED_DESCRIPTORS: u64 = 1_048_576;
 /// limit costs nothing until connections are actually opened.
 pub fn default_max_connections() -> usize {
     descriptor_share(FD_BUDGET_NUMERATOR, FD_BUDGET_DENOMINATOR)
+}
+
+/// Host-wide ceiling on the TCP connections the HTTP ingress holds, when the
+/// operator names none.
+///
+/// Counted where they are accepted, before TLS and before a protocol is known,
+/// so this bounds sockets rather than requests: an idle keep-alive connection
+/// holds a slot, and an HTTP/2 connection holds one however many streams it
+/// carries. They are not a guest's to account for — which workload a connection
+/// belongs to is unknown until its first request names one — so they draw on
+/// their own share rather than on [`default_max_connections`].
+pub fn default_max_http_ingress_connections() -> usize {
+    descriptor_share(INGRESS_BUDGET_NUMERATOR, INGRESS_BUDGET_DENOMINATOR)
+        .max(MIN_INGRESS_CONNECTIONS)
 }
 
 /// `numerator/denominator` of the process's descriptor budget, bounded.
@@ -524,6 +553,50 @@ mod tests {
                 "half the budget is left for listeners, pulls, and open files"
             );
         }
+    }
+
+    /// Guests and ingress take their shares of one budget, and both fit inside
+    /// it with room left for the listeners, pulls and open files that are
+    /// neither. Checked against limits this process need not be running under,
+    /// because the interesting ones are not the ones a test machine has.
+    #[test]
+    fn ingress_and_guests_fit_inside_one_descriptor_budget() {
+        for soft in [4096usize, 65_536, 1_048_576] {
+            let guests = super::share_of(
+                Some(soft),
+                super::FD_BUDGET_NUMERATOR,
+                super::FD_BUDGET_DENOMINATOR,
+            );
+            let ingress = super::share_of(
+                Some(soft),
+                super::INGRESS_BUDGET_NUMERATOR,
+                super::INGRESS_BUDGET_DENOMINATOR,
+            )
+            .max(super::MIN_INGRESS_CONNECTIONS);
+            assert!(
+                guests + ingress < soft,
+                "{guests} guest and {ingress} ingress connections must fit in {soft}"
+            );
+            assert!(ingress <= guests, "ingress takes the smaller share");
+        }
+    }
+
+    /// Under a limit too small to divide, the floors win and together promise
+    /// more than the budget holds. That is the deliberate trade — a host this
+    /// constrained is unusable at a proportional ceiling — and it is recorded
+    /// here so it stays a choice rather than becoming a surprise.
+    #[test]
+    fn a_tiny_descriptor_limit_gets_the_floors_not_a_share() {
+        let soft = 128;
+        assert_eq!(
+            super::share_of(
+                Some(soft),
+                super::FD_BUDGET_NUMERATOR,
+                super::FD_BUDGET_DENOMINATOR
+            ),
+            super::MIN_DERIVED_MAX_CONNECTIONS
+        );
+        assert!(super::MIN_DERIVED_MAX_CONNECTIONS + super::MIN_INGRESS_CONNECTIONS > soft);
     }
 
     /// What the raise asks for, without asking the kernel for anything.

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -208,6 +208,11 @@ impl CliCommand for DevCommand {
 
         let http_handler = wash_runtime::host::http::DevRouter::default();
 
+        // Before the ceilings below, each of which is a share of the soft
+        // descriptor limit this leaves in place. `wash dev` applies it for the
+        // same reason `wash host` does: both own their process.
+        wash_runtime::host::quota::raise_descriptor_limit();
+
         // One registry for every surface: HTTP pool, raw sockets, inbound
         // published ports.
         let quotas = dev_config.connection_quotas()?;

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -124,6 +124,25 @@ pub struct HostCommand {
     #[arg(long = "max-connections", env = "WASH_MAX_CONNECTIONS")]
     pub max_connections: Option<usize>,
 
+    /// Cap on the TCP connections accepted on `--http-addr` at once.
+    ///
+    /// Connections, not requests: a keep-alive connection counts while it sits
+    /// idle, and one HTTP/2 connection counts once however many streams it
+    /// carries. Separate from `--max-connections`, which is what workloads may
+    /// hold, because which workload an inbound connection belongs to is unknown
+    /// until its first request names one; and from
+    /// `--max-inbound-socket-connections-per-workload`, which is a workload's
+    /// own published ports rather than this listener.
+    ///
+    /// Connections past this are closed as soon as they are accepted, so the
+    /// host keeps answering rather than going silent. Defaults to a quarter of
+    /// the process's descriptor limit.
+    #[arg(
+        long = "max-http-ingress-connections",
+        env = "WASH_MAX_HTTP_INGRESS_CONNECTIONS"
+    )]
+    pub max_http_ingress_connections: Option<usize>,
+
     /// Cap on live pooled HTTP and gRPC connections a single workload may
     /// hold, across all authorities it talks to. Idle keep-alive connections
     /// count, so this is really how large a workload's pool may grow.
@@ -547,6 +566,10 @@ impl CliCommand for HostCommand {
             self.core_instances,
         )
         .map_err(|e| anyhow::anyhow!(e))?;
+        anyhow::ensure!(
+            self.max_http_ingress_connections != Some(0),
+            "max_http_ingress_connections must be at least 1"
+        );
 
         // Installed before connect_nats so TLS-enabled NATS clusters have a
         // crypto provider available. Idempotent; also called by Ingress::new.
@@ -801,6 +824,9 @@ impl CliCommand for HostCommand {
 
             let mut ingress_builder = wash_runtime::host::http::Ingress::builder(http_router, addr)
                 .outgoing_handler(outgoing_handler);
+            if let Some(max) = self.max_http_ingress_connections {
+                ingress_builder = ingress_builder.max_connections(max);
+            }
             if let (Some(cert_path), Some(key_path)) = (&self.tls_cert_path, &self.tls_key_path) {
                 let mut tls = wash_runtime::host::http::TlsConfig::new(cert_path, key_path);
                 if let Some(ca) = self.tls_ca_path.as_deref() {

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -607,6 +607,13 @@ impl CliCommand for HostCommand {
         wash_runtime::oci::set_extra_ca_certificates(&host_config.oci_ca_paths)
             .context("failed to load --oci-ca-path CA certificates")?;
 
+        // Before any ceiling below is derived: each is a share of the soft
+        // descriptor limit, and this is what that limit ends up being.
+        match wash_runtime::host::quota::raise_descriptor_limit() {
+            Some(limit) => tracing::debug!(descriptors = limit, "descriptor limit"),
+            None => tracing::debug!("descriptor limit is not known on this platform"),
+        }
+
         let mut engine_builder = Engine::builder()
             .with_pooling_allocator(true)
             .with_fuel_consumption(ctx.meters().consumes_fuel());


### PR DESCRIPTION
Reported symptoms for this failure mode is that a hostgroup pod dies with `exit code 137`, `reason: Error` and is not `OOMKilled`, with normal CPU and memory, and nothing in the pod events but:

```bash
Warning  Unhealthy  Liveness probe failed: dial tcp 10.0.0.167:80: i/o timeout Normal   Killing    Container host failed liveness probe, will be restarted
```

Alongside it, the operator reports `host heartbeat failed: context deadline exceeded` and `failed to stop workload on host: context deadline exceeded`, and the host disconnects from NATS as a slow consumer. Killing the pod recovers it immediately.

## The cause

`run_http_server`'s accept loop treated every `accept()` failure as transient and would then call `accept()` again at once:

```rust
Err(e) => {
    error!(err = ?e, "failed to accept HTTP connection");
}
```

That is correct for an error concerning the one connection, which the kernel has already dequeued. It is wrong for a condition of the *process*. `EMFILE` leaves the connection at the head of the accept queue, so the next call returns the same error immediately, and the next, for as long as the host is out of descriptors.

One loop then pins one core, writes an error line per turn, and ends up not accepting anything. Each symptom above follows from that:

| Symptom | Why |
| --- | --- |
| CPU pinned at ~1 core, steady, on every pod, under a 2-core limit | one spinning task is exactly one core |
| liveness `dial tcp :80: i/o timeout` | nothing accepted → the 1024 listen backlog fills → the kernel drops new handshakes. A TCP probe otherwise succeeds against a wedged process, so a *connect* timeout means the backlog, not the process |
| readiness fails but it never recovers | leaving the endpoints stops new traffic; it does not close the descriptors already held |
| NATS slow-consumer, heartbeat and workload-stop deadlines | the log flood where stdout writes are blocking syscalls under a global writer lock, so every other task queues behind it |
| instant recovery on pod kill | descriptors reset |

The loop has been this way since `f66468a2` (2025-11-14), so it is in every 2.x host.

Two things made running out of descriptors likely in the first place, and both are fixed here: nothing raised `RLIMIT_NOFILE`, and inbound ingress connections did not have a ceiling. `with_quotas()` is wired only to the *outgoing* handler.

## The changes

**`stop the ingress accept loop spinning on a failure`**: This change paces the retries by the rate of failure. More than 1024 failures inside one second is the signal to begin backoff. The loop then pauses, 5ms doubling to 1s, cleared by a window that passes without tripping.

We also now bound the two different ways a peer could hold a connection open indefinitely while it is being counted: the h1 timer that arms hyper's header-read timeout was never set (only the h2 one, so hyper's 30s default was inert), and the TLS handshake had no deadline at all.

**`host descriptor budget`**: raise `RLIMIT_NOFILE` soft to hard at host startup, before any ceiling is derived from it. A hard limit of "unlimited" is not a number the kernel accepts (Linux caps at `fs.nr_open`, macOS at `kern.maxfilesperproc`) and neither reports what it *would* accept, so the raise asks for less until one succeeds rather than giving up on the first refusal.

**`bound the connections for HTTP ingress`**: The HTTP listener gets its own share of the budget, a quarter by default, or whatever
`--max-http-ingress-connections` / `WASH_MAX_HTTP_INGRESS_CONNECTIONS` names. This is for the host and not workloads.

Past the ceiling the host **accepts the connection and closes it**. Shedding keeps the hosst answering while it is over budget.

Every offered connection is counted on `http.ingress.connections`, with `error.type` marking the shed ones inside the same series. It's possible now to create shed rate filter. A `warn!` still reports saturation once a minute for an operator not looking at metrics.

## Behavior change to know about

`default_max_connections()` reads an unlimited `RLIMIT_NOFILE` as the largest budget rather than as no answer. `getrlimit` reports unlimited as no value, which previously fell into the "cannot be read" branch and returned the 512 fallback:

| `LimitNOFILE` | host-wide guest ceiling, before | after |
| --- | --- | --- |
| 1024 | 512 | 512 |
| 1048576 | 32768 | 32768 |
| `infinity` | **512** | **32768** |

A container with *no* descriptor limit was getting a 64× smaller connection budget than one limited to a million, silently. `LimitNOFILE=infinity` is the containerd default on several distros, so this was a common case. Every guest's pooled HTTP, raw sockets and inbound ports draw on that ceiling, with a 5s wait before a connect timeout once it saturates, so it presented as unexplained latency under load. Hosts on such a limit will now permit more concurrent guest connections. This is still overridable via `--max-connections`.

## Not in this PR

- **The probe is the wrong signal.** Liveness and readiness are `tcpSocket` on `port: http`, the port serving production traffic, so they cannot distinguish a wedged host from a busy one. A dedicated admin port with a real `/healthz`, answering from the host's own liveness rather than from "a socket accepted", is the fix. I'm working on a separate PR for this.
- **A third-party embedder** must call `raise_descriptor_limit()` itself, the way `wash host` and `wash dev` do. This is to set a process-global and there are likely other factors host needs to account for more than what a library should do.