### PR TITLE
fix(wash-runtime): cache components by digest

### DIFF
--- a/crates/wash-runtime/src/component_source.rs
+++ b/crates/wash-runtime/src/component_source.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result, bail, ensure};
 use bytes::Bytes;
+use sha2::{Digest, Sha256};
 
 use crate::oci::{OciConfig, OciPullPolicy, pull_component};
 
@@ -41,12 +42,14 @@ pub enum ComponentSource {
 #[derive(Debug, Clone)]
 pub struct LoadedComponent {
     pub bytes: Bytes,
-    /// Registry digest of the pulled image, `None` for a file source.
+    /// Registry digest of the pulled image, or a content hash of the bytes
+    /// for a file source.
     ///
-    /// The engine keys its compilation cache on this. A local path carries no
-    /// such identity. The same path can hold different bytes between two
-    /// reads so a file source declines to be cached rather than offering a
-    /// name that would collide with every other file.
+    /// The engine keys its compiled-component cache on this. A file's path
+    /// carries no identity of its own (the same path can hold different
+    /// bytes between two reads), so this hashes the bytes rather than the
+    /// path, letting repeated loads of identical file content still share
+    /// one cached [`wasmtime::component::Component`].
     pub digest: Option<String>,
 }
 
@@ -54,8 +57,9 @@ impl LoadedComponent {
     /// Check the fetched bytes against a pinned registry digest.
     ///
     /// Callers add their own context (which plugin, which component); this
-    /// supplies the reason. A file source has no digest to check, so pinning
-    /// one is a configuration error rather than a mismatch.
+    /// supplies the reason. A `LoadedComponent` with no digest at all has
+    /// nothing to check, so pinning one is a configuration error rather than
+    /// a mismatch.
     pub fn verify_digest(&self, expected: &str) -> Result<()> {
         match &self.digest {
             Some(digest) if digest == expected => Ok(()),
@@ -133,8 +137,11 @@ impl ComponentSource {
 
     /// Fetch the bytes and check them against a pinned registry digest.
     ///
-    /// A source that carries no digest is rejected before any bytes move, so a
-    /// pin on a file is a configuration error rather than wasted I/O.
+    /// A pin only ever means a registry digest, so it is rejected against a
+    /// file source before any bytes move — even though a file load now
+    /// produces its own content digest, that digest names local bytes, not a
+    /// registry artifact, so pinning one is a configuration error rather than
+    /// wasted I/O.
     pub async fn load_pinned(
         &self,
         oci_config: OciConfig,
@@ -168,12 +175,22 @@ impl ComponentSource {
                 })
             }
             Self::File(path) => {
-                let bytes = tokio::fs::read(path)
+                let bytes: Bytes = tokio::fs::read(path)
                     .await
-                    .with_context(|| format!("failed to read component file {}", path.display()))?;
+                    .with_context(|| format!("failed to read component file {}", path.display()))?
+                    .into();
+                // Off the async runtime: a large component's hash can take
+                // long enough to stall whatever else that worker thread was
+                // driving (e.g. draining a NATS connection).
+                let for_hash = bytes.clone();
+                let digest = tokio::task::spawn_blocking(move || {
+                    format!("sha256:{:x}", Sha256::digest(&for_hash))
+                })
+                .await
+                .context("digest hashing task panicked")?;
                 Ok(LoadedComponent {
-                    bytes: bytes.into(),
-                    digest: None,
+                    bytes,
+                    digest: Some(digest),
                 })
             }
         }
@@ -325,7 +342,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_file_source_loads_bytes_without_a_digest() {
+    async fn a_file_source_loads_bytes_with_a_content_digest() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("kv.wasm");
         std::fs::write(&path, b"\0asm\x0d\0\x01\0").unwrap();
@@ -335,7 +352,36 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(loaded.bytes.as_ref(), b"\0asm\x0d\0\x01\0");
-        assert!(loaded.digest.is_none());
+        assert!(
+            loaded
+                .digest
+                .as_deref()
+                .is_some_and(|d| d.starts_with("sha256:"))
+        );
+    }
+
+    #[tokio::test]
+    async fn two_file_sources_with_identical_bytes_share_a_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_a = dir.path().join("a.wasm");
+        let path_b = dir.path().join("b.wasm");
+        std::fs::write(&path_a, b"\0asm\x0d\0\x01\0").unwrap();
+        std::fs::write(&path_b, b"\0asm\x0d\0\x01\0").unwrap();
+
+        let loaded_a = ComponentSource::File(path_a)
+            .load(OciConfig::default())
+            .await
+            .unwrap();
+        let loaded_b = ComponentSource::File(path_b)
+            .load(OciConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(loaded_a.digest, loaded_b.digest);
+
+        let different = ComponentSource::File(dir.path().join("c.wasm"));
+        std::fs::write(dir.path().join("c.wasm"), b"\0asm\x0d\0\x01\x01").unwrap();
+        let loaded_c = different.load(OciConfig::default()).await.unwrap();
+        assert_ne!(loaded_a.digest, loaded_c.digest);
     }
 
     #[tokio::test]

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -503,6 +503,15 @@ struct SidecarComponent {
     reclaim_min_instances: Option<i32>,
 }
 
+/// A configured `dev.service` source's loaded inputs, once fetched and its
+/// interfaces extracted. Bundled so [`build_workload`] takes one optional
+/// argument for the service rather than one per field.
+struct LoadedService {
+    bytes: Bytes,
+    digest: Option<String>,
+    interfaces: HashSet<WitInterface>,
+}
+
 /// Thin wrapper around [`build_workload`]: extracts dev-component
 /// interfaces, loads sidecar bytes + interfaces, resolves each sidecar's
 /// overrides over the workload-level base, and (when configured) loads the
@@ -559,7 +568,7 @@ async fn create_workload(
     // isn't itself the service (`dev.service = false`); see `build_workload`.
     // When `dev.service` is true it is ignored, so there's no point fetching it
     // or folding its imports into the workload host interfaces.
-    let (service_bytes, service_digest, service_interfaces) = match dev_config.service_source()? {
+    let configured_service = match dev_config.service_source()? {
         Some(source) if !dev_config.service => {
             let loaded = source
                 .load(oci_config.clone())
@@ -568,9 +577,13 @@ async fn create_workload(
             let interfaces = host
                 .intersect_interfaces(&loaded.bytes)
                 .context("failed to extract service interfaces")?;
-            (Some(loaded.bytes), loaded.digest, Some(interfaces))
+            Some(LoadedService {
+                bytes: loaded.bytes,
+                digest: loaded.digest,
+                interfaces,
+            })
         }
-        _ => (None, None, None),
+        _ => None,
     };
 
     Ok(build_workload(
@@ -578,9 +591,7 @@ async fn create_workload(
         bytes,
         dev_interfaces,
         sidecars,
-        service_bytes,
-        service_digest,
-        service_interfaces,
+        configured_service,
         resolved_workload,
     ))
 }
@@ -605,9 +616,7 @@ fn build_workload(
     bytes: Bytes,
     dev_interfaces: HashSet<WitInterface>,
     sidecars: Vec<SidecarComponent>,
-    service_bytes: Option<Bytes>,
-    service_digest: Option<String>,
-    service_interfaces: Option<HashSet<WitInterface>>,
+    configured_service: Option<LoadedService>,
     resolved_workload: &ResolvedWorkload,
 ) -> Workload {
     let mut volumes = Vec::<Volume>::new();
@@ -634,8 +643,8 @@ fn build_workload(
     for s in &sidecars {
         all_component_interfaces.push(s.interfaces.clone());
     }
-    if let Some(svc_interfaces) = service_interfaces {
-        all_component_interfaces.push(svc_interfaces);
+    if let Some(svc) = &configured_service {
+        all_component_interfaces.push(svc.interfaces.clone());
     }
 
     let host_interfaces = build_workload_host_interfaces(
@@ -676,10 +685,10 @@ fn build_workload(
             reclaim_min_instances: UNSET_LIMIT,
         });
 
-        if let Some(service_bytes) = service_bytes {
+        if let Some(configured_service) = configured_service {
             service = Some(Service {
-                bytes: service_bytes,
-                digest: service_digest,
+                bytes: configured_service.bytes,
+                digest: configured_service.digest,
                 max_restarts: 0,
                 local_resources: local_resources_for(resolved_workload),
             });
@@ -922,8 +931,6 @@ mod tests {
             HashSet::new(),
             sidecars,
             None,
-            None,
-            None,
             &resolved,
         );
 
@@ -978,8 +985,6 @@ mod tests {
             HashSet::new(),
             sidecars,
             None,
-            None,
-            None,
             &resolved,
         );
 
@@ -1015,8 +1020,6 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             vec![sidecar],
-            None,
-            None,
             None,
             &resolved,
         );
@@ -1078,8 +1081,6 @@ mod tests {
             HashSet::new(),
             sidecars,
             None,
-            None,
-            None,
             &resolved,
         );
 
@@ -1128,8 +1129,6 @@ mod tests {
             HashSet::new(),
             Vec::new(),
             None,
-            None,
-            None,
             &resolved,
         );
 
@@ -1158,9 +1157,11 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             Vec::new(),
-            Some(fake_bytes("svc-sidecar")),
-            Some("sha256:svc-sidecar-digest".to_string()),
-            None,
+            Some(LoadedService {
+                bytes: fake_bytes("svc-sidecar"),
+                digest: Some("sha256:svc-sidecar-digest".to_string()),
+                interfaces: HashSet::new(),
+            }),
             &resolved,
         );
 
@@ -1196,9 +1197,11 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             sidecars,
-            Some(fake_bytes("svc")),
-            None,
-            None,
+            Some(LoadedService {
+                bytes: fake_bytes("svc"),
+                digest: None,
+                interfaces: HashSet::new(),
+            }),
             &ResolvedWorkload::default(),
         );
 
@@ -1252,8 +1255,6 @@ mod tests {
             HashSet::from([iface("wasi", "http")]),
             sidecars,
             None,
-            None,
-            None,
             &resolved,
         );
 
@@ -1276,9 +1277,11 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             Vec::new(),
-            Some(fake_bytes("svc")),
-            None,
-            Some(HashSet::from([iface("wasi", "keyvalue")])),
+            Some(LoadedService {
+                bytes: fake_bytes("svc"),
+                digest: None,
+                interfaces: HashSet::from([iface("wasi", "keyvalue")]),
+            }),
             &ResolvedWorkload::default(),
         );
 
@@ -1311,8 +1314,6 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             sidecars,
-            None,
-            None,
             None,
             &ResolvedWorkload::default(),
         );

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -488,6 +488,10 @@ const UNSET_LIMIT: i32 = -1;
 struct SidecarComponent {
     name: String,
     bytes: Bytes,
+    /// The content/registry digest the source resolved this sidecar's bytes
+    /// to, so it can share the engine's compiled-component cache instead of
+    /// recompiling on every dev reload.
+    digest: Option<String>,
     interfaces: HashSet<WitInterface>,
     workload: ResolvedWorkload,
     /// The warm-instance limits from `dev.components[]`, `None` where the
@@ -540,6 +544,7 @@ async fn create_workload(
         sidecars.push(SidecarComponent {
             name: name.clone(),
             bytes: loaded.bytes,
+            digest: loaded.digest,
             interfaces,
             workload,
             pool_size: dev_component.pool_size,
@@ -554,7 +559,7 @@ async fn create_workload(
     // isn't itself the service (`dev.service = false`); see `build_workload`.
     // When `dev.service` is true it is ignored, so there's no point fetching it
     // or folding its imports into the workload host interfaces.
-    let (service_bytes, service_interfaces) = match dev_config.service_source()? {
+    let (service_bytes, service_digest, service_interfaces) = match dev_config.service_source()? {
         Some(source) if !dev_config.service => {
             let loaded = source
                 .load(oci_config.clone())
@@ -563,9 +568,9 @@ async fn create_workload(
             let interfaces = host
                 .intersect_interfaces(&loaded.bytes)
                 .context("failed to extract service interfaces")?;
-            (Some(loaded.bytes), Some(interfaces))
+            (Some(loaded.bytes), loaded.digest, Some(interfaces))
         }
-        _ => (None, None),
+        _ => (None, None, None),
     };
 
     Ok(build_workload(
@@ -574,6 +579,7 @@ async fn create_workload(
         dev_interfaces,
         sidecars,
         service_bytes,
+        service_digest,
         service_interfaces,
         resolved_workload,
     ))
@@ -600,6 +606,7 @@ fn build_workload(
     dev_interfaces: HashSet<WitInterface>,
     sidecars: Vec<SidecarComponent>,
     service_bytes: Option<Bytes>,
+    service_digest: Option<String>,
     service_interfaces: Option<HashSet<WitInterface>>,
     resolved_workload: &ResolvedWorkload,
 ) -> Workload {
@@ -672,7 +679,7 @@ fn build_workload(
         if let Some(service_bytes) = service_bytes {
             service = Some(Service {
                 bytes: service_bytes,
-                digest: None,
+                digest: service_digest,
                 max_restarts: 0,
                 local_resources: local_resources_for(resolved_workload),
             });
@@ -683,7 +690,7 @@ fn build_workload(
         components.push(Component {
             name: sidecar.name,
             bytes: sidecar.bytes,
-            digest: None,
+            digest: sidecar.digest,
             local_resources: local_resources_for(&sidecar.workload),
             // `Component` carries these as `sint32`, where a negative means
             // "not configured"; the runtime decodes them into an
@@ -875,6 +882,7 @@ mod tests {
         SidecarComponent {
             name: name.into(),
             bytes: fake_bytes(name),
+            digest: None,
             interfaces: HashSet::new(),
             workload,
             pool_size: None,
@@ -913,6 +921,7 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             sidecars,
+            None,
             None,
             None,
             &resolved,
@@ -970,6 +979,7 @@ mod tests {
             sidecars,
             None,
             None,
+            None,
             &resolved,
         );
 
@@ -984,6 +994,35 @@ mod tests {
         assert_eq!(unpooled.max_invocations, UNSET_LIMIT);
         assert_eq!(unpooled.reclaim_window_seconds, UNSET_LIMIT);
         assert_eq!(unpooled.reclaim_min_instances, UNSET_LIMIT);
+    }
+
+    /// The digest `create_workload` resolved when loading a sidecar's bytes
+    /// must reach the sidecar's `Component`, or it can never share the
+    /// engine's compiled-component cache with another workload using the
+    /// same source.
+    #[test]
+    fn build_workload_sidecar_carries_its_resolved_digest() {
+        let resolved = ResolvedWorkload::default();
+        let dev_cfg = DevConfig {
+            components: vec![dev_component_named("sidecar-a")],
+            ..Default::default()
+        };
+        let mut sidecar = loaded_sidecar("sidecar-a", resolved.clone());
+        sidecar.digest = Some("sha256:sidecar-digest".to_string());
+
+        let workload = build_workload(
+            &dev_cfg,
+            fake_bytes("dev"),
+            HashSet::new(),
+            vec![sidecar],
+            None,
+            None,
+            None,
+            &resolved,
+        );
+
+        let sidecar = find_component(&workload, "sidecar-a").unwrap();
+        assert_eq!(sidecar.digest.as_deref(), Some("sha256:sidecar-digest"));
     }
 
     /// The config keys are camelCase on the wire and optional, so a component
@@ -1040,6 +1079,7 @@ mod tests {
             sidecars,
             None,
             None,
+            None,
             &resolved,
         );
 
@@ -1089,6 +1129,7 @@ mod tests {
             Vec::new(),
             None,
             None,
+            None,
             &resolved,
         );
 
@@ -1118,6 +1159,7 @@ mod tests {
             HashSet::new(),
             Vec::new(),
             Some(fake_bytes("svc-sidecar")),
+            Some("sha256:svc-sidecar-digest".to_string()),
             None,
             &resolved,
         );
@@ -1127,6 +1169,10 @@ mod tests {
             .as_ref()
             .expect("service_file should produce a Service");
         assert_eq!(svc.local_resources.environment.get("LOG").unwrap(), "info");
+        // The digest resolved when loading the service's bytes must reach
+        // the Service, or it can never share the engine's compiled-component
+        // cache with another workload using the same source.
+        assert_eq!(svc.digest.as_deref(), Some("sha256:svc-sidecar-digest"));
         let dev = find_component(&workload, "wash-dev-component").unwrap();
         assert_eq!(dev.local_resources.environment.get("LOG").unwrap(), "info");
     }
@@ -1151,6 +1197,7 @@ mod tests {
             HashSet::new(),
             sidecars,
             Some(fake_bytes("svc")),
+            None,
             None,
             &ResolvedWorkload::default(),
         );
@@ -1189,6 +1236,7 @@ mod tests {
         let sidecars = vec![SidecarComponent {
             name: "sidecar".into(),
             bytes: fake_bytes("sidecar"),
+            digest: None,
             interfaces: HashSet::from([iface("wasi", "config")]),
             workload: ResolvedWorkload::default(),
             pool_size: None,
@@ -1203,6 +1251,7 @@ mod tests {
             fake_bytes("dev"),
             HashSet::from([iface("wasi", "http")]),
             sidecars,
+            None,
             None,
             None,
             &resolved,
@@ -1228,6 +1277,7 @@ mod tests {
             HashSet::new(),
             Vec::new(),
             Some(fake_bytes("svc")),
+            None,
             Some(HashSet::from([iface("wasi", "keyvalue")])),
             &ResolvedWorkload::default(),
         );
@@ -1261,6 +1311,7 @@ mod tests {
             fake_bytes("dev"),
             HashSet::new(),
             sidecars,
+            None,
             None,
             None,
             &ResolvedWorkload::default(),

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -715,9 +715,9 @@ impl HostPluginConfig {
     /// without resolving `configFrom`/`secretFrom` — used where no [`Config`]
     /// is available. Prefer [`HostPluginConfig::to_spec`] when one is.
     ///
-    /// `expectedDigest` on a file source is caught by the loader when it finds
-    /// no digest to check against, so this only has to validate what it can see
-    /// without fetching.
+    /// `expectedDigest` on a file source is caught by the loader, which only
+    /// checks a pin against an `Oci` source, so this only has to validate
+    /// what it can see without fetching.
     pub fn to_spec_unresolved(&self) -> Result<wash_runtime::plugin::ComponentPluginSpec> {
         if self.id.is_empty() {
             bail!("host.plugins entry is missing a non-empty `id`");


### PR DESCRIPTION
Engine::load_component_bytes caches a compiled wasmtime::component::Component in a moka cache, but only when the caller supplies a digest to key it on. A file-sourced ComponentSource returned digest: None unconditionally, so every component loaded from a local file including wash dev sidecars and service, host component plugins loaded from disk, recompiled and re-registered its own copy of wasmtime's JIT unwind info on every load, even when the bytes were identical to one already cached. Dropping a component deregisters that unwind info one FDE at a time, and libunwind's global table is rescanned on every deregistration, so needless duplication compounds directly into teardown cost.

Hash the file's bytes (sha256, matching the OCI digest format already used for registry pulls) instead of leaving digest None. The original reason a file source declined to be cached was that a path carries no identity of its own and hashing the content rather than the path preserves that. Two reads of different bytes never collide, and repeated reads of identical content now share the cache. The hash runs off the async runtime (spawn_blocking), since a large component's hash can otherwise stall whatever else that worker thread was driving, e.g. draining a NATS connection.

wash dev's create_workload already resolved a real digest for every sidecar and service loaded through a ComponentSource, but build_workload discarded it. Component and Service were always constructed with `digest: None` so none of wash dev's file- or OCI-sourced components could ever reach the cache.
