### PR TITLE
instance pool refactor

### DIFF
--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -428,18 +428,35 @@ impl Accepts {
 }
 
 impl InstanceDriver {
-    /// Build an instantiated store's driver and start it. The caller
-    /// instantiates, so a component that fails to do so reports that failure
-    /// where it can still be returned to whoever asked for the call.
+    /// Build an instantiated store's driver and start it, to serve `job`
+    /// first. The caller instantiates, so a component that fails to do so
+    /// reports that failure where it can still be returned to whoever asked
+    /// for the call.
+    ///
+    /// An instance that does not export what `job` needs comes straight back
+    /// instead: parking it would leave a warm instance that could only ever
+    /// refuse this kind of call, and every later one of the kind would spawn
+    /// another beside it.
     pub(crate) fn spawn(
         instance: ComponentInstance,
+        job: &InstanceJob,
         max_concurrency: usize,
         max_invocations: Option<usize>,
-    ) -> Self {
+    ) -> Result<Self, ComponentInstance> {
         let ComponentInstance {
             mut store,
             instance,
         } = instance;
+
+        // Built before the run loop so admission knows what this instance can
+        // take at all, rather than accepting work it could only drop. The views
+        // move into the run loop; admission keeps only their presence.
+        let bound = BoundExports::bind(&mut store, &instance);
+        let accepts = bound.accepts();
+        if !accepts.takes(job) {
+            return Err(ComponentInstance { store, instance });
+        }
+
         let (tx, mut rx) =
             tokio::sync::mpsc::channel::<(InstanceJob, InFlightGuard)>(max_concurrency.max(1));
         let state = Arc::new(DriverState {
@@ -448,12 +465,6 @@ impl InstanceDriver {
             drained: tokio::sync::Notify::new(),
         });
         let task_state = Arc::clone(&state);
-
-        // Built before the run loop so admission knows what this instance can
-        // take at all, rather than accepting work it could only drop. The views
-        // move into the run loop; admission keeps only their presence.
-        let bound = BoundExports::bind(&mut store, &instance);
-        let accepts = bound.accepts();
 
         tokio::spawn(async move {
             // One `run_concurrent` for the life of the instance. Each call is
@@ -563,14 +574,14 @@ impl InstanceDriver {
             }
         });
 
-        Self {
+        Ok(Self {
             tx,
             state,
             admitted: AtomicUsize::new(0),
             max_concurrency,
             max_invocations,
             accepts,
-        }
+        })
     }
 
     /// Calls in flight on this instance right now.

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -113,8 +113,8 @@ pub(crate) enum Dispatch {
 /// A call [`InstancePool::dispatch_on_new`] would not take, and the instance
 /// built for it — so the caller's own store path runs on that rather than
 /// instantiating a second time. `None` when there is none to give back: the
-/// pool parked the instance and the call still did not fit on it, or the call
-/// was declined before one was built.
+/// call was declined before one was built, or the driver it was parked on
+/// ended before it could take the call.
 pub(crate) struct Declined {
     pub(crate) job: InstanceJob,
     pub(crate) instance: Option<ComponentInstance>,
@@ -449,17 +449,17 @@ impl InstancePool {
             if drivers.len() >= pool_size {
                 break 'sent Err(Declined::with_instance(job, instance));
             }
-            let driver = Arc::new(InstanceDriver::spawn(
-                instance,
-                max_concurrency,
-                max_invocations,
-            ));
+            let driver =
+                match InstanceDriver::spawn(instance, &job, max_concurrency, max_invocations) {
+                    Ok(driver) => Arc::new(driver),
+                    Err(instance) => break 'sent Err(Declined::with_instance(job, instance)),
+                };
             drivers.push(Arc::clone(&driver));
             // Sent under the lock, as `try_dispatch` sends: a sweep landing
             // between the push and the send would find an idle instance
             // nothing had claimed yet and retire it out from under this call.
-            // The instance is parked whether or not it takes the call, so a
-            // refusal here has none to hand back.
+            // The instance is parked by now, so a refusal here — the driver's
+            // task ended before it could take the call — has none to hand back.
             driver.try_send(job).map_err(Declined::without_instance)
         };
 
@@ -468,8 +468,13 @@ impl InstancePool {
         if reclaims {
             *peak_in_flight = (*peak_in_flight).max(in_flight_total(drivers));
         }
+        // A pool holding nothing has nothing to reclaim, and an instance the
+        // spawn declined leaves it as empty as it found it.
+        let holds_instances = !drivers.is_empty();
         drop(state);
-        self.start_sweeping();
+        if holds_instances {
+            self.start_sweeping();
+        }
         sent
     }
 
@@ -630,7 +635,10 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use super::{Duration, InstancePolicy, InstancePool, NonZeroUsize, sort_least_busy};
+    use super::{
+        ComponentInstance, Duration, InstancePolicy, InstancePool, NonZeroUsize, SharedCtx,
+        sort_least_busy,
+    };
     use crate::engine::instance_driver::{InFlightGuard, InstanceDriver, InstanceJob};
     use crate::types::Component;
 
@@ -810,6 +818,73 @@ mod tests {
             channels.push(rx);
         }
         (pool, channels)
+    }
+
+    /// A real store with a component instantiated in it, which is what
+    /// [`InstancePool::dispatch_on_new`] takes and the stub drivers cannot
+    /// stand in for. The component is empty, so it exports nothing — which is
+    /// all these need, since the pool's decisions are about where an instance
+    /// goes, and an instance exporting nothing is also the one a job-kind gate
+    /// must refuse.
+    fn built_instance() -> ComponentInstance {
+        // A ctx builds a TLS provider under `wasi-tls`, which needs the
+        // process-wide crypto provider a host installs at startup.
+        #[cfg(feature = "wasi-tls")]
+        crate::init_crypto();
+
+        let mut config = wasmtime::Config::new();
+        config.wasm_component_model(true);
+        let engine = wasmtime::Engine::new(&config).expect("an engine for the component model");
+        let bytes = wat::parse_str("(component)").expect("the empty component parses");
+        let component =
+            wasmtime::component::Component::new(&engine, &bytes).expect("it compiles too");
+        let ctx = crate::engine::ctx::Ctx::builder("workload", "component").build();
+        let mut store = wasmtime::Store::new(&engine, SharedCtx::new(ctx));
+        let instance = wasmtime::component::Linker::new(&engine)
+            .instantiate(&mut store, &component)
+            .expect("an empty component instantiates against an empty linker");
+        ComponentInstance { store, instance }
+    }
+
+    /// A delivery to dispatch. Messaging because it is a kind the driver gates
+    /// on the instance's exports, which is what makes it the job an instance
+    /// exporting nothing has to be refused for.
+    fn messaging_job() -> InstanceJob {
+        let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
+        InstanceJob::Messaging(Box::new(crate::host::trigger_service::MessagingJob {
+            msg: crate::host::trigger_service::BrokerMessage {
+                subject: "subject".into(),
+                body: Vec::new(),
+                reply_to: None,
+            },
+            result_tx,
+            abandoned: crate::engine::abandon::DispatchedCall::new("test", Duration::from_secs(1))
+                .flag(),
+            attributes: Arc::from([]),
+        }))
+    }
+
+    /// An instance that does not export what the job needs is never parked.
+    /// Parking it would leave a warm instance that can only refuse this kind
+    /// of call, and nothing retires an instance that admits nothing: it would
+    /// hold its store for the workload's life, with another spawned beside it
+    /// on the next call of the kind.
+    #[test]
+    fn an_instance_that_cannot_take_the_call_is_not_parked() {
+        let (pool, _channels) = warm_pool(0, &limits(4, 0, 0, 0, 0));
+
+        let declined = pool
+            .dispatch_on_new(built_instance(), messaging_job())
+            .expect_err("an empty component exports no messaging handler");
+        assert!(
+            declined.instance.is_some(),
+            "the instance must come back for the caller's own store, where the \
+             binding is built per call and its error reaches the caller"
+        );
+        assert!(
+            pool.lock_state().drivers.is_empty(),
+            "the pool must not park an instance that can only refuse the call"
+        );
     }
 
     /// Instances still admitting calls.

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -110,12 +110,41 @@ pub(crate) enum Dispatch {
     Saturated(InstanceJob),
 }
 
+/// A call [`InstancePool::dispatch_on_new`] would not take, and the instance
+/// built for it — so the caller's own store path runs on that rather than
+/// instantiating a second time. `None` when there is none to give back: the
+/// pool parked the instance and the call still did not fit on it, or the call
+/// was declined before one was built.
+pub(crate) struct Declined {
+    pub(crate) job: InstanceJob,
+    pub(crate) instance: Option<ComponentInstance>,
+}
+
+impl Declined {
+    /// A declined call with no instance to give back.
+    pub(crate) fn without_instance(job: InstanceJob) -> Self {
+        Self {
+            job,
+            instance: None,
+        }
+    }
+
+    /// A declined call and the instance the caller built for it.
+    fn with_instance(job: InstanceJob, instance: ComponentInstance) -> Self {
+        Self {
+            job,
+            instance: Some(instance),
+        }
+    }
+}
+
 /// An instantiated component and the store it lives in.
 ///
 /// Built by the caller, where instantiating is allowed to await and a failure
 /// to instantiate can still be returned to whoever asked for the call. It then
 /// either serves that one call and is dropped with it, or is handed to
-/// [`InstancePool::dispatch_on_new`] to be kept warm.
+/// [`InstancePool::dispatch_on_new`] — to be kept warm, or to come back in a
+/// [`Declined`] and serve the call the pool would not take.
 pub(crate) struct ComponentInstance {
     pub(crate) store: wasmtime::Store<SharedCtx>,
     pub(crate) instance: Instance,
@@ -385,13 +414,17 @@ impl InstancePool {
     /// the sweep would retire them a window later, and the next burst would
     /// build them all over again. So an instance whose call fits on one
     /// already warm is dropped instead, after the lock is released.
+    ///
+    /// A call the pool cannot take at all is the other case: there the
+    /// instance comes back in the [`Declined`], and the caller runs the call
+    /// on it rather than instantiating a second time for the same call.
     pub(crate) fn dispatch_on_new(
         self: &Arc<Self>,
         instance: ComponentInstance,
         job: InstanceJob,
-    ) -> Result<(), InstanceJob> {
+    ) -> Result<(), Declined> {
         let Some((pool_size, max_invocations, max_concurrency)) = self.limits() else {
-            return Err(job);
+            return Err(Declined::with_instance(job, instance));
         };
         let reclaims = self.reclaim_policy().is_some();
         let mut state = self.lock_state();
@@ -409,7 +442,7 @@ impl InstancePool {
                 }
             }
             if drivers.len() >= pool_size {
-                break 'sent Err(job);
+                break 'sent Err(Declined::with_instance(job, instance));
             }
             let driver = Arc::new(InstanceDriver::spawn(
                 instance,
@@ -420,7 +453,9 @@ impl InstancePool {
             // Sent under the lock, as `try_dispatch` sends: a sweep landing
             // between the push and the send would find an idle instance
             // nothing had claimed yet and retire it out from under this call.
-            driver.try_send(job)
+            // The instance is parked whether or not it takes the call, so a
+            // refusal here has none to hand back.
+            driver.try_send(job).map_err(Declined::without_instance)
         };
 
         // Sampled again with the call in place: at `try_dispatch` it may have

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -290,6 +290,11 @@ struct PoolState {
     /// [`InstancePool::dispatch_on_new`], read and reset by
     /// [`InstancePool::sweep`].
     peak_in_flight: usize,
+    /// Whether the workload this pool belongs to has been let go, after which
+    /// nothing is parked again. Guarded by the same lock as `drivers` because
+    /// the race it closes is exactly between a caller finding room and
+    /// filling it.
+    closed: bool,
 }
 
 impl InstancePool {
@@ -298,6 +303,7 @@ impl InstancePool {
             state: Mutex::new(PoolState {
                 drivers: Vec::new(),
                 peak_in_flight: 0,
+                closed: false,
             }),
             policy,
             sweep_started: Once::new(),
@@ -374,7 +380,13 @@ impl InstancePool {
         let PoolState {
             drivers,
             peak_in_flight,
+            closed,
         } = &mut *state;
+        // A closed pool has no room and never will, so say so here rather
+        // than sending the caller off to build a store for it to decline.
+        if *closed {
+            return Dispatch::Saturated(job);
+        }
         reap(drivers);
 
         // This call on top of what the warm instances already hold. A lower
@@ -431,6 +443,7 @@ impl InstancePool {
         let PoolState {
             drivers,
             peak_in_flight,
+            closed,
         } = &mut *state;
         // The pool this instance was built for is the one being measured
         // against `pool_size`, so the spent handles go first: a store built
@@ -439,6 +452,14 @@ impl InstancePool {
         reap(drivers);
 
         let sent = 'sent: {
+            // The workload was let go while this instance was being built.
+            // Parking it now would strand it: `close` has already emptied the
+            // pool and nothing empties it again, so the store and the guest
+            // resources it holds would stay parked for as long as the pool is
+            // referenced. The call runs on it instead.
+            if *closed {
+                break 'sent Err(Declined::with_instance(job, instance));
+            }
             let mut job = job;
             for driver in drivers.iter() {
                 match driver.try_send(job) {
@@ -508,6 +529,14 @@ impl InstancePool {
                     // Nothing holds the pool any more: its workload stopped,
                     // and its instances went with it.
                     let Some(alive) = pool.upgrade() else { return };
+                    // Or the workload was let go while something still holds a
+                    // reference to the pool — which is the case `close` exists
+                    // for. There is nothing left to reclaim and nothing will
+                    // arrive, so stop rather than waking for the life of that
+                    // reference.
+                    if alive.is_closed() {
+                        return;
+                    }
                     alive.sweep();
                 }
             });
@@ -538,6 +567,8 @@ impl InstancePool {
         let PoolState {
             drivers,
             peak_in_flight,
+            // A closed pool holds nothing, so a sweep of it finds no surplus.
+            closed: _,
         } = &mut *state;
         reap(drivers);
 
@@ -593,13 +624,25 @@ impl InstancePool {
         self.policy
     }
 
-    /// Drop every warm instance, e.g. when the component is being shut down.
-    /// Dropping a driver's handle closes its channel, which ends its store's
-    /// run loop. This does not wait for a drain: calls still in flight on
-    /// those instances end with the store they were running on.
-    pub(crate) fn clear(&self) {
+    /// Close the pool and drop every warm instance, when the workload it
+    /// belongs to is let go. Dropping a driver's handle closes its channel,
+    /// which ends its store's run loop. This does not wait for a drain: calls
+    /// still in flight on those instances end with the store they were
+    /// running on.
+    ///
+    /// Closing is what makes emptying it stick. A call that was building an
+    /// instance when this ran would otherwise park it a moment later, into a
+    /// pool nothing empties again — and every path here is one the workload
+    /// does not come back from, so a closed pool stays closed.
+    pub(crate) fn close(&self) {
         let mut state = self.lock_state();
+        state.closed = true;
         drop(std::mem::take(&mut state.drivers));
+    }
+
+    /// Whether the workload this pool belongs to has been let go.
+    fn is_closed(&self) -> bool {
+        self.lock_state().closed
     }
 }
 
@@ -636,8 +679,8 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::{
-        ComponentInstance, Duration, InstancePolicy, InstancePool, NonZeroUsize, SharedCtx,
-        sort_least_busy,
+        ComponentInstance, Dispatch, Duration, InstancePolicy, InstancePool, NonZeroUsize,
+        SharedCtx, sort_least_busy,
     };
     use crate::engine::instance_driver::{InFlightGuard, InstanceDriver, InstanceJob};
     use crate::types::Component;
@@ -887,6 +930,26 @@ mod tests {
         );
     }
 
+    /// A job to dispatch, of the one kind that carries no store-bound
+    /// payload. Never run: these tests only ask where the pool would put it.
+    fn plugin_job() -> InstanceJob {
+        struct NeverRun;
+        impl crate::engine::instance_driver::PluginJob for NeverRun {
+            fn describe(&self) -> &str {
+                "test"
+            }
+            fn run<'a>(
+                self: Box<Self>,
+                _: &'a wasmtime::component::Accessor<crate::engine::ctx::SharedCtx>,
+                _: wasmtime::component::Instance,
+                _: Option<crate::engine::instance_driver::PoolSlot>,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+                unreachable!("the pool never runs this job")
+            }
+        }
+        InstanceJob::Plugin(Box::new(NeverRun))
+    }
+
     /// Instances still admitting calls.
     fn live(pool: &InstancePool) -> usize {
         pool.lock_state()
@@ -894,6 +957,49 @@ mod tests {
             .iter()
             .filter(|d| !d.is_retired())
             .count()
+    }
+
+    /// A pool closed with its workload takes no more instances. Without the
+    /// closing, emptying it does not stick: the pool reads as one with room,
+    /// and the next call is told to build an instance for it to park — into a
+    /// pool nothing empties again.
+    #[test]
+    fn a_closed_pool_asks_for_no_more_instances() {
+        let (pool, _channels) = warm_pool(2, &limits(4, 0, 0, 0, 0));
+
+        pool.close();
+        assert!(
+            pool.lock_state().drivers.is_empty(),
+            "closing drops the warm instances rather than retiring them"
+        );
+        assert!(
+            matches!(pool.try_dispatch(plugin_job()), Dispatch::Saturated(_)),
+            "a closed pool must send the call to a store of its own, not ask \
+             for an instance to park in it"
+        );
+    }
+
+    /// The half of closing that the race actually turns on: a call that was
+    /// already building an instance when `close` ran must not park it. The
+    /// pool is emptied once and never again, so an instance parked after that
+    /// holds its store — and the guest sockets and files with it — for as long
+    /// as anything still references the pool.
+    #[test]
+    fn a_closed_pool_hands_back_an_instance_built_before_it_closed() {
+        let (pool, _channels) = warm_pool(0, &limits(4, 0, 0, 0, 0));
+        pool.close();
+
+        let declined = pool
+            .dispatch_on_new(built_instance(), plugin_job())
+            .expect_err("a closed pool must not take the call");
+        assert!(
+            declined.instance.is_some(),
+            "the instance must come back for the caller's own store"
+        );
+        assert!(
+            pool.lock_state().drivers.is_empty(),
+            "a closed pool must stay empty"
+        );
     }
 
     /// A sweep keeps the instances the window's peak concurrency needed and
@@ -1062,10 +1168,10 @@ mod tests {
             1,
             "a recovered pool must still hold and serve its warm instances"
         );
-        pool.clear();
+        pool.close();
         assert!(
             pool.lock_state().drivers.is_empty(),
-            "a recovered pool must still clear"
+            "a recovered pool must still close"
         );
     }
 }

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -432,6 +432,11 @@ impl InstancePool {
             drivers,
             peak_in_flight,
         } = &mut *state;
+        // The pool this instance was built for is the one being measured
+        // against `pool_size`, so the spent handles go first: a store built
+        // while an instance was trapping or draining would otherwise be
+        // turned away by a pool that has the room for it.
+        reap(drivers);
 
         let sent = 'sent: {
             let mut job = job;

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -36,7 +36,7 @@ use crate::engine::abandon::{AbandonedCallPolicy, arm_epoch_deadline};
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
 use crate::engine::instance_driver::{InstanceJob, LinkedJob};
-use crate::engine::instance_pool::{self, ComponentInstance, Dispatch, InstancePool};
+use crate::engine::instance_pool::{self, ComponentInstance, Declined, Dispatch, InstancePool};
 use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
 use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
@@ -804,6 +804,9 @@ async fn invoke_ephemeral_plain(
     // them back, so the cold path below reuses that allocation rather than
     // cloning them a second time.
     let mut declined_params = None;
+    // As does an instance built for a pool that then declined the call: the
+    // store of its own below is that instance.
+    let mut reclaimed = None;
 
     if let Some(pool) = pool.as_ref() {
         let (reply, reply_rx) = tokio::sync::oneshot::channel();
@@ -837,7 +840,7 @@ async fn invoke_ephemeral_plain(
                 let instance = inv.pre.instantiate_async(&mut store).await?;
                 pool.dispatch_on_new(ComponentInstance { store, instance }, job)
             }
-            Dispatch::Saturated(job) => Err(job),
+            Dispatch::Saturated(job) => Err(Declined::without_instance(job)),
         };
         match outcome {
             Ok(()) => {
@@ -864,17 +867,27 @@ async fn invoke_ephemeral_plain(
                     fn_name = %inv.export_name,
                     "warm instances saturated; serving this call from a store of its own"
                 );
-                if let InstanceJob::Linked(job) = declined {
+                reclaimed = declined.instance;
+                if let InstanceJob::Linked(job) = declined.job {
                     declined_params = Some(job.params);
                 }
             }
         }
     }
 
-    let mut store = new_ephemeral_store(ephemeral_call)
-        .await
-        .map_err(|e| wasmtime::format_err!("new ephemeral store creation failed: {e:#}"))?;
-    let instance = inv.pre.instantiate_async(&mut store).await?;
+    let ComponentInstance {
+        mut store,
+        instance,
+    } = match reclaimed {
+        Some(built) => built,
+        None => {
+            let mut store = new_ephemeral_store(ephemeral_call)
+                .await
+                .map_err(|e| wasmtime::format_err!("new ephemeral store creation failed: {e:#}"))?;
+            let instance = inv.pre.instantiate_async(&mut store).await?;
+            ComponentInstance { store, instance }
+        }
+    };
 
     let params_buf = declined_params.unwrap_or_else(|| params.to_vec());
     let mut results_buf = vec![Val::Bool(false); results.len()];

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1912,9 +1912,10 @@ impl ResolvedWorkload {
         for component in self.components.read().await.values() {
             // Warm instances hold guest resources (sockets, open files) for as
             // long as they stay parked, so release them with the rest of the
-            // workload's teardown. Calls still in flight own their own stores
-            // and are unaffected.
-            component.instances.clear();
+            // workload's teardown, and close the pool against a call that is
+            // building one right now. Calls still in flight own their own
+            // stores and are unaffected.
+            component.instances.close();
 
             if let Some(plugins) = component.plugins() {
                 for (plugin_id, plugin) in plugins.iter() {

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -2308,9 +2308,10 @@ async fn invoke_component_handler(
         // alongside whatever else that instance already has in flight. Only
         // when every warm instance is full and the pool is at `pool_size` does
         // the request fall through to a store of its own.
+        let mut reclaimed = None;
         let req = if let Some(pool) = pool.as_ref() {
             use crate::engine::instance_driver::InstanceJob;
-            use crate::engine::instance_pool::Dispatch;
+            use crate::engine::instance_pool::{Declined, Dispatch};
             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
             let call = DispatchedCall::new("HTTP (pooled)", crate::timeouts::http_response());
             let outcome = match pool.try_dispatch(InstanceJob::Http(Box::new(ServiceHttpJob {
@@ -2331,7 +2332,7 @@ async fn invoke_component_handler(
                         job,
                     )
                 }
-                Dispatch::Saturated(job) => Err(job),
+                Dispatch::Saturated(job) => Err(Declined::without_instance(job)),
             };
             match outcome {
                 Ok(()) => {
@@ -2344,10 +2345,16 @@ async fn invoke_component_handler(
                     return Ok(watch_body(resp, watch));
                 }
                 // Every warm instance was busy; serve it cold below.
-                Err(InstanceJob::Http(job)) => job.req,
+                Err(Declined {
+                    job: InstanceJob::Http(job),
+                    instance,
+                }) => {
+                    reclaimed = instance;
+                    job.req
+                }
                 // A job comes back as the variant it went in as, so this is
                 // unreachable — but not worth a panic on a request path.
-                Err(other) => {
+                Err(Declined { job: other, .. }) => {
                     debug_assert!(false, "an HTTP job cannot come back as another kind");
                     anyhow::bail!(
                         "instance pool returned a {} job for an HTTP request",
@@ -2364,9 +2371,14 @@ async fn invoke_component_handler(
             req
         };
 
-        let mut store = workload_handle.new_store(component_id).await?;
-        let instance = instance_pre.instantiate_async(&mut store).await?;
-        let cold = crate::engine::instance_pool::ComponentInstance { store, instance };
+        let cold = match reclaimed {
+            Some(built) => built,
+            None => {
+                let mut store = workload_handle.new_store(component_id).await?;
+                let instance = instance_pre.instantiate_async(&mut store).await?;
+                crate::engine::instance_pool::ComponentInstance { store, instance }
+            }
+        };
         let call = DispatchedCall::new("HTTP (cold store)", crate::timeouts::http_response());
         let flag = call.flag();
         let (resp, watch) = call

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/mod.rs
@@ -258,8 +258,9 @@ pub(crate) fn log_delivery(result: &anyhow::Result<Result<(), String>>) {
 /// never do.
 ///
 /// The same job runs either way: a delivery the pool declines is not rebuilt,
-/// it is handed back and run in a fresh store, so a large payload is never
-/// copied to pay for the attempt.
+/// it is handed back and run in a store of its own — the one built for the
+/// pool, when the pool did not park that — so neither a large payload nor an
+/// instantiation is paid for twice.
 ///
 /// Only `@0.3.0` reaches here. The sync `@0.2.0` handler takes `&mut Store` for
 /// the length of its call, so it cannot share an instance and keeps a store per
@@ -273,7 +274,7 @@ pub(crate) async fn deliver_pooled(
     attributes: std::sync::Arc<[KeyValue]>,
 ) -> anyhow::Result<Result<(), String>> {
     use crate::engine::instance_driver::InstanceJob;
-    use crate::engine::instance_pool::{ComponentInstance, Dispatch};
+    use crate::engine::instance_pool::{ComponentInstance, Declined, Dispatch};
     use crate::host::trigger_service::{MessagingJob, MessagingTask};
 
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
@@ -301,10 +302,14 @@ pub(crate) async fn deliver_pooled(
             pool.dispatch_on_new(ComponentInstance { store, instance }, job)
                 .err()
         }
-        Dispatch::Saturated(job) => Some(job),
+        Dispatch::Saturated(job) => Some(Declined::without_instance(job)),
     };
 
-    let Some(declined) = declined else {
+    let Some(Declined {
+        job: declined,
+        instance: reclaimed,
+    }) = declined
+    else {
         return call
             .await_reply(result_rx)
             .await
@@ -313,14 +318,23 @@ pub(crate) async fn deliver_pooled(
     };
 
     // Every instance was busy and the pool is full, so run the very same job in
-    // a store of its own.
+    // a store of its own — the one built for the pool, when there is one.
     let InstanceJob::Messaging(job) = declined else {
         anyhow::bail!("instance pool returned the wrong job kind for a message");
     };
     tracing::debug!(component_id, "warm instances saturated; own store");
 
-    let mut store = workload.new_store(component_id).await?;
-    let instance = pre.instantiate_async(&mut store).await?;
+    let ComponentInstance {
+        mut store,
+        instance,
+    } = match reclaimed {
+        Some(built) => built,
+        None => {
+            let mut store = workload.new_store(component_id).await?;
+            let instance = pre.instantiate_async(&mut store).await?;
+            ComponentInstance { store, instance }
+        }
+    };
     let handler = Arc::new(
         crate::host::trigger_service::AsyncMessaging::new(&mut store, &instance).map_err(|e| {
             anyhow::anyhow!("component does not export wasmcloud:messaging/handler@0.3.0: {e:#}")

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, warn};
 
 use crate::engine::instance_driver::InstanceJob;
-use crate::engine::instance_pool::{ComponentInstance, Dispatch};
+use crate::engine::instance_pool::{ComponentInstance, Declined, Dispatch};
 use crate::engine::workload::ResolvedWorkload;
 use crate::wasmtime::component::{Accessor, InstancePre, Resource};
 
@@ -377,8 +377,9 @@ async fn build_instance(
 /// of the call.
 ///
 /// The same job runs either way: a delivery the pool declines is not rebuilt,
-/// it is handed back and run in a fresh store, so a large payload is never
-/// copied to pay for the attempt.
+/// it is handed back and run in a store of its own — the one built for the
+/// pool, when the pool did not park that — so neither a large payload nor an
+/// instantiation is paid for twice.
 ///
 /// JetStream stays on the warm set. Its call carries a `message-handle`
 /// resource — an index into one store's table — so its argument cannot exist
@@ -388,7 +389,9 @@ async fn build_instance(
 /// `cancel_token` ends the delivery at the two awaits that can block on a
 /// workload being torn down: building a store and instantiating into it is work
 /// nobody will see the result of, and an instance built for the pool could
-/// otherwise be installed after the pool was cleared.
+/// otherwise be installed after the pool was cleared. A delivery carrying an
+/// instance the pool declined reaches neither await, so it is checked against
+/// the token directly.
 async fn run_delivery(
     workload: &ResolvedWorkload,
     target: &HandlerTarget,
@@ -399,6 +402,9 @@ async fn run_delivery(
 ) -> anyhow::Result<Result<(), String>> {
     let component_id = target.component_id.as_ref();
     let mut job = job;
+    // An instance built for a pool that then declined the delivery: the store
+    // of its own below is that instance.
+    let mut reclaimed = None;
 
     if let Some(pool) = workload.instance_pool_for_component(component_id).await {
         let outcome = match pool.try_dispatch(InstanceJob::Plugin(job)) {
@@ -414,7 +420,7 @@ async fn run_delivery(
                 };
                 pool.dispatch_on_new(ComponentInstance { store, instance }, pending)
             }
-            Dispatch::Saturated(pending) => Err(pending),
+            Dispatch::Saturated(pending) => Err(Declined::without_instance(pending)),
         };
         match outcome {
             Ok(()) => {
@@ -427,7 +433,7 @@ async fn run_delivery(
             // Every instance was busy and the pool is full, so run the very
             // same job in a store of its own.
             Err(declined) => {
-                let InstanceJob::Plugin(returned) = declined else {
+                let InstanceJob::Plugin(returned) = declined.job else {
                     return Err(anyhow::anyhow!("pool returned the wrong job kind"));
                 };
                 debug!(
@@ -435,14 +441,33 @@ async fn run_delivery(
                     "warm instances saturated; own store"
                 );
                 job = returned;
+                reclaimed = declined.instance;
             }
         }
     }
 
-    let Some((mut store, instance)) =
-        build_instance(workload, target, component_id, cancel_token).await?
-    else {
-        return Ok(Ok(()));
+    let ComponentInstance {
+        mut store,
+        instance,
+    } = match reclaimed {
+        // A reclaimed instance reaches neither await `build_instance` gives
+        // up at, so the teardown it gives up for is checked here instead.
+        Some(_) if cancel_token.is_cancelled() => {
+            debug!(
+                job = job.describe(),
+                "workload torn down before the delivery ran; abandoning it"
+            );
+            return Ok(Ok(()));
+        }
+        Some(built) => built,
+        None => {
+            let Some((store, instance)) =
+                build_instance(workload, target, component_id, cancel_token).await?
+            else {
+                return Ok(Ok(()));
+            };
+            ComponentInstance { store, instance }
+        }
     };
     // Awaited through the same `DispatchedCall` the pooled path uses:
     // `arm_after` runs inside `await_reply`, so a cold delivery that skipped it

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -388,10 +388,11 @@ async fn build_instance(
 ///
 /// `cancel_token` ends the delivery at the two awaits that can block on a
 /// workload being torn down: building a store and instantiating into it is work
-/// nobody will see the result of, and an instance built for the pool could
-/// otherwise be installed after the pool was cleared. A delivery carrying an
-/// instance the pool declined reaches neither await, so it is checked against
-/// the token directly.
+/// nobody will see the result of. A delivery carrying an instance the pool
+/// declined reaches neither await, so it is checked against the token directly.
+/// What keeps such an instance from being parked in a pool that teardown has
+/// already emptied is the pool itself, which refuses one once it is closed
+/// (see [`crate::engine::instance_pool::InstancePool::close`]).
 async fn run_delivery(
     workload: &ResolvedWorkload,
     target: &HandlerTarget,


### PR DESCRIPTION
Hardening for `InstancePool`.

1. `InstancePool::dispatch_on_new` took a `ComponentInstance` by value and dropped it on every path that did not spawn a driver. By then the caller had paid for a full store construction and a component instantiation.
2. The pool measured its room against dead handles. `dispatch_on_new` tested `drivers.len() >= pool_size` without reaping first.
3. `InstanceDriver::spawn` started a driver and `dispatch_on_new` pushed into the pool before anything asked whether the instance could serve the call it was built for.
4. Emptying a pool at teardown had a race. `InstancePool::clear` took the lock and dropped every warm instance, but a call already past `try_dispatch`, out building a store, then took that same lock, found an empty pool with room in it, and parked its instance there. Nothing empties the pool a second time.

### Fix

`dispatch_on_new` now returns the call and the instance together:

```rust pub(crate) fn dispatch_on_new(
    self: &Arc<Self>,
    instance: ComponentInstance,
    job: InstanceJob,
) -> Result<(), Declined>;

pub(crate) struct Declined {
    pub(crate) job: InstanceJob,
    pub(crate) instance: Option<ComponentInstance>,
}
```

Each of the four callers then runs its own store path on the instance it already built, rather than constructing another:

| caller | path |
| --- | --- |
| `host/http.rs` | inbound HTTP |
| `engine/linked_call.rs` | ephemeral linked calls |
| `plugin/wasmcloud_messaging/mod.rs` | `wasmcloud:messaging@0.3.0` deliveries |
| `plugin/wasmcloud_nats/subscriber.rs` | core and KV NATS deliveries |

Every one of them already built its pooled store with the same call it builds its cold store with (`new_store` / `new_ephemeral_store`, then `instantiate_async`), and nothing had touched the store yet, so the reclaimed instance is indistinguishable from a fresh one. Arming and abandon-watching happen per path, after this point.

`reap(drivers)` now runs in `dispatch_on_new` too. `try_dispatch` and `sweep` already reap before they read the pool.

`InstanceDriver::spawn` already binds the exports before starting its run loop, to decide what the instance can be given at all. It now takes the job that prompted it and makes that decision there, before the channel, the state and the task exist. An instance that cannot take the call is handed straight back, and `dispatch_on_new` returns it in the `Declined` for the caller's own store path. Declining is the first way `dispatch_on_new` can return having parked nothing, so the idle sweep is now armed only once the pool actually holds an instance.