### PR TITLE
feat(wash-runtime): liveness and readiness on own probes port

### DIFF
--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -231,6 +231,41 @@ spec:
             - "--wasmcloud-nats-url={{ . }}"
             {{- end }}
             - "--oci-cache-dir=/oci-cache"
+            {{- /* `networking` is the host's half of every two-sided grant, plus
+                   the ceilings it enforces alone. A key is rendered only when
+                   the values file sets it, so an unset one keeps the host's own
+                   default rather than having the chart restate it — which
+                   matters for the derived ceilings, where "unset" and "the same
+                   number typed out" mean different things downstream. */}}
+            {{- with .networking }}
+            {{- if .allowHostLoopback }}
+            - "--allow-host-loopback"
+            {{- end }}
+            {{- with .socketEgress }}
+            - "--socket-egress={{ . }}"
+            {{- end }}
+            {{- if hasKey . "denySpecialRanges" }}
+            - "--deny-special-ranges={{ .denySpecialRanges }}"
+            {{- end }}
+            {{- if .denyPrivateRanges }}
+            - "--deny-private-ranges"
+            {{- end }}
+            {{- with .maxConnections }}
+            - "--max-connections={{ . }}"
+            {{- end }}
+            {{- with .maxHttpIngressConnections }}
+            - "--max-http-ingress-connections={{ . }}"
+            {{- end }}
+            {{- with .maxOutboundHttpConnectionsPerWorkload }}
+            - "--max-outbound-http-connections-per-workload={{ . }}"
+            {{- end }}
+            {{- with .maxOutboundSocketConnectionsPerWorkload }}
+            - "--max-outbound-socket-connections-per-workload={{ . }}"
+            {{- end }}
+            {{- with .maxInboundSocketConnectionsPerWorkload }}
+            - "--max-inbound-socket-connections-per-workload={{ . }}"
+            {{- end }}
+            {{- end }}
             {{- if and (.http) (.http.enabled) }}
             - "--http-addr=0.0.0.0:{{ .http.port }}"
             {{- if and ($top.Values.global.tls.enabled) (.http.tls) (.http.tls.enabled) }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -20,6 +20,13 @@
 {{- $resources := .resources | default $top.Values.runtime.resources | default dict }}
 {{- /* Probes, unlike `resources`, merge per field: a group naming one timing
        keeps the chart-wide values for the rest. */}}
+{{- /* The shutdown budget, checked rather than described: the host serves for
+       `drainDelaySeconds`, then drains commands for up to 5s, and SIGKILL lands
+       at `terminationGracePeriodSeconds` whatever it is doing. */}}
+{{- $drain := int ($top.Values.runtime.drainDelaySeconds | default 0) }}
+{{- if gt (add $drain 5) (int $top.Values.runtime.terminationGracePeriodSeconds) }}
+{{- fail (printf "runtime.terminationGracePeriodSeconds (%v) is under drainDelaySeconds (%v) plus the 5s command drain; the host would be killed mid-shutdown" $top.Values.runtime.terminationGracePeriodSeconds $drain) }}
+{{- end }}
 {{- $probeArgs := dict "group" .probes "chart" $top.Values.runtime.probes }}
 {{- /* The port the probes are answered on, merged per field like the timings
        beside it: a group may turn it off or move it without restating the
@@ -238,6 +245,9 @@ spec:
             - "--wasmcloud-nats-url={{ . }}"
             {{- end }}
             - "--oci-cache-dir=/oci-cache"
+            {{- with $top.Values.runtime.drainDelaySeconds }}
+            - "--drain-delay={{ . }}s"
+            {{- end }}
             {{- if $endpoint.enabled }}
             - "--probe-addr=0.0.0.0:{{ $endpoint.port }}"
             {{- end }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -21,6 +21,13 @@
 {{- /* Probes, unlike `resources`, merge per field: a group naming one timing
        keeps the chart-wide values for the rest. */}}
 {{- $probeArgs := dict "group" .probes "chart" $top.Values.runtime.probes }}
+{{- /* The port the probes are answered on, merged per field like the timings
+       beside it: a group may turn it off or move it without restating the
+       chart-wide default. */}}
+{{- $endpoint := include "runtime-operator.hostProbe" (merge (dict "name" "endpoint") $probeArgs) | fromJson }}
+{{- if and $endpoint.enabled .http .http.enabled (eq (int $endpoint.port) (int .http.port)) }}
+{{- fail (printf "host group %s: probes.endpoint.port and http.port are both %v; the host would fail to bind the second" .name $endpoint.port) }}
+{{- end }}
 {{- $liveness := include "runtime-operator.hostProbe" (merge (dict "name" "liveness") $probeArgs) | fromJson }}
 {{- $readiness := include "runtime-operator.hostProbe" (merge (dict "name" "readiness") $probeArgs) | fromJson }}
 {{- $partition := include "runtime-operator.hostPluginPartition" . | fromJson }}
@@ -231,6 +238,9 @@ spec:
             - "--wasmcloud-nats-url={{ . }}"
             {{- end }}
             - "--oci-cache-dir=/oci-cache"
+            {{- if $endpoint.enabled }}
+            - "--probe-addr=0.0.0.0:{{ $endpoint.port }}"
+            {{- end }}
             {{- /* `networking` is the host's half of every two-sided grant, plus
                    the ceilings it enforces alone. A key is rendered only when
                    the values file sets it, so an unset one keeps the host's own
@@ -357,6 +367,11 @@ spec:
               containerPort: {{ .http.port }}
               protocol: TCP
             {{- end }}
+            {{- if $endpoint.enabled }}
+            - name: probes
+              containerPort: {{ $endpoint.port }}
+              protocol: TCP
+            {{- end }}
             {{- /* Optional additional container ports (e.g. metrics scrape).
                    Do NOT re-list the http port — the chart renders it from
                    `.http.port` above; a duplicate containerPort fails
@@ -364,26 +379,51 @@ spec:
             {{- with .ports }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if and (.http) (.http.enabled) }}
-          {{- /* A host serves workload routes on this port and nothing else,
-                 so both probes can only ask whether it still accepts
-                 connections. What each one does about that answer, and why
-                 they are timed apart, is documented on `runtime.probes`. */}}
-          {{- /* Every field but `enabled` is passed through as given, so a `0`
-                 reaches the manifest and `runtime.probes` stays the one place
-                 the timings are written down. */}}
+          {{- /* With the probe endpoint on, the probes ask the host about
+                 itself: `/livez` is "restart me", `/readyz` is "stop sending me
+                 work". Without it they fall back to a TCP connect on the
+                 traffic port, which cannot tell a wedged host from a busy one
+                 and cannot say "full" at all. Every field
+                 but `enabled` is passed through as given, so a `0` reaches the
+                 manifest and `runtime.probes` stays the one place the timings
+                 are written down. */}}
+          {{- if or $endpoint.enabled (and (.http) (.http.enabled)) }}
+          {{- /* Liveness on the probe port answers only once the host has
+                 bound it, which is late in startup — after the plugin pulls
+                 and compiles. A startup probe gives that as long as it needs
+                 without loosening the liveness timings that follow it. */}}
+          {{- if and $endpoint.enabled $liveness.enabled }}
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: probes
+            periodSeconds: 5
+            failureThreshold: {{ $endpoint.startupFailureThreshold }}
+          {{- end }}
           {{- if $liveness.enabled }}
           livenessProbe:
+            {{- if $endpoint.enabled }}
+            httpGet:
+              path: /livez
+              port: probes
+            {{- else }}
             tcpSocket:
               port: http
+            {{- end }}
             {{- range $field, $value := omit $liveness "enabled" }}
             {{ $field }}: {{ $value }}
             {{- end }}
           {{- end }}
           {{- if $readiness.enabled }}
           readinessProbe:
+            {{- if $endpoint.enabled }}
+            httpGet:
+              path: /readyz
+              port: probes
+            {{- else }}
             tcpSocket:
               port: http
+            {{- end }}
             {{- range $field, $value := omit $readiness "enabled" }}
             {{ $field }}: {{ $value }}
             {{- end }}

--- a/charts/runtime-operator/templates/runtime/networkpolicy.yaml
+++ b/charts/runtime-operator/templates/runtime/networkpolicy.yaml
@@ -2,6 +2,7 @@
 {{- range .Values.runtime.hostGroups }}
 {{- if $top.Values.networkPolicy.enabled }}
 {{- $ns := default $top.Release.Namespace .namespace }}
+{{- $endpoint := include "runtime-operator.hostProbe" (dict "name" "endpoint" "group" .probes "chart" $top.Values.runtime.probes) | fromJson }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -21,9 +22,17 @@ spec:
   ingress:
     # The host's served HTTP port plus any additional container ports the host
     # group declares (e.g. a metrics scrape endpoint).
+    #
+    # The probe port is in this list because the kubelet reaches it from the
+    # node: under a default-deny policy, a CNI that applies NetworkPolicy to
+    # probe traffic would fail every probe and restart every host.
     - ports:
         {{- if and .http .http.enabled }}
         - port: {{ .http.port }}
+          protocol: TCP
+        {{- end }}
+        {{- if $endpoint.enabled }}
+        - port: {{ $endpoint.port }}
           protocol: TCP
         {{- end }}
         {{- range .ports }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -710,6 +710,13 @@ runtime:
         # -- Host-wide cap on live connections across every workload. Empty
         # derives it from the process's file-descriptor limit.
         maxConnections: ""
+        # -- Cap on the TCP connections the host's own HTTP listener holds at
+        # once. Connections, not requests: an idle keep-alive connection counts,
+        # and one HTTP/2 connection counts once however many streams it carries.
+        # Separate from `maxConnections`, which is what workloads hold — which
+        # workload an inbound connection belongs to is unknown until its first
+        # request names one. Empty derives it from the descriptor limit.
+        maxHttpIngressConnections: ""
         # -- Pooled HTTP and gRPC connections one workload may hold. Idle
         # keep-alive connections count, so this is how large its pool may grow.
         maxOutboundHttpConnectionsPerWorkload: 128
@@ -726,9 +733,12 @@ runtime:
         # published port fails to start rather than coming up silently
         # unreachable. Publishing makes a service reachable by every co-tenant
         # on the machine unless socketEgress is `enforce`.
+        # NOTE: not yet wired to the host — there is no `wash host` flag behind
+        # this key, so setting it changes nothing today.
         publishPorts: false
         # -- Restrict published ports to a range, e.g. "31000-32767". Empty
         # allows any port the OS will grant.
+        # NOTE: not yet wired to the host, as with `publishPorts` above.
         publishPortRange: ""
       http:
         enabled: true

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -463,12 +463,26 @@ runtime:
   # -- Additional CLI args appended to every host group container, for host
   # flags the chart does not template. Merged with per-host-group `extraArgs`.
   extraArgs: []
+  # -- How long the host keeps serving after `SIGTERM`, before it starts
+  # stopping.
+  #
+  # A pod leaves its Service the moment Kubernetes marks it Terminating, but
+  # that removal reaches each kube-proxy a beat later. Without this the host
+  # stops first and refuses the requests still on their way to it. Readiness
+  # goes red as the wait starts, so anything reading `/readyz` learns at the
+  # same time.
+  #
+  # It has to fit inside `terminationGracePeriodSeconds` alongside the 5s
+  # command drain that follows it; the chart refuses to render if it does not.
+  drainDelaySeconds: 5
   # -- How long a terminating host pod has to shut down before it is killed.
-  # On `SIGTERM` the host stops taking work, waits up to 5s for the commands
-  # already running to finish, then stops itself — unbinding every plugin the
-  # workloads it holds are bound to. Kubernetes sends `SIGKILL` when this
-  # expires, so anything below that 5s drain cuts the shutdown short and leaves
-  # the unbinding to the operator's unreachable-host path instead.
+  #
+  # Three numbers in sequence, and this is the budget for all of them:
+  # `drainDelaySeconds` serving while the endpoint is withdrawn, then up to 5s for
+  # the commands already running to finish, then the host unbinds every plugin its
+  # workloads are bound to. Kubernetes sends `SIGKILL` when this expires, so a
+  # value under `drainDelaySeconds` + 5s cuts the shutdown short and leaves the
+  # unbinding to the operator's unreachable-host path instead.
   terminationGracePeriodSeconds: 15
   hostGroups:
     - name: default

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -390,15 +390,19 @@ runtime:
     # explicitly on a host group that is requested far below the node it lands
     # on.
     maxConcurrentStarts: ""
-  # -- Probes for host containers, rendered only for a host group that serves
-  # HTTP (`hostGroups[].http.enabled`); both connect to its `http` port. A host
-  # group sets its own with `hostGroups[].probes`, and any field left out of
-  # that falls back to the value here.
+  # -- Probes for host containers, rendered for a host group with
+  # `probes.endpoint` enabled or one that serves HTTP
+  # (`hostGroups[].http.enabled`). A host group sets its own with
+  # `hostGroups[].probes`, and any field left out of that falls back to the
+  # value here.
   #
-  # Readiness and liveness are deliberately not tuned alike. Both connect to
-  # the port the host serves workload routes on, which the kernel answers from
-  # the listener's accept queue whether or not the host is polling it — so what
-  # a failure reports is a host busy enough to have let that queue fill.
+  # With `endpoint` on they are HTTP GETs against `/livez` and `/readyz`,
+  # answered from what the host knows about itself. With it off they fall back
+  # to a TCP connect on the workload port, which the kernel answers from the accept queue
+  # whether or not the host is polling it — so what a failure reports there is a
+  # host busy enough to have let that queue fill.
+  #
+  # Readiness and liveness are deliberately not tuned alike.
   # Leaving the Service over that is cheap, which is readiness' job. Restarting
   # is a different trade: the pod loses every workload running on it, and the
   # scheduler places them all again at once, which is the burst that stalled it
@@ -411,6 +415,31 @@ runtime:
   # running whatever it still holds. Disable it only where something else
   # takes that job.
   probes:
+    # -- The port `/livez` and `/readyz` are answered on. The timings below
+    # target it when this is on.
+    #
+    # It exists because a TCP probe against the traffic port answers the wrong
+    # question. The kernel completes a handshake whether or not the host
+    # process is running, so the probe passes against a wedged host until its
+    # backlog fills, and fails against a healthy one briefly behind on accepts.
+    # It also cannot say "full, send work elsewhere": a host shedding every
+    # connection at its ceiling still accepts, so its endpoint stays in the
+    # Service. `/readyz` reports that, and traffic moves to a replica with room.
+    #
+    # Turning it off falls the timings back to a TCP connect on `http.port`.
+    #
+    # Requires a host image carrying `--probe-addr`, which arrived with this
+    # chart's appVersion. A host group pinning an older `image.tag` must set
+    # `probes.endpoint.enabled: false` for that group — `wash host` refuses to
+    # start on an argument it does not know, so leaving it on there is a
+    # CrashLoopBackOff rather than a degraded probe.
+    endpoint:
+      enabled: true
+      port: 8081
+      # -- How many 5s attempts the host gets to bind the probe port before the
+      # kubelet gives up. It binds after plugin pulls and compiles, so this is
+      # the startup budget: 60 is five minutes.
+      startupFailureThreshold: 60
     readiness:
       enabled: true
       initialDelaySeconds: 5

--- a/crates/wash-runtime/src/host/accept.rs
+++ b/crates/wash-runtime/src/host/accept.rs
@@ -1,0 +1,238 @@
+//! Pacing an accept loop that is failing.
+//!
+//! `accept` reports two unrelated things through one return value. An error
+//! concerning the connection it just dequeued — a peer that went away, a
+//! firewall verdict, a pending error Linux surfaces on the new socket — is over
+//! as soon as it is read, and the next call proceeds. A condition of the
+//! *process* is not: `EMFILE` leaves the connection queued, so every call
+//! returns the same error until descriptors come back.
+//!
+//! Retrying the second at full speed pins a core and writes a log line per turn
+//! while accepting nothing, which is how a live host stops answering its own
+//! liveness probe.
+//!
+//! Only an error that leaves the connection queued can repeat, so only those are
+//! paced. A count of consecutive failures cannot find them — descriptor
+//! exhaustion under churn lets the occasional call succeed — so the pacing is on
+//! their *rate*.
+
+use core::time::Duration;
+#[cfg(any(not(unix), test))]
+use std::io::ErrorKind;
+use std::time::Instant;
+
+/// How many failures without a quiet [`FAILURE_WINDOW`] mean the loop is
+/// spinning rather than meeting the occasional bad connection.
+const FAILURES_BEFORE_BACKOFF: u32 = 1024;
+const FAILURE_WINDOW: Duration = Duration::from_secs(1);
+
+/// How long a spinning loop pauses between calls, and how far that grows. The
+/// cap bounds how long the listener leaves its backlog alone.
+const RETRY_MIN: Duration = Duration::from_millis(5);
+const RETRY_MAX: Duration = Duration::from_secs(1);
+
+/// Whether this error is the process's own rather than one connection's.
+///
+/// Named by errno, not by kind: `EMFILE` and the per-connection errors
+/// `accept(2)` says to retry like `EAGAIN` — `EPROTO`, `ENOPROTOOPT`,
+/// `ENETRESET` — all reach Rust as `ErrorKind::Uncategorized`, so a kind cannot
+/// tell them apart. These four leave the connection queued, which is what makes
+/// the next call fail identically.
+#[cfg(unix)]
+fn concerns_the_process(e: &std::io::Error) -> bool {
+    use rustix::io::Errno;
+    e.raw_os_error().is_some_and(|raw| {
+        let errno = Errno::from_raw_os_error(raw);
+        matches!(
+            errno,
+            Errno::MFILE | Errno::NFILE | Errno::NOBUFS | Errno::NOMEM
+        )
+    })
+}
+
+/// Without errnos to name, keep the kinds that are definitely one connection's
+/// and treat the rest as the process's.
+#[cfg(not(unix))]
+fn concerns_the_process(e: &std::io::Error) -> bool {
+    !matches!(
+        e.kind(),
+        ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::Interrupted
+            | ErrorKind::WouldBlock
+    )
+}
+
+/// Tracks how fast an accept loop is failing, and how long it should wait.
+#[derive(Debug)]
+pub(crate) struct AcceptBackoff {
+    failures: u32,
+    last_failure: Instant,
+    retry_delay: Duration,
+}
+
+impl Default for AcceptBackoff {
+    fn default() -> Self {
+        Self {
+            failures: 0,
+            last_failure: Instant::now(),
+            retry_delay: RETRY_MIN,
+        }
+    }
+}
+
+impl AcceptBackoff {
+    /// How long to wait before the next `accept`, if the loop is failing fast
+    /// enough to be spinning. Call once per turn, before accepting.
+    ///
+    /// Only a window with no failure in it clears the pause. Clearing on the
+    /// window's age instead would reset mid-escalation — the escalating sleeps
+    /// alone outlast a window — leaving the loop to re-spin its way to the
+    /// threshold once a second, forever.
+    ///
+    /// Taking the delay before doubling it is what makes the first pause
+    /// [`RETRY_MIN`] rather than twice it.
+    pub(crate) fn pause(&mut self) -> Option<Duration> {
+        if self.last_failure.elapsed() >= FAILURE_WINDOW {
+            self.failures = 0;
+            self.retry_delay = RETRY_MIN;
+        }
+        if self.failures <= FAILURES_BEFORE_BACKOFF {
+            return None;
+        }
+        let taken = self.retry_delay;
+        self.retry_delay = (self.retry_delay * 2).min(RETRY_MAX);
+        Some(taken)
+    }
+
+    /// Record one failed `accept`. `true` when the loop is failing fast enough
+    /// that the condition is the process's own and worth an `error!`.
+    pub(crate) fn failed(&mut self, e: &std::io::Error) -> bool {
+        if !concerns_the_process(e) {
+            return false;
+        }
+        self.last_failure = Instant::now();
+        self.failures = self.failures.saturating_add(1);
+        self.failures > FAILURES_BEFORE_BACKOFF
+    }
+
+    /// How many failures have gone by without a quiet window, for the log line.
+    pub(crate) fn failures(&self) -> u32 {
+        self.failures
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn emfile() -> std::io::Error {
+        // `EMFILE` reaches Rust with no `ErrorKind` of its own, which is the
+        // whole reason this module paces on a rate rather than on a kind.
+        std::io::Error::from_raw_os_error(24)
+    }
+
+    fn spin(backoff: &mut AcceptBackoff) {
+        for _ in 0..=FAILURES_BEFORE_BACKOFF {
+            backoff.failed(&emfile());
+        }
+    }
+
+    #[test]
+    fn a_single_failure_never_pauses_the_loop() {
+        let mut backoff = AcceptBackoff::default();
+        assert!(!backoff.failed(&emfile()), "one failure is not a spin");
+        assert_eq!(backoff.pause(), None);
+    }
+
+    /// A peer that connects and resets in a loop is not a reason to stop
+    /// accepting. Counting those would let anyone throttle the listener for
+    /// everyone else by doing something every TCP stack permits.
+    #[test]
+    fn errors_about_one_connection_do_not_pace_the_loop() {
+        let mut backoff = AcceptBackoff::default();
+        let per_connection: Vec<std::io::Error> = vec![
+            ErrorKind::ConnectionAborted.into(),
+            ErrorKind::ConnectionReset.into(),
+            // `EPROTO`: `accept(2)` says to retry it like `EAGAIN`, and it
+            // reaches Rust with the same uncategorized kind `EMFILE` does.
+            #[cfg(target_os = "linux")]
+            std::io::Error::from_raw_os_error(71),
+            #[cfg(target_os = "macos")]
+            std::io::Error::from_raw_os_error(100),
+        ];
+        for _ in 0..FAILURES_BEFORE_BACKOFF {
+            for e in &per_connection {
+                assert!(!backoff.failed(e), "{e:?} concerns one connection");
+            }
+        }
+        assert_eq!(backoff.pause(), None, "a reset storm must not pause anyone");
+        assert_eq!(backoff.failures(), 0);
+    }
+
+    #[test]
+    fn the_pause_starts_at_the_minimum_and_grows_to_the_cap() {
+        let mut backoff = AcceptBackoff::default();
+        spin(&mut backoff);
+        assert!(
+            backoff.failed(&emfile()),
+            "past the threshold this is worth reporting"
+        );
+
+        assert_eq!(
+            backoff.pause(),
+            Some(RETRY_MIN),
+            "the first pause is the minimum, not twice it"
+        );
+        let mut last = RETRY_MIN;
+        for _ in 0..64 {
+            let Some(next) = backoff.pause() else {
+                panic!("a loop over its threshold must keep pausing");
+            };
+            assert!(next >= last, "the delay only grows");
+            last = next;
+        }
+        assert_eq!(last, RETRY_MAX, "and stops at the cap");
+    }
+
+    /// The pause has to end on its own, or a host that recovered would sleep
+    /// before every accept forever.
+    #[test]
+    fn a_window_with_no_failure_in_it_clears_the_pause() {
+        let mut backoff = AcceptBackoff::default();
+        spin(&mut backoff);
+        assert!(backoff.pause().is_some());
+
+        backoff.last_failure = Instant::now() - FAILURE_WINDOW;
+        assert_eq!(
+            backoff.pause(),
+            None,
+            "a quiet window means the loop recovered"
+        );
+        assert_eq!(backoff.failures(), 0);
+    }
+
+    /// Sustained failure must not clear itself. The escalating sleeps outlast a
+    /// window on their own, so ageing the window rather than the last failure
+    /// would reset mid-escalation and re-spin to the threshold every second.
+    #[test]
+    fn sustained_failure_keeps_escalating_across_windows() {
+        let mut backoff = AcceptBackoff::default();
+        spin(&mut backoff);
+        for _ in 0..12 {
+            backoff.pause();
+        }
+        let escalated = backoff.retry_delay;
+
+        // A window's worth of time passes, and the failures never stopped. Under
+        // a reset keyed on the window's age rather than the last failure, this
+        // is where the escalation would be thrown away.
+        backoff.last_failure = Instant::now() - FAILURE_WINDOW;
+        backoff.failed(&emfile());
+        assert_eq!(
+            backoff.pause(),
+            Some(escalated),
+            "a loop still failing must not be handed the minimum again"
+        );
+    }
+}

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
+use std::sync::atomic::AtomicBool;
 
 use crate::engine::abandon::{AbandonFlag, AbandonOnDrop, DispatchedCall};
 use crate::host::allowed_hosts::AllowedHost;
@@ -1311,6 +1312,12 @@ impl<T: Router, O: OutgoingHandler> Ingress<T, O> {
         self.addr
     }
 
+    /// This ingress's connection ceiling, to register with the probe listener
+    /// as a reason the host may be not-ready.
+    pub fn connection_limit(&self) -> ConnectionLimit {
+        self.connections.clone()
+    }
+
     /// The h2 (ALPN) variant of the outgoing handler's client TLS
     /// configuration, used by the gRPC egress fast path. Derived once on the
     /// first gRPC request so the per-request `ClientConfig` clone is avoided
@@ -1369,6 +1376,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         let handler = self.router.clone();
         let guest_meter = self.meters.read().await.guest();
         let connections = self.connections.clone();
+        let stopped = AcceptingGuard(connections.clone());
         tokio::spawn(async move {
             if let Err(e) = run_http_server(
                 listener,
@@ -1384,6 +1392,7 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
             {
                 error!(err = ?e, addr = ?addr, "HTTP server error");
             }
+            drop(stopped);
         });
         Ok(())
     }
@@ -1645,6 +1654,13 @@ const SHED_LOG_INTERVAL: Duration = Duration::from_secs(60);
 /// taken back.
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long an accepted connection has to produce its first request.
+///
+/// Generous, because it also covers a client that connects ahead of the traffic
+/// it is about to send. What it is not is unbounded, which is what deciding a
+/// connection's protocol otherwise is.
+const FIRST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// The ingress connection ceiling, the permits enforcing it, and the counter
 /// reporting it.
 ///
@@ -1652,9 +1668,13 @@ const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 /// is decided: the accept loop is the only place that knows a connection was
 /// offered and turned away.
 #[derive(Clone)]
-pub(crate) struct ConnectionLimit {
+pub struct ConnectionLimit {
     max: usize,
     permits: Arc<Semaphore>,
+    /// Cleared when the accept loop returns. A ceiling with every permit free is
+    /// indistinguishable from a listener that stopped accepting, and the second
+    /// is the more urgent of the two.
+    accepting: Arc<AtomicBool>,
     offered: opentelemetry::metrics::Counter<u64>,
     /// Built once. `error.type` marks the refusals inside the one series, so a
     /// shed rate is a filter on it rather than a second counter to keep in step.
@@ -1662,10 +1682,11 @@ pub(crate) struct ConnectionLimit {
 }
 
 impl ConnectionLimit {
-    pub(crate) fn new(max: usize) -> Self {
+    pub fn new(max: usize) -> Self {
         Self {
             max,
             permits: Arc::new(Semaphore::new(max)),
+            accepting: Arc::new(AtomicBool::new(true)),
             offered: opentelemetry::global::meter("wash-runtime")
                 .u64_counter("http.ingress.connections")
                 .with_description(
@@ -1676,12 +1697,16 @@ impl ConnectionLimit {
         }
     }
 
+    /// Record that the accept loop is no longer running.
+    fn stopped_accepting(&self) {
+        self.accepting
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Take a slot for an accepted connection, or `None` at the ceiling.
     ///
-    /// Counted either way, and with no attribute naming who was refused: a
-    /// connection is turned away before its first request names a workload, and
-    /// its peer address is invented by traffic — so there is nothing bounded to
-    /// split the series by.
+    /// Counted either way, with no attribute naming who was refused: a
+    /// connection is turned away before its first request names a workload.
     fn take(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
         match Arc::clone(&self.permits).try_acquire_owned() {
             Ok(permit) => {
@@ -1693,6 +1718,49 @@ impl ConnectionLimit {
                 None
             }
         }
+    }
+}
+
+impl std::fmt::Debug for ConnectionLimit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionLimit")
+            .field("max", &self.max)
+            .field("available", &self.permits.available_permits())
+            .finish()
+    }
+}
+
+/// A full ingress is a reason to stop being sent work, and not a reason to be
+/// restarted.
+///
+/// Shedding keeps the host reachable, which means it keeps passing a TCP probe
+/// — so without this its endpoint stays in the Service and traffic keeps
+/// arriving for it to refuse. Readiness is what moves that traffic to a replica
+/// with capacity.
+impl crate::host::probes::ReadinessCheck for ConnectionLimit {
+    fn name(&self) -> &'static str {
+        if self.accepting.load(std::sync::atomic::Ordering::Relaxed) {
+            "http_ingress_saturated"
+        } else {
+            "http_ingress_stopped"
+        }
+    }
+
+    fn ready(&self) -> bool {
+        self.accepting.load(std::sync::atomic::Ordering::Relaxed)
+            && self.permits.available_permits() > 0
+    }
+}
+
+/// Clears [`ConnectionLimit`]'s accepting flag however the accept loop ends.
+///
+/// A guard rather than a statement after the await: a panicking task unwinds
+/// past the statement, leaving readiness reporting a healthy idle host.
+struct AcceptingGuard(ConnectionLimit);
+
+impl Drop for AcceptingGuard {
+    fn drop(&mut self) {
+        self.0.stopped_accepting();
     }
 }
 
@@ -1775,7 +1843,10 @@ async fn run_http_server<T: Router>(
                             // Held for the connection's life: its descriptor is
                             // only given back once hyper is done with it.
                             let _slot = slot;
+                            let requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                            let first_request = Arc::clone(&requested);
                             let service = hyper::service::service_fn(move |req| {
+                                first_request.store(true, std::sync::atomic::Ordering::Relaxed);
                                 let handles = handles_clone.clone();
                                 let service_handlers = service_handlers_clone.clone();
                                 let handler = handler_clone.clone();
@@ -1790,10 +1861,10 @@ async fn run_http_server<T: Router>(
                             });
 
                             let mut builder = auto::Builder::new(TokioExecutor::new());
-                            // The timer is what arms hyper's header-read
-                            // timeout; without one a peer that opens a
-                            // connection and sends nothing holds its slot for
-                            // as long as it likes.
+                            // Arms hyper's own header-read timeout, which
+                            // bounds a peer dribbling headers once its protocol
+                            // is known. Deciding that protocol is bounded
+                            // separately, below.
                             builder
                                 .http1()
                                 .timer(TokioTimer::new())
@@ -1803,7 +1874,8 @@ async fn run_http_server<T: Router>(
                                 .timer(TokioTimer::new())
                                 .keep_alive_interval(Some(Duration::from_secs(20)));
 
-                            let result = if let Some(acceptor) = tls_acceptor_clone {
+                            let serve = async {
+                            if let Some(acceptor) = tls_acceptor_clone {
                                 // Handle HTTPS connection. Bounded, because a
                                 // handshake nobody finishes holds a connection
                                 // slot that no request will ever release.
@@ -1814,7 +1886,7 @@ async fn run_http_server<T: Router>(
                                 match handshake.await {
                                     Err(_) => {
                                         warn!(addr = ?client_addr, "TLS handshake timed out");
-                                        return;
+                                        Ok(())
                                     }
                                     Ok(Ok(tls_stream)) => {
                                         builder
@@ -1823,7 +1895,7 @@ async fn run_http_server<T: Router>(
                                     }
                                     Ok(Err(e)) => {
                                         error!(addr = ?client_addr, err = ?e, "TLS handshake failed");
-                                        return;
+                                        Ok(())
                                     }
                                 }
                             } else {
@@ -1831,6 +1903,27 @@ async fn run_http_server<T: Router>(
                                 builder
                                     .serve_connection_with_upgrades(TokioIo::new(client), service)
                                     .await
+                            }
+                            };
+
+                            // A connection earns its slot by asking for
+                            // something: sniffing its protocol is bounded by
+                            // nothing, so a peer sending half an HTTP/2 preface
+                            // would hold one forever.
+                            let mut serve = std::pin::pin!(serve);
+                            let mut deadline = std::pin::pin!(tokio::time::sleep(FIRST_REQUEST_TIMEOUT));
+                            let mut expired = false;
+                            let result = loop {
+                                tokio::select! {
+                                    result = &mut serve => break result,
+                                    () = &mut deadline, if !expired => {
+                                        expired = true;
+                                        if !requested.load(std::sync::atomic::Ordering::Relaxed) {
+                                            debug!(addr = ?client_addr, "closing a connection that sent no request");
+                                            return;
+                                        }
+                                    }
+                                }
                             };
 
                             if let Err(e) = result {
@@ -3034,7 +3127,12 @@ mod tests {
         match closed.expect("a connection past the ceiling must be closed, not left hanging") {
             Ok(0) => {}
             // The kernel answers unread bytes with an RST rather than a FIN.
-            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => {}
+            // Windows reports that as `ConnectionAborted` (WSAECONNABORTED).
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                ) => {}
             Ok(n) => {
                 panic!("the ceiling was not enforced: the shed connection was served {n} bytes")
             }
@@ -3043,6 +3141,69 @@ mod tests {
 
         let _ = shutdown_tx.send(()).await;
         let _ = tokio::time::timeout(Duration::from_secs(5), server).await;
+    }
+
+    /// Wait for the ingress to reach `want` free permits, or fail saying what it
+    /// reached instead. Bounded well past `FIRST_REQUEST_TIMEOUT` so a paused
+    /// clock advances through the deadline under test.
+    async fn await_permits(limit: &ConnectionLimit, want: usize, why: &str) {
+        for _ in 0..2_000 {
+            if limit.permits.available_permits() == want {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!(
+            "{why}: permits stayed at {}",
+            limit.permits.available_permits()
+        );
+    }
+
+    /// A connection that never asks for anything must give its slot back.
+    ///
+    /// hyper decides h1 vs h2 by reading up to 24 preface bytes, and that read
+    /// has no timeout of its own — a peer sending nothing, or half a preface,
+    /// parks there. Holding a ceiling slot the whole time turns a handful of
+    /// silent peers into a host that reports itself full, which the readiness
+    /// check then reports to Kubernetes as a reason to take it out of service.
+    #[tokio::test(start_paused = true)]
+    async fn a_connection_that_never_speaks_gives_its_slot_back() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (_shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
+        let limit = ConnectionLimit::new(1);
+
+        let served = limit.clone();
+        tokio::spawn(async move {
+            run_http_server(
+                listener,
+                Arc::new(DevRouter::default()),
+                WorkloadHandles::default(),
+                ServiceHandlers::default(),
+                &mut shutdown_rx,
+                None,
+                Meters::default().guest(),
+                served,
+            )
+            .await
+        });
+
+        // Half an HTTP/2 preface: enough that the connection is not idle, not
+        // enough for hyper to decide what it is.
+        let mut silent = TcpStream::connect(addr).await.unwrap();
+        silent.write_all(b"PRI * HTTP/2.0").await.unwrap();
+
+        // Polled rather than slept on: the paused clock advances the moment this
+        // task idles, which can be before the OS has delivered accept readiness.
+        await_permits(&limit, 0, "the silent connection should hold the only slot").await;
+        await_permits(
+            &limit,
+            1,
+            "a connection that sent no request must not hold its slot forever",
+        )
+        .await;
     }
 
     // --- check_allowed_hosts tests ---

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1637,21 +1637,6 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
     }
 }
 
-/// How many `accept` failures within [`ACCEPT_FAILURE_WINDOW`] mean the loop is
-/// spinning rather than meeting the occasional bad connection.
-///
-/// Counted per window rather than consecutively: descriptor exhaustion under
-/// churn lets the odd `accept` succeed, and a consecutive count resets on each
-/// one and never notices. A busy server sheds a handful of half-open
-/// connections a second; a spinning one reaches this in milliseconds.
-const ACCEPT_FAILURES_PER_WINDOW: u32 = 1024;
-const ACCEPT_FAILURE_WINDOW: Duration = Duration::from_secs(1);
-
-/// How long the loop pauses once `accept` is failing persistently, and how far
-/// that grows. The cap bounds how long the listener leaves its backlog alone.
-const ACCEPT_RETRY_MIN: Duration = Duration::from_millis(5);
-const ACCEPT_RETRY_MAX: Duration = Duration::from_secs(1);
-
 /// How often a saturated ingress says so. Reporting each shed connection would
 /// make the log the load problem.
 const SHED_LOG_INTERVAL: Duration = Duration::from_secs(60);
@@ -1736,27 +1721,13 @@ async fn run_http_server<T: Router>(
     guest_meter: GuestMeter,
     connections: ConnectionLimit,
 ) -> anyhow::Result<()> {
-    let mut failures: u32 = 0;
-    let mut window = std::time::Instant::now();
-    let mut retry_delay = ACCEPT_RETRY_MIN;
+    let mut backoff = crate::host::accept::AcceptBackoff::default();
     let mut shed = 0u64;
     let mut shed_reported: Option<std::time::Instant> = None;
     loop {
-        // A window that ends without tripping the threshold is the loop working
-        // again, and is the only thing that clears the pause.
-        if window.elapsed() >= ACCEPT_FAILURE_WINDOW {
-            window = std::time::Instant::now();
-            failures = 0;
-            retry_delay = ACCEPT_RETRY_MIN;
-        }
         // Taken before the select rather than inside it, so the pause races the
-        // shutdown branch instead of needing a second copy of it. Doubling here
-        // rather than on the failure is what makes the first pause the minimum.
-        let pause = (failures > ACCEPT_FAILURES_PER_WINDOW).then(|| {
-            let taken = retry_delay;
-            retry_delay = (retry_delay * 2).min(ACCEPT_RETRY_MAX);
-            taken
-        });
+        // shutdown branch instead of needing a second copy of it.
+        let pause = backoff.pause();
         tokio::select! {
             // Handle shutdown signal
             _ = shutdown_rx.recv() => {
@@ -1868,11 +1839,10 @@ async fn run_http_server<T: Router>(
                         });
                     }
                     Err(e) => {
-                        failures = failures.saturating_add(1);
-                        if failures <= ACCEPT_FAILURES_PER_WINDOW {
-                            debug!(err = ?e, "failed to accept HTTP connection");
+                        if backoff.failed(&e) {
+                            error!(err = ?e, failures = backoff.failures(), "HTTP ingress cannot accept connections");
                         } else {
-                            error!(err = ?e, failures, "HTTP ingress cannot accept connections");
+                            debug!(err = ?e, "failed to accept HTTP connection");
                         }
                     }
                 }
@@ -3023,33 +2993,6 @@ mod tests {
         assert!(
             server.nodelay().unwrap(),
             "run_http_server must set TCP_NODELAY on accepted connections"
-        );
-    }
-
-    /// The backoff triggers on a rate of failure, not on a kind of failure and
-    /// not on a run of them.
-    ///
-    /// `accept` also reports errors belonging to the single connection it
-    /// dequeued, so pausing the listener for one would be the bug in reverse —
-    /// and descriptor exhaustion under churn lets the odd call through, which a
-    /// consecutive count would keep resetting on.
-    #[test]
-    fn the_pause_is_paced_by_the_failure_rate() {
-        // The sequence the loop walks: the pause is taken, then doubled, so the
-        // first one it sleeps is the minimum rather than twice it.
-        let mut delay = ACCEPT_RETRY_MIN;
-        let mut steps = 0;
-        while delay < ACCEPT_RETRY_MAX && steps < 64 {
-            delay = (delay * 2).min(ACCEPT_RETRY_MAX);
-            steps += 1;
-        }
-        assert_eq!(
-            delay, ACCEPT_RETRY_MAX,
-            "the delay has to reach its cap and stop there"
-        );
-        assert!(
-            ACCEPT_FAILURES_PER_WINDOW > 1,
-            "one dequeued-connection error must not pause the listener"
         );
     }
 

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -59,6 +59,7 @@ use crate::plugin::{HostPlugin, WorkloadFailure, WorkloadFailureSink};
 use crate::types::*;
 use crate::wit::{WitInterface, WitWorld};
 
+pub(crate) mod accept;
 pub mod allowed_loopback;
 pub mod declared_port;
 pub mod egress_policy;

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -64,6 +64,7 @@ pub mod allowed_loopback;
 pub mod declared_port;
 pub mod egress_policy;
 pub mod ports;
+pub mod probes;
 pub mod quota;
 pub(crate) mod sysinfo;
 use sysinfo::SystemMonitor;

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -1,0 +1,466 @@
+//! The host's probe listener: liveness and readiness, on a port of their own.
+//!
+//! A `tcpSocket` probe against the traffic port asks whether there is room in
+//! the listen backlog, which the kernel answers whether or not the process is
+//! running. This listener answers from what the host knows about itself.
+//!
+//! `/livez` is "restart me" and fails only when the command loop has stopped —
+//! the cure costs every workload on the host. `/readyz` is "stop sending me
+//! work" and fails while starting, while draining, and while the ingress is at
+//! its ceiling, which a TCP probe cannot express at all.
+
+use core::time::Duration;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+use anyhow::Context as _;
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::{TokioIo, TokioTimer};
+use tokio::net::TcpListener;
+use tracing::{debug, error, info, warn};
+
+use crate::host::accept::AcceptBackoff;
+
+/// Paths this listener answers. Anything else is a 404, so a misconfigured
+/// probe fails loudly rather than passing against the wrong endpoint.
+const LIVEZ: &str = "/livez";
+const READYZ: &str = "/readyz";
+
+/// How long a peer has to send its request line and headers.
+const HEADER_READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Connections this listener will hold at once.
+///
+/// It needs a ceiling because its port is reachable from the whole cluster and
+/// spends the same descriptors the ingress ceiling is a share of. It needs a
+/// generous one, and connections that end quickly, because shedding here costs
+/// the kubelet its probe and the host a restart — see [`CONNECTION_TIMEOUT`].
+const MAX_PROBE_CONNECTIONS: usize = 512;
+
+/// How long one probe connection may live. Each serves a single request and
+/// closes, so holding a slot open is not something a caller has a reason to do.
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A monotonic "still turning" signal, beaten by whatever owns the host's main
+/// loop.
+///
+/// Held as milliseconds since this was built rather than as an `Instant`, so a
+/// beat is one relaxed store on a loop that runs for the life of the host.
+/// [`NEVER_BEATEN`] separates "has not started" from "has stopped": startup is
+/// readiness's to report, and restarting a host for being slow to start is how
+/// a slow start becomes a crash loop.
+#[derive(Debug)]
+pub struct Liveness {
+    start: Instant,
+    last_beat_ms: AtomicU64,
+    max_silence: Duration,
+}
+
+/// `last_beat_ms` before the first beat. No real elapsed-millis reading can
+/// collide with it.
+const NEVER_BEATEN: u64 = u64::MAX;
+
+impl Liveness {
+    /// A signal that goes stale after `max_silence` without a beat.
+    ///
+    /// Size it well above whatever paces the loop being watched: the point is
+    /// to catch a loop that has stopped, not one that is between ticks.
+    pub fn new(max_silence: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            start: Instant::now(),
+            last_beat_ms: AtomicU64::new(NEVER_BEATEN),
+            max_silence,
+        })
+    }
+
+    /// Record that the loop turned.
+    pub fn beat(&self) {
+        let elapsed = self
+            .start
+            .elapsed()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        self.last_beat_ms.store(elapsed, Ordering::Relaxed);
+    }
+
+    /// How long since the last beat, or `None` before the first.
+    pub fn silence(&self) -> Option<Duration> {
+        match self.last_beat_ms.load(Ordering::Relaxed) {
+            NEVER_BEATEN => None,
+            last => Some(
+                self.start
+                    .elapsed()
+                    .saturating_sub(Duration::from_millis(last)),
+            ),
+        }
+    }
+
+    fn alive(&self) -> bool {
+        self.silence()
+            .is_none_or(|silence| silence <= self.max_silence)
+    }
+}
+
+/// Something the host can be not-ready because of.
+///
+/// Readiness is a claim about whether more work should be sent here, so every
+/// implementor answers for one reason it should not be.
+pub trait ReadinessCheck: Send + Sync + std::fmt::Debug {
+    /// Named in the `/readyz` body, so an operator reading a probe failure
+    /// learns which condition failed without reaching for the logs.
+    fn name(&self) -> &'static str;
+
+    /// `true` when this check is satisfied.
+    fn ready(&self) -> bool;
+}
+
+/// The state [`serve`] reports, and the handle a host drives it through.
+#[derive(Clone, Debug, Default)]
+pub struct ProbeState {
+    liveness: Option<Arc<Liveness>>,
+    started: Arc<AtomicBool>,
+    draining: Arc<AtomicBool>,
+    checks: Vec<Arc<dyn ReadinessCheck>>,
+}
+
+impl ProbeState {
+    /// Watch `liveness` for `/livez`. Without one, `/livez` reports alive
+    /// whenever the listener can answer at all — still stronger than a TCP
+    /// probe, which the kernel answers whether or not the runtime is running.
+    #[must_use]
+    pub fn with_liveness(mut self, liveness: Arc<Liveness>) -> Self {
+        self.liveness = Some(liveness);
+        self
+    }
+
+    /// Add a reason the host may be not-ready.
+    #[must_use]
+    pub fn with_readiness(mut self, check: Arc<dyn ReadinessCheck>) -> Self {
+        self.checks.push(check);
+        self
+    }
+
+    /// Report ready-if-nothing-else-objects from now on.
+    ///
+    /// Until this is called `/readyz` refuses, because the listener binds before
+    /// the host is subscribed to its command subject and before any workload is
+    /// placed. Reporting ready in that window puts the pod in the Service with
+    /// no routes behind it.
+    pub fn started(&self) {
+        self.started.store(true, Ordering::Relaxed);
+    }
+
+    /// Report not-ready from now on, without touching liveness.
+    ///
+    /// Called when the host starts draining: the endpoint should leave the
+    /// Service while in-flight requests finish, and a host that answered
+    /// `/livez` with a failure instead would be killed mid-drain.
+    pub fn drain(&self) {
+        self.draining.store(true, Ordering::Relaxed);
+    }
+
+    fn live(&self) -> bool {
+        self.liveness.as_ref().is_none_or(|l| l.alive())
+    }
+
+    /// The checks currently refusing, empty when the host is ready.
+    fn not_ready(&self) -> Vec<&'static str> {
+        if self.draining.load(Ordering::Relaxed) {
+            return vec!["draining"];
+        }
+        if !self.started.load(Ordering::Relaxed) {
+            return vec!["starting"];
+        }
+        self.checks
+            .iter()
+            .filter(|check| !check.ready())
+            .map(|check| check.name())
+            .collect()
+    }
+}
+
+fn text(status: StatusCode, body: impl Into<Bytes>) -> Response<Full<Bytes>> {
+    let mut response = Response::new(Full::new(body.into()));
+    *response.status_mut() = status;
+    response
+}
+
+fn answer(state: &ProbeState, req: &Request<hyper::body::Incoming>) -> Response<Full<Bytes>> {
+    match req.uri().path() {
+        LIVEZ if state.live() => text(StatusCode::OK, "ok\n"),
+        LIVEZ => text(StatusCode::SERVICE_UNAVAILABLE, "stalled\n"),
+        READYZ => match state.not_ready() {
+            reasons if reasons.is_empty() => text(StatusCode::OK, "ok\n"),
+            reasons => text(
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("{}\n", reasons.join(",")),
+            ),
+        },
+        _ => text(StatusCode::NOT_FOUND, "not found\n"),
+    }
+}
+
+/// Bind the probe listener, before the host takes work.
+///
+/// Separate from [`serve`] because a port already taken leaves every probe
+/// failing, and that has to fail the command rather than a background task.
+pub async fn bind(addr: SocketAddr) -> anyhow::Result<TcpListener> {
+    TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind the probe listener on {addr}"))
+}
+
+/// Serve an already-bound probe listener until `shutdown` resolves.
+///
+/// Its own accept loop rather than a route on the ingress, so saturating the
+/// data plane cannot starve the answer to "is this host alive", and paced by the
+/// same [`AcceptBackoff`]: whatever exhausts the process's descriptors exhausts
+/// them for both listeners.
+pub async fn serve(
+    listener: TcpListener,
+    state: ProbeState,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) {
+    if let Ok(bound) = listener.local_addr() {
+        info!(addr = %bound, "probe server listening");
+    }
+
+    let connections = Arc::new(tokio::sync::Semaphore::new(MAX_PROBE_CONNECTIONS));
+    let mut backoff = AcceptBackoff::default();
+    let mut shutdown = std::pin::pin!(shutdown);
+    loop {
+        let pause = backoff.pause();
+        tokio::select! {
+            () = &mut shutdown => {
+                info!("probe server received shutdown signal");
+                return;
+            }
+            accepted = async {
+                if let Some(pause) = pause {
+                    tokio::time::sleep(pause).await;
+                }
+                listener.accept().await
+            } => {
+                let (client, peer) = match accepted {
+                    Ok(accepted) => accepted,
+                    Err(e) => {
+                        if backoff.failed(&e) {
+                            error!(err = ?e, failures = backoff.failures(), "probe server cannot accept connections");
+                        } else {
+                            debug!(err = ?e, "failed to accept a probe connection");
+                        }
+                        continue;
+                    }
+                };
+                let Ok(slot) = Arc::clone(&connections).try_acquire_owned() else {
+                    debug!(addr = ?peer, "probe listener at its ceiling; closing");
+                    drop(client);
+                    continue;
+                };
+                let state = state.clone();
+                tokio::spawn(async move {
+                    let _slot = slot;
+                    let service = service_fn(move |req| {
+                        let response = answer(&state, &req);
+                        async move { Ok::<_, std::convert::Infallible>(response) }
+                    });
+                    let mut builder = hyper::server::conn::http1::Builder::new();
+                    builder
+                        .timer(TokioTimer::new())
+                        .header_read_timeout(HEADER_READ_TIMEOUT)
+                        // One request per connection: a slot held open is a
+                        // slot the kubelet cannot have.
+                        .keep_alive(false);
+                    let served = tokio::time::timeout(
+                        CONNECTION_TIMEOUT,
+                        builder.serve_connection(TokioIo::new(client), service),
+                    );
+                    match served.await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => warn!(addr = ?peer, err = ?e, "error serving a probe request"),
+                        Err(_) => debug!(addr = ?peer, "probe connection timed out"),
+                    }
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct Gate {
+        name: &'static str,
+        ready: AtomicBool,
+    }
+
+    impl ReadinessCheck for Gate {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn ready(&self) -> bool {
+            self.ready.load(Ordering::Relaxed)
+        }
+    }
+
+    fn gate(name: &'static str, ready: bool) -> Arc<Gate> {
+        Arc::new(Gate {
+            name,
+            ready: AtomicBool::new(ready),
+        })
+    }
+
+    /// The distinction the TCP probe cannot make: a host at its ceiling is
+    /// still alive — restarting it would lose every workload on it — but it
+    /// must stop being sent work, or the Service keeps routing to a host that
+    /// sheds everything it is offered.
+    #[test]
+    fn a_saturated_host_is_live_but_not_ready() {
+        let saturated = gate("http_ingress_saturated", false);
+        let state = ProbeState::default().with_readiness(saturated);
+        state.started();
+
+        assert!(state.live(), "saturation is not a reason to restart");
+        assert_eq!(state.not_ready(), vec!["http_ingress_saturated"]);
+    }
+
+    /// Draining is the same shape and the more common one: leave the Service,
+    /// keep serving what is in flight, and do not get killed doing it.
+    #[test]
+    fn draining_is_not_ready_but_stays_live() {
+        let state = ProbeState::default().with_readiness(gate("ingress", true));
+        state.started();
+        assert!(state.not_ready().is_empty());
+
+        state.drain();
+        assert_eq!(state.not_ready(), vec!["draining"]);
+        assert!(state.live(), "a draining host must not be restarted");
+    }
+
+    /// Every refusing check is named, so a probe failure says which without
+    /// needing the logs — and draining answers alone, since once the host is
+    /// going away the rest is noise.
+    #[test]
+    fn readiness_names_what_is_refusing() {
+        let state = ProbeState::default()
+            .with_readiness(gate("first", false))
+            .with_readiness(gate("second", true))
+            .with_readiness(gate("third", false));
+        state.started();
+        assert_eq!(state.not_ready(), vec!["first", "third"]);
+
+        state.drain();
+        assert_eq!(state.not_ready(), vec!["draining"]);
+    }
+
+    /// The listener binds before the host has a NATS subscription or a single
+    /// workload, so until the host says it started, readiness has to refuse.
+    /// A pod that joins the Service in that window is sent traffic that nothing
+    /// is behind.
+    #[test]
+    fn a_host_that_has_not_started_is_not_ready() {
+        let state = ProbeState::default().with_readiness(gate("ingress", true));
+        assert_eq!(state.not_ready(), vec!["starting"]);
+        assert!(state.live(), "starting is not a reason to restart");
+
+        state.started();
+        assert!(state.not_ready().is_empty());
+    }
+
+    /// The whole point of the probe listener over a `tcpSocket` probe:
+    /// answering needs the runtime to schedule a task, not just the kernel to
+    /// complete a handshake. Driven over a real socket so the routing, the
+    /// status codes and the 404 for a mistyped path are all pinned.
+    #[tokio::test]
+    async fn the_listener_answers_both_paths_over_a_socket() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let saturated = gate("http_ingress_saturated", true);
+        let state =
+            ProbeState::default().with_readiness(Arc::clone(&saturated) as Arc<dyn ReadinessCheck>);
+        let (stop, stopped) = tokio::sync::oneshot::channel::<()>();
+
+        // Port 0, so this test does not fight whatever else is running.
+        let listener = bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let served = state.clone();
+        served.started();
+        tokio::spawn(async move {
+            let _ = serve(listener, served, async {
+                let _ = stopped.await;
+            })
+            .await;
+        });
+
+        async fn get(addr: SocketAddr, path: &str) -> String {
+            for _ in 0..50 {
+                let Ok(mut conn) = tokio::net::TcpStream::connect(addr).await else {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    continue;
+                };
+                let request =
+                    format!("GET {path} HTTP/1.1\r\nHost: probes\r\nConnection: close\r\n\r\n");
+                conn.write_all(request.as_bytes()).await.unwrap();
+                let mut body = String::new();
+                conn.read_to_string(&mut body).await.unwrap();
+                return body;
+            }
+            panic!("probe server never came up on {addr}");
+        }
+
+        assert!(get(addr, LIVEZ).await.starts_with("HTTP/1.1 200"));
+        assert!(get(addr, READYZ).await.starts_with("HTTP/1.1 200"));
+
+        // A full ingress: still alive, no longer ready.
+        saturated.ready.store(false, Ordering::Relaxed);
+        assert!(get(addr, LIVEZ).await.starts_with("HTTP/1.1 200"));
+        let ready = get(addr, READYZ).await;
+        assert!(ready.starts_with("HTTP/1.1 503"), "{ready}");
+        assert!(ready.contains("http_ingress_saturated"), "{ready}");
+
+        // A mistyped probe path must fail rather than pass against nothing.
+        assert!(get(addr, "/healthz").await.starts_with("HTTP/1.1 404"));
+
+        let _ = stop.send(());
+    }
+
+    /// A loop that stopped turning is what `/livez` exists to catch, and the
+    /// only thing it should: a host with no liveness source registered reports
+    /// alive whenever it can answer.
+    #[test]
+    fn liveness_goes_stale_without_a_beat() {
+        let liveness = Liveness::new(Duration::from_millis(50));
+        let state = ProbeState::default().with_liveness(Arc::clone(&liveness));
+        assert!(state.live(), "a fresh signal starts alive");
+
+        // Still starting, not yet stalled: a host slow to bind plugins and pull
+        // images has not failed, and restarting it for that is how a slow start
+        // becomes a crash loop.
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(
+            state.live(),
+            "a loop that has not started yet is not stalled"
+        );
+
+        liveness.beat();
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(!state.live(), "silence past the bound is a stalled host");
+
+        liveness.beat();
+        assert!(state.live(), "a beat brings it back");
+
+        assert!(
+            ProbeState::default().live(),
+            "with nothing to watch, answering at all is the signal"
+        );
+    }
+}

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -14,6 +14,16 @@ use tracing::{debug, error, info, instrument, warn};
 pub const HOST_API_PREFIX: &str = "runtime.host";
 pub const OPERATOR_API_PREFIX: &str = "runtime.operator";
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// How long the command loop may go quiet before it counts as stopped rather
+/// than slow.
+///
+/// Three of whatever interval the host actually heartbeats on: the loop turns
+/// at least once per interval, and a restart costs every workload on the host,
+/// so this must not fire on one that is merely behind.
+pub fn liveness_silence(heartbeat_interval: Duration) -> Duration {
+    heartbeat_interval * 3
+}
 /// Most `workload.start` requests a host pulls and compiles at once, however
 /// many cores it has. Past this the images held in memory cost more than the
 /// extra parallelism buys.
@@ -68,9 +78,26 @@ pub struct ClusterHostBuilder {
     cleanup_age: Option<Duration>,
     host_config: Option<HostConfig>,
     max_concurrent_starts: Option<usize>,
+    liveness: Option<Arc<crate::host::probes::Liveness>>,
 }
 
 impl ClusterHostBuilder {
+    /// The interval this host will actually heartbeat on, resolved.
+    ///
+    /// Public so a caller sizing a liveness bound reads the number the host was
+    /// built with rather than restating a default that can move underneath it.
+    pub fn heartbeat_interval(&self) -> Duration {
+        self.heartbeat_interval.unwrap_or(HEARTBEAT_INTERVAL)
+    }
+
+    /// Beat `liveness` every time the command loop turns, so `/livez` answers
+    /// from whether this host is still servicing its control plane rather than
+    /// from whether a socket accepted.
+    pub fn with_liveness(mut self, liveness: Arc<crate::host::probes::Liveness>) -> Self {
+        self.liveness = Some(liveness);
+        self
+    }
+
     pub fn with_host_group(mut self, host_group: impl AsRef<str>) -> Self {
         self.host_group = Some(host_group.as_ref().into());
         self
@@ -221,6 +248,7 @@ impl ClusterHostBuilder {
             max_concurrent_starts: self
                 .max_concurrent_starts
                 .unwrap_or_else(default_max_concurrent_starts),
+            liveness: self.liveness,
         })
     }
 }
@@ -232,6 +260,7 @@ pub struct ClusterHost {
     cleanup_interval: Duration,
     cleanup_age: Duration,
     max_concurrent_starts: usize,
+    liveness: Option<Arc<crate::host::probes::Liveness>>,
 }
 
 impl ClusterHost {
@@ -254,6 +283,7 @@ impl ClusterHost {
         let heartbeat_interval = self.heartbeat_interval;
         let cleanup_interval = self.cleanup_interval;
         let max_concurrent_starts = self.max_concurrent_starts;
+        let liveness = self.liveness.clone();
         let host_id = host.id().to_string();
         let host = host.clone();
 
@@ -293,6 +323,13 @@ impl ClusterHost {
                 let mut oci_cleanup_timer = tokio::time::interval(cleanup_interval);
 
                 loop {
+                    // Every turn, whichever branch woke it. The heartbeat timer
+                    // alone guarantees one per interval, so silence here means
+                    // the loop itself has stopped — which is what `/livez`
+                    // reports and the only thing worth a restart.
+                    if let Some(liveness) = &liveness {
+                        liveness.beat();
+                    }
                     tokio::select! {
                         // Shutdown signal
                         _ = &mut one_shot_rx => {

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -382,7 +382,17 @@ pub struct HostCommand {
     /// Deny outbound connections to loopback, link-local (including the cloud
     /// metadata address), multicast, and documentation ranges — including
     /// whatever DNS returned for a permitted name.
-    #[arg(long = "deny-special-ranges", default_value_t = true)]
+    //
+    // Takes an optional value, unlike the default-off toggles above: presence
+    // alone cannot express "off" for something whose default is on. The bare
+    // flag still means `true`.
+    #[arg(
+        long = "deny-special-ranges",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     pub deny_special_ranges: bool,
 
     /// Deny outbound connections to private ranges (RFC1918, ULA, CGNAT).

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -349,6 +349,25 @@ pub struct HostCommand {
     #[arg(long = "oci-ca-path", env = "WASH_OCI_CA_PATHS", value_delimiter = ',')]
     pub oci_ca_paths: Vec<PathBuf>,
 
+    /// How long to keep serving after a shutdown signal, before stopping.
+    ///
+    /// A pod leaves its Service when Kubernetes marks it Terminating, but that
+    /// removal takes time to reach every kube-proxy, and a host that stops the
+    /// moment it is signalled refuses the requests still in flight toward it.
+    /// This is that gap: readiness reports the host as gone, and it keeps
+    /// answering until the delay is up.
+    ///
+    /// Must fit inside `terminationGracePeriodSeconds` alongside the command
+    /// drain that follows it, or the kernel ends the process mid-drain. Zero
+    /// stops immediately, which is what a developer pressing Ctrl-C wants.
+    #[arg(
+        long = "drain-delay",
+        env = "WASH_DRAIN_DELAY",
+        value_parser = humantime::parse_duration,
+        default_value = "0s"
+    )]
+    pub drain_delay: Duration,
+
     /// Timeout for pulling artifacts from OCI registries
     #[arg(long = "registry-pull-timeout", value_parser = humantime::parse_duration, default_value = "30s")]
     pub registry_pull_timeout: Duration,
@@ -998,11 +1017,15 @@ impl CliCommand for HostCommand {
 
         shutdown.await;
 
-        // Before the drain below, not after: readiness has to go red while the
-        // host is still serving, so its endpoint leaves the Service and the
-        // in-flight requests are the last ones it sees.
+        // Reported before the wait, not after: the point of the wait is that
+        // the host is still serving while everything upstream learns it is
+        // going away.
         if let Some(state) = &probe_state {
             state.drain();
+        }
+        if !self.drain_delay.is_zero() {
+            info!(delay = ?self.drain_delay, "Draining...");
+            tokio::time::sleep(self.drain_delay).await;
         }
 
         info!("Stopping host...");

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -10,6 +10,7 @@ use wash_runtime::{
 };
 
 use crate::cli::{CliCommand, CliContext, CommandOutput, signal};
+
 use crate::config::{HttpClientTrustRoots, load_config};
 
 #[derive(Debug, Clone, Args)]
@@ -123,6 +124,15 @@ pub struct HostCommand {
     /// concurrency, kept inside the process's file-descriptor limit.
     #[arg(long = "max-connections", env = "WASH_MAX_CONNECTIONS")]
     pub max_connections: Option<usize>,
+
+    /// Address for the probe listener serving `/livez` and `/readyz`.
+    ///
+    /// Point Kubernetes probes here rather than at `--http-addr`. A TCP probe
+    /// against the traffic port cannot tell a wedged host from a busy one — the
+    /// kernel answers the handshake either way — and cannot express "full, send
+    /// work elsewhere" at all. Unset, no probe listener is started.
+    #[arg(long = "probe-addr", env = "WASH_PROBE_ADDR")]
+    pub probe_addr: Option<SocketAddr>,
 
     /// Cap on the TCP connections accepted on `--http-addr` at once.
     ///
@@ -809,10 +819,21 @@ impl CliCommand for HostCommand {
             cluster_host_builder = cluster_host_builder.with_max_concurrent_starts(starts);
         }
 
+        // Sized off the interval this host will actually heartbeat on, not off a
+        // number restated here: the bound decides when a host is restarted, and
+        // it has to move if the interval does.
+        let liveness = wash_runtime::host::probes::Liveness::new(
+            wash_runtime::washlet::liveness_silence(cluster_host_builder.heartbeat_interval()),
+        );
+        cluster_host_builder = cluster_host_builder.with_liveness(Arc::clone(&liveness));
+
         // One publishing context for the whole host: workloads and plugins
         // reserve from the same table, so a collision between them is a start
         // failure naming both rather than two listeners that each think they
         // own the address.
+        // Taken while the ingress is built, so the probe listener below can
+        // report a full ingress as a reason to stop being sent work.
+        let mut ingress_connections = None;
         if let Some(addr) = self.http_addr {
             let http_router = wash_runtime::host::http::DynamicRouter::default();
 
@@ -845,6 +866,7 @@ impl CliCommand for HostCommand {
                 ingress_builder = ingress_builder.tls(tls);
             }
             let ingress = ingress_builder.build().await?;
+            ingress_connections = Some(ingress.connection_limit());
             cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(ingress));
         }
 
@@ -938,15 +960,55 @@ impl CliCommand for HostCommand {
         // The host is about to start taking work, so from here a signal runs
         // the shutdown below rather than ending the process.
         let shutdown = shutdown.ready();
+
+        let probe = self.probe_addr.map(|addr| {
+            let mut state =
+                wash_runtime::host::probes::ProbeState::default().with_liveness(liveness);
+            if let Some(connections) = ingress_connections {
+                state = state.with_readiness(Arc::new(connections));
+            }
+            (addr, state)
+        });
+        let (probe_stop, probe_stopped) = tokio::sync::oneshot::channel::<()>();
+        let probe_state = probe.as_ref().map(|(_, state)| state.clone());
+        if let Some((addr, state)) = probe {
+            // Bound here rather than inside the task: a port already taken
+            // leaves every probe failing, and a pod restart-looping for a
+            // reason buried in startup output is worse than not starting.
+            let listener = wash_runtime::host::probes::bind(addr).await?;
+            tokio::spawn(async move {
+                let stop = async {
+                    let _ = probe_stopped.await;
+                };
+                wash_runtime::host::probes::serve(listener, state, stop).await;
+            });
+        }
+
         let host_cleanup = wash_runtime::washlet::run_cluster_host(cluster_host)
             .await
             .context("failed to start cluster node")?;
 
+        // Only now: the listener has been answering `/readyz` with "starting"
+        // since it bound, because until this returns the host has no
+        // subscription and no workloads, and a pod that joins the Service in
+        // that window is sent traffic nothing is behind.
+        if let Some(state) = &probe_state {
+            state.started();
+        }
+
         shutdown.await;
+
+        // Before the drain below, not after: readiness has to go red while the
+        // host is still serving, so its endpoint leaves the Service and the
+        // in-flight requests are the last ones it sees.
+        if let Some(state) = &probe_state {
+            state.drain();
+        }
 
         info!("Stopping host...");
 
         host_cleanup.await?;
+        let _ = probe_stop.send(());
 
         Ok(CommandOutput::ok(
             "Host exited successfully".to_string(),

--- a/runtime-gateway/proxy_test.go
+++ b/runtime-gateway/proxy_test.go
@@ -86,7 +86,7 @@ func TestStartWaitsForInFlightRequests(t *testing.T) {
 			responded <- proxiedResponse{err: err}
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		// Read it out so the connection goes idle and the drain can finish.
 		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			responded <- proxiedResponse{err: err}

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -473,6 +473,14 @@ func buildBaseHelmSets() []string {
 			fmt.Sprintf("runtime.image.tag=%s", runtimeImageTag),
 			"runtime.image.pull_policy=IfNotPresent",
 			"gateway.image.tag=canary",
+			// Chart features whose host flags are not in canary yet. This path
+			// runs whatever upstream last published, so it cannot enable a
+			// flag added on the branch: `wash host` exits on an argument it
+			// does not know, and the pod never starts. Drop an entry here once
+			// its flag has merged. `BUILD_RUNTIME_IMAGE=true` runs the
+			// branch's own host and exercises them.
+			"runtime.probes.endpoint.enabled=false",
+			"runtime.drainDelaySeconds=0",
 		)
 	}
 	return sets


### PR DESCRIPTION
This is a follow on to #5529 where we identified a place where descriptor exhaustion may happen and cause a host to stop responding.

This change exposes liveness and readiness on their own port.

A host at its ingress ceiling accepts each connection and closes it, so it stays reachable rather than going silent. That means it keeps passing a TCP connect, so its endpoint stays in the Service and Kubernetes keeps routing traffic to a host shedding 100% of traffic. Nothing in a `tcpSocket` probe can express "I am full, send work elsewhere." `/livez` and `/readyz` are now surfaced on a dedicated listener.

| | `/livez` | `/readyz` |
| --- | --- | --- |
| Means | restart me | stop sending me work |
| Fails when | the command loop stopped turning | draining, or the ingress is at its ceiling |
| Cost of a false positive | every workload on the host is lost and the scheduler places them all at once | traffic moves to a replica with room |

`/livez` is backed by a `Liveness` signal the washlet command loop beats every turn. The heartbeat timer guarantees one beat per interval (15s), so silence past 45s means the loop itself has stopped and not that it or a workload is slow.

`/readyz` fails while draining, and while the ingress connection ceiling is exhausted. This is a major improvement over the TCP probe where we can respond with 429 once the host is saturated. Every refusing check is named in the `/readyz` body, so a probe failure says *which* condition failed without reaching for the logs.

Draining is reported **before** the host stops rather than after, so the endpoint leaves the Service while the host is still serving and the in-flight requests are the last ones it sees.

## Chart

The chart had a `runtime.hostGroups[].networking` block but no template read any of values. They are rendered now, plus `maxHttpIngressConnections` for the ceiling. `--deny-special-ranges` had to be fixed before its key could work: a bare `bool` is a presence flag, so a flag defaulting to *on* could never be turned off, and `denySpecialRanges: false` would have rendered an argument the host refused to parse. It now takes an optional value, and the bare form still means `true`.

`runtime.probes.endpoint` (on by default, port 8081) is a sibling of `probes.liveness` and `probes.readiness`, so it merges through the same per-field helper.

The probes then target it with `httpGet`. With it off they fall back to the TCP connect on `http.port`, so nothing changes for anyone who leaves it disabled. Verified by rendering with every networking key set and parsing the result with the host binary, which is what caught the `--deny-special-ranges` bug.

The NetworkPolicy opens the admin port.

## Not in this PR

**No metrics on the admin port.** It answers two paths and 404s everything else; `/metrics` would be a natural third but is a separate decision about what a host exposes unauthenticated.
