### PR TITLE
Add bindings support for host component plugins

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -103,6 +103,15 @@ pub struct SharedCtx {
 pub struct CallerIdentity {
     pub workload_id: Arc<str>,
     pub component_id: Option<Arc<str>>,
+    /// The binding the call arrived on: the `(implements ..)` label the caller
+    /// imported the plugin's interface under, which is also the name the
+    /// operator declared it by. `None` for a plain import, and for a lifecycle
+    /// hook, which is about a whole workload rather than one binding.
+    ///
+    /// Read by `wasmcloud:host/identity#get-binding-name`, so a plugin serving
+    /// two bindings of one workload can pair a call with the configuration that
+    /// binding was resolved with.
+    pub binding: Option<Arc<str>>,
 }
 
 impl SharedCtx {

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2299,7 +2299,7 @@ impl UnresolvedWorkload {
                             !p.supports_named_instances()
                                 && other_plugin_serves(plugins, plugin_id, wit_interface, true)
                         } else {
-                            p.supports_named_instances()
+                            p.defers_unnamed_instances()
                                 && other_plugin_serves(plugins, plugin_id, wit_interface, false)
                         };
                         if defer_to_other {
@@ -3037,6 +3037,9 @@ mod tests {
         on_workload_item_bind_count: Arc<AtomicUsize>,
         on_workload_resolved_count: Arc<AtomicUsize>,
         named_instance_support: bool,
+        /// Serves labeled and unlabeled imports off one backend, so it never
+        /// defers a plain import to a single-backend plugin.
+        serves_unnamed_too: bool,
         /// Minimum version this plugin will claim, mirroring a plugin whose
         /// `world()` cannot express the constraint. `None` claims everything.
         claims_from: Option<semver::Version>,
@@ -3061,6 +3064,7 @@ mod tests {
                 on_workload_item_bind_count: Arc::new(AtomicUsize::new(0)),
                 on_workload_resolved_count: Arc::new(AtomicUsize::new(0)),
                 named_instance_support: false,
+                serves_unnamed_too: false,
                 claims_from: None,
                 host_owned: Vec::new(),
                 bound_interfaces: Arc::new(Mutex::new(Vec::new())),
@@ -3089,6 +3093,13 @@ mod tests {
 
         fn with_named_instance_support(mut self) -> Self {
             self.named_instance_support = true;
+            self
+        }
+
+        /// Serves labeled and unlabeled imports off one backend, the way a host
+        /// component plugin does, so it never defers a plain import.
+        fn serving_unnamed_too(mut self) -> Self {
+            self.serves_unnamed_too = true;
             self
         }
 
@@ -3127,6 +3138,10 @@ mod tests {
 
         fn supports_named_instances(&self) -> bool {
             self.named_instance_support
+        }
+
+        fn defers_unnamed_instances(&self) -> bool {
+            self.named_instance_support && !self.serves_unnamed_too
         }
 
         fn claims(&self, interface: &WitInterface) -> bool {
@@ -4315,6 +4330,54 @@ mod tests {
 
         assert_eq!(bound_plugins.len(), 1);
         assert_eq!(bound_plugins[0].0.id(), "blobstore-a-newer");
+    }
+
+    /// A plugin that serves labeled *and* plain imports off one backend keeps
+    /// its plain imports when a single-backend native serves the same
+    /// interface. A host component plugin is that shape: the operator deployed
+    /// it to answer `wasi:keyvalue`, and declaring a binding on it says which
+    /// labels it answers to — not that it has stopped answering the unlabeled
+    /// import it was already serving.
+    #[tokio::test]
+    async fn test_a_dual_mode_plugin_keeps_its_plain_imports() {
+        let iface = WitInterface::from("wasi:blobstore/container");
+
+        // Sorts first, so ordering alone cannot be what decides this.
+        let dual = Arc::new(
+            MockPlugin::new("blobstore-a-component", vec![iface.clone()], vec![])
+                .with_named_instance_support()
+                .serving_unnamed_too(),
+        );
+        let native = Arc::new(MockPlugin::new(
+            "blobstore-b-native",
+            vec![iface.clone()],
+            vec![],
+        ));
+
+        let mut plugins = HashMap::new();
+        plugins.insert(dual.id(), dual.clone() as Arc<dyn HostPlugin>);
+        plugins.insert(native.id(), native.clone() as Arc<dyn HostPlugin>);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![iface],
+        );
+
+        let bound_plugins = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .unwrap();
+
+        assert_eq!(bound_plugins.len(), 1);
+        assert_eq!(
+            bound_plugins[0].0.id(),
+            "blobstore-a-component",
+            "a plugin serving both must not hand its unlabeled import to a native"
+        );
     }
 
     /// Tests basic plugin binding with one plugin and one component.

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2323,11 +2323,23 @@ impl UnresolvedWorkload {
                     if plugin_interfaces.includes_bidirectional(wit_interface)
                         && p.claims(wit_interface)
                     {
-                        // an `(implements ..)` named interface is served only
-                        // by a plugin that supports named instances.
-                        let defer_to_other = if wit_interface.name.is_some() {
-                            !p.supports_named_instances()
-                                && other_plugin_serves(plugins, plugin_id, wit_interface, true)
+                        // An `(implements ..)` label routes to the plugin
+                        // whose `host.plugins` entry declares it; failing
+                        // that, to one that supports named instances. A plain
+                        // import stays with a plugin that serves it plainly.
+                        let defer_to_other = if let Some(label) = wit_interface.name.as_deref() {
+                            match declaring_plugin(plugins, plugin_bindings, label, wit_interface) {
+                                Some(owner) => owner != *plugin_id,
+                                None => {
+                                    !p.supports_named_instances()
+                                        && other_plugin_serves(
+                                            plugins,
+                                            plugin_id,
+                                            wit_interface,
+                                            true,
+                                        )
+                                }
+                            }
                         } else {
                             p.defers_unnamed_instances()
                                 && other_plugin_serves(plugins, plugin_id, wit_interface, false)
@@ -2396,23 +2408,22 @@ impl UnresolvedWorkload {
                 // one package need two backends to route between. A plugin
                 // serving a single instance has one, and collapsing them into
                 // it delivers one binding's configuration under both names.
-                //
-                // A label equal to the plugin's own id addresses the plugin
-                // rather than a backend, and reads as unnamed here exactly as
-                // it does in [`crate::plugin::PluginBindingSet`].
+                // The operator declaring names under the plugin's
+                // `host.plugins` entry says it routes them, whatever it
+                // reports on its own.
+                let routes_names =
+                    p.supports_named_instances() || declared.binding_names().next().is_some();
                 let mut ns_pkg_bindings: BTreeMap<(&str, &str), BTreeSet<&str>> = BTreeMap::new();
                 for iface in &plugin_matched_interfaces {
-                    let binding = match iface.name.as_deref() {
-                        Some(name) if name != *plugin_id => name,
-                        _ => "",
-                    };
+                    let binding =
+                        crate::plugin::binding_of(plugin_id, iface.name.as_deref()).unwrap_or("");
                     ns_pkg_bindings
                         .entry((iface.namespace.as_str(), iface.package.as_str()))
                         .or_default()
                         .insert(binding);
                 }
                 for ((ns, pkg), bindings) in ns_pkg_bindings {
-                    if bindings.len() > 1 && !p.supports_named_instances() {
+                    if bindings.len() > 1 && !routes_names {
                         let named: Vec<&str> =
                             bindings.iter().copied().filter(|b| !b.is_empty()).collect();
                         // Plugins bind in id order, so earlier ones are already
@@ -2913,10 +2924,10 @@ async fn unbind_all(workload_id: &str, bound: &[BoundPluginWithInterfaces], reas
     }
 }
 
-/// Returns whether some *other* registered plugin (not `self_id`) with
-/// `supports_named_instances() == want_named` can serve `iface`.
-/// Used to determine whether a plugin can defer an `(implements ..)`
-///  interface to a named-capable one, and vice versa).
+/// Returns whether some *other* registered plugin (not `self_id`) can take
+/// `iface` off this one's hands: with `want_named`, one that supports named
+/// instances; without, one that serves plain imports itself rather than
+/// deferring them ([`HostPlugin::defers_unnamed_instances`]).
 ///
 /// A plugin that would refuse `iface` via [`HostPlugin::claims`] is not a
 /// deferral target: deferring to it would leave the interface bound by nobody.
@@ -2928,9 +2939,33 @@ fn other_plugin_serves(
 ) -> bool {
     plugins.iter().any(|(id, q)| {
         *id != self_id
-            && q.supports_named_instances() == want_named
+            && (if want_named {
+                q.supports_named_instances()
+            } else {
+                !q.defers_unnamed_instances()
+            })
             && q.world().includes_bidirectional(iface)
             && q.claims(iface)
+    })
+}
+
+/// The plugin whose `host.plugins` entry declares `label` and that serves
+/// `iface`, if any — lowest id first, so the answer is stable. An operator's
+/// declaration is the routing key: it beats id order and whatever the plugins
+/// report for named-instance support.
+fn declaring_plugin(
+    plugins: &HashMap<&'static str, Arc<dyn HostPlugin + 'static>>,
+    plugin_bindings: &crate::plugin::PluginBindings,
+    label: &str,
+    iface: &WitInterface,
+) -> Option<&'static str> {
+    plugin_bindings.plugin_ids().find_map(|id| {
+        let (id, q) = plugins.get_key_value(id)?;
+        let declares = plugin_bindings
+            .for_plugin(id)
+            .binding_names()
+            .any(|name| name == label);
+        (declares && q.world().includes_bidirectional(iface) && q.claims(iface)).then_some(*id)
     })
 }
 
@@ -4410,6 +4445,109 @@ mod tests {
             bound_plugins[0].0.id(),
             "blobstore-a-component",
             "a plugin serving both must not hand its unlabeled import to a native"
+        );
+    }
+
+    /// A multiplexer defers a plain import to any plugin that serves plain
+    /// imports itself — including one that also routes labels. Keying the
+    /// deferral target on named-instance support alone would have the
+    /// multiplexer keep the import the moment the other plugin grew a label.
+    #[tokio::test]
+    async fn test_a_multiplexer_defers_plain_imports_to_a_dual_mode_plugin() {
+        let iface = WitInterface::from("wasi:blobstore/container");
+
+        // Sorts first, so it is offered the import before the dual plugin.
+        let mux = Arc::new(
+            MockPlugin::new("aaa-multiplexed", vec![iface.clone()], vec![])
+                .with_named_instance_support(),
+        );
+        let dual = Arc::new(
+            MockPlugin::new("zzz-component", vec![iface.clone()], vec![])
+                .with_named_instance_support()
+                .serving_unnamed_too(),
+        );
+
+        let mut plugins = HashMap::new();
+        plugins.insert(mux.id(), mux.clone() as Arc<dyn HostPlugin>);
+        plugins.insert(dual.id(), dual.clone() as Arc<dyn HostPlugin>);
+
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![iface],
+        );
+
+        let bound_plugins = workload
+            .bind_plugins(&plugins, &crate::plugin::PluginBindings::new())
+            .await
+            .unwrap();
+
+        assert_eq!(bound_plugins.len(), 1);
+        assert_eq!(
+            bound_plugins[0].0.id(),
+            "zzz-component",
+            "the multiplexer must hand a plain import to the plugin serving it plainly"
+        );
+    }
+
+    /// An `(implements ..)` label declared under a plugin's `host.plugins`
+    /// entry routes to that plugin: ahead of id order, and whether or not the
+    /// plugin reports named-instance support of its own. The declaration also
+    /// lets it take a named entry beside the unnamed one.
+    #[tokio::test]
+    async fn test_a_declared_label_routes_to_the_declaring_plugin() {
+        let iface = WitInterface::from("wasi:blobstore/container");
+
+        // Sorts first and supports names, so without the declaration it would
+        // claim the label.
+        let mux = Arc::new(
+            MockPlugin::new("aaa-multiplexed", vec![iface.clone()], vec![])
+                .with_named_instance_support(),
+        );
+        let component = Arc::new(MockPlugin::new(
+            "zzz-component",
+            vec![iface.clone()],
+            vec![],
+        ));
+
+        let mut plugins = HashMap::new();
+        plugins.insert(mux.id(), mux.clone() as Arc<dyn HostPlugin>);
+        plugins.insert(component.id(), component.clone() as Arc<dyn HostPlugin>);
+
+        let mut labeled = iface.clone();
+        labeled.name = Some("tenant-a".to_string());
+        let mut workload = UnresolvedWorkload::new(
+            "test-workload-id".to_string(),
+            "test-workload".to_string(),
+            "test-namespace".to_string(),
+            None,
+            vec![create_test_component("component1")],
+            vec![iface, labeled],
+        );
+
+        let declared = crate::plugin::PluginBindings::new().with_plugin(
+            crate::plugin::PluginBindingSet::new("zzz-component")
+                .with_binding("tenant-a", HashMap::new()),
+        );
+        let bound_plugins = workload.bind_plugins(&plugins, &declared).await.unwrap();
+
+        assert_eq!(
+            bound_plugins.len(),
+            1,
+            "both entries must land on the declaring plugin, got {:?}",
+            bound_plugins
+                .iter()
+                .map(|(p, _)| p.id())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(bound_plugins[0].0.id(), "zzz-component");
+        assert_eq!(
+            mux.get_call_count("on_workload_bind"),
+            0,
+            "a label the operator declared elsewhere is not the multiplexer's"
         );
     }
 

--- a/crates/wash-runtime/src/host/job_registry.rs
+++ b/crates/wash-runtime/src/host/job_registry.rs
@@ -252,6 +252,7 @@ mod tests {
         CallerIdentity {
             workload_id: Arc::from(workload),
             component_id: Some(Arc::from(component)),
+            binding: None,
         }
     }
 

--- a/crates/wash-runtime/src/plugin/bindings.rs
+++ b/crates/wash-runtime/src/plugin/bindings.rs
@@ -631,15 +631,9 @@ impl PluginBindingSet {
     }
 
     /// The binding name an interface routes under: its `(implements ..)` label,
-    /// or the unnamed binding.
-    ///
-    /// A label equal to the plugin's own id is how a workload routes directly
-    /// to a plugin rather than naming a backend, so it reads as unnamed here.
+    /// or the unnamed binding. See [`binding_of`].
     fn binding_name<'a>(&self, interface: &'a WitInterface) -> &'a str {
-        match interface.name.as_deref() {
-            Some(name) if name != self.plugin_id => name,
-            _ => UNNAMED_BINDING,
-        }
+        binding_of(&self.plugin_id, interface.name.as_deref()).unwrap_or(UNNAMED_BINDING)
     }
 
     /// Fold every entry a workload wrote for one binding into a single config.
@@ -1134,6 +1128,19 @@ fn first_widening_element(
         .into_iter()
         .find(|element| !narrows(key, host, element))
         .map(str::to_string)
+}
+
+/// The binding an `(implements ..)` label names on `plugin_id`, or `None` for
+/// the unnamed binding.
+///
+/// A label equal to the plugin's own id is how a workload routes directly to
+/// a plugin rather than naming a backend, so it reads as unnamed. Every place
+/// that turns a label into a binding — config resolution, the engine's
+/// per-package binding count, a plugin's own linker wiring — goes through
+/// this so they agree.
+#[must_use]
+pub fn binding_of<'a>(plugin_id: &str, label: Option<&'a str>) -> Option<&'a str> {
+    label.filter(|name| *name != plugin_id)
 }
 
 /// How a binding reads in an error message.

--- a/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
+++ b/crates/wash-runtime/src/plugin/component_host/lifecycle.rs
@@ -190,10 +190,13 @@ pub(super) fn replay_snapshot(
         .map(|(workload_id, info)| LifecycleReplay {
             interface: Arc::clone(&lifecycle.interface),
             func: Arc::clone(&lifecycle.bind.name),
-            // A replayed bind is about the workload, not any component of it.
+            // A replayed bind is about the workload, not any component of it
+            // nor any one of its bindings, which are listed on the
+            // `workload-info` the hook is handed.
             caller: CallerIdentity {
                 workload_id: Arc::clone(workload_id),
                 component_id: None,
+                binding: None,
             },
             args: vec![Relocated::Val(info.clone())],
             result_tys: Arc::clone(&lifecycle.bind.result_tys),
@@ -304,6 +307,7 @@ pub(super) async fn send_lifecycle_job(
         caller: CallerIdentity {
             workload_id: Arc::clone(workload_id),
             component_id: None,
+            binding: None,
         },
         args: vec![Relocated::Val(arg)],
         result_tys: Arc::clone(&func.result_tys),

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -310,7 +310,7 @@ pub struct ComponentHostPlugin {
     /// imports — so the declaration is what says which labels this host serves.
     /// Nothing declared means nothing changes: label routing stays off and the
     /// plugin matches exactly what it did before.
-    named_bindings: Arc<AtomicBool>,
+    named_bindings: AtomicBool,
     state: Arc<ComponentHostPluginState>,
 }
 
@@ -467,7 +467,7 @@ impl ComponentHostPlugin {
             direct_binds: Arc::from(direct_binds),
             network: crate::host::ports::NetworkHandle::new(),
             socket_policy: socket_policy.unwrap_or_default(),
-            named_bindings: Arc::new(AtomicBool::new(false)),
+            named_bindings: AtomicBool::new(false),
             state,
         })
     }
@@ -566,14 +566,26 @@ impl ComponentHostPlugin {
             if !interfaces.contains(&exported.wit.namespace, &exported.wit.package, &iface_names) {
                 continue;
             }
-            for binding in import_labels(&world, &exported.wit, self.id) {
+            for label in import_labels(&world, &exported.wit, self.id) {
                 // The component model names an `(implements ..)` import by its
                 // label, so that — not the interface — is the linker instance
                 // that has to be defined for it.
-                let instance = match &binding {
+                let instance = match &label {
                     Some(label) => label.as_ref(),
                     None => exported.name.as_ref(),
                 };
+                // The instance comes from the component's world; the binding
+                // *name* has to come from the entry whose config was resolved,
+                // and the two are not the same question.
+                // [`crate::wit::WitWorld::uses`] ignores labels, so an unnamed
+                // entry matches a labeled import: wire the label, because the
+                // import is unresolved otherwise, but report only a name the
+                // plugin was handed config for at bind time. Reporting the
+                // other would have `get-binding-name` name a binding
+                // `on-workload-bind` never mentioned.
+                let binding = label
+                    .clone()
+                    .filter(|name| entry_named(&interfaces, &exported.wit, name));
                 add_capabilities_to_linker(
                     linker,
                     &self.state,
@@ -584,6 +596,7 @@ impl ComponentHostPlugin {
                 debug!(
                     id = self.id,
                     interface = %exported.name,
+                    instance,
                     binding = binding.as_deref().unwrap_or("<unnamed>"),
                     "wired host component capability"
                 );
@@ -591,6 +604,19 @@ impl ComponentHostPlugin {
         }
         Ok(())
     }
+}
+
+/// Whether a matched entry for `exported`'s package was declared under `name`.
+///
+/// The workload's entries as they reached this bind, so this answers "did the
+/// plugin see a binding called this?" — the one `on-workload-bind` delivered
+/// config for.
+fn entry_named(interfaces: &WitInterfaces<'_>, exported: &WitInterface, name: &str) -> bool {
+    interfaces.iter().any(|entry| {
+        entry.namespace == exported.namespace
+            && entry.package == exported.package
+            && entry.name.as_deref() == Some(name)
+    })
 }
 
 /// The bindings a component imports `exported` under: one entry per distinct
@@ -764,6 +790,22 @@ impl HostPlugin for ComponentHostPlugin {
     /// those names, so it is what turns the routing on.
     fn supports_named_instances(&self) -> bool {
         self.named_bindings.load(Ordering::Relaxed)
+    }
+
+    /// Never: one store answers a labeled and an unlabeled import alike.
+    ///
+    /// The deferral this turns off is for a multiplexer that routes labels
+    /// between backends it names in code and has no plain one — not for a
+    /// plugin an operator deployed to serve an interface. Left at the default
+    /// it follows [`HostPlugin::supports_named_instances`], and declaring a
+    /// single binding would hand every plain import of every package this
+    /// plugin serves to whichever single-backend native serves it too
+    /// (`wasi:keyvalue`, `wasi:blobstore`, `wasi:config` and
+    /// `wasmcloud:messaging` all have one registered by default). A `bindings`
+    /// block says which labels this plugin answers to; it says nothing about
+    /// the imports it was already serving.
+    fn defers_unnamed_instances(&self) -> bool {
+        false
     }
 
     fn set_workload_failure_sink(&self, sink: crate::plugin::WorkloadFailureSink) {
@@ -2243,6 +2285,45 @@ mod tests {
         );
     }
 
+    /// One entry per matched binding, the way `on_workload_item_bind` is
+    /// handed them.
+    fn matched(entries: &[Option<&str>]) -> HashSet<WitInterface> {
+        entries
+            .iter()
+            .map(|name| {
+                let mut wit = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+                wit.name = name.map(str::to_string);
+                wit
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_label_the_workload_declared_is_reported_as_the_binding() {
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        let entries = matched(&[Some("restricted")]);
+        assert!(entry_named(
+            &WitInterfaces::new(&entries),
+            &served,
+            "restricted"
+        ));
+    }
+
+    /// `WitWorld::uses` ignores labels, so a plain entry matches a labeled
+    /// import. The label still has to be wired — the import is unresolved
+    /// otherwise — but it is not a binding the plugin was handed config for, so
+    /// `get-binding-name` must not name it.
+    #[test]
+    fn a_label_no_entry_declared_is_not_a_binding() {
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        let entries = matched(&[None]);
+        assert!(!entry_named(
+            &WitInterfaces::new(&entries),
+            &served,
+            "restricted"
+        ));
+    }
+
     #[test]
     fn a_different_package_wires_nothing() {
         let served = WitInterface::from("acme:kv/store@0.1.0");
@@ -2269,7 +2350,7 @@ mod tests {
     /// The `wasmcloud:host/workload-call` import every opted-in plugin
     /// declares, as a WAT line to paste into a test component.
     const DECLARES_WORKLOAD_CALLS: &str =
-        r#"(import "wasmcloud:host/workload-call@0.1.3" (instance))"#;
+        r#"(import "wasmcloud:host/workload-call@0.1.4" (instance))"#;
 
     /// Only an import nothing else can satisfy becomes the workload's to
     /// export. A native serving the interface wins — so introducing a built-in

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -66,7 +66,7 @@
 //! to the workload whose capability call is being served.
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -300,6 +300,17 @@ pub struct ComponentHostPlugin {
     network: crate::host::ports::NetworkHandle,
     /// The host-level half of this plugin's socket policy.
     socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
+    /// Whether the operator declared any named binding for this plugin, set
+    /// once from its `host.plugins` entry by
+    /// [`HostPlugin::validate_bindings`] and read by
+    /// [`HostPlugin::supports_named_instances`].
+    ///
+    /// A wasm plugin cannot name its backends in code the way a native
+    /// multiplexer does — it has one store and serves whatever a workload
+    /// imports — so the declaration is what says which labels this host serves.
+    /// Nothing declared means nothing changes: label routing stays off and the
+    /// plugin matches exactly what it did before.
+    named_bindings: Arc<AtomicBool>,
     state: Arc<ComponentHostPluginState>,
 }
 
@@ -456,6 +467,7 @@ impl ComponentHostPlugin {
             direct_binds: Arc::from(direct_binds),
             network: crate::host::ports::NetworkHandle::new(),
             socket_policy: socket_policy.unwrap_or_default(),
+            named_bindings: Arc::new(AtomicBool::new(false)),
             state,
         })
     }
@@ -543,6 +555,9 @@ impl ComponentHostPlugin {
             );
         }
 
+        // Read before the linker is borrowed mutably: the labels below come from
+        // the component's own type, which is what says how it names each import.
+        let world = item.world();
         let linker = item.linker();
         for exported in self.exports.iter() {
             let iface_names: Vec<&str> =
@@ -551,11 +566,79 @@ impl ComponentHostPlugin {
             if !interfaces.contains(&exported.wit.namespace, &exported.wit.package, &iface_names) {
                 continue;
             }
-            add_capabilities_to_linker(linker, &self.state, exported)?;
-            debug!(id = self.id, interface = %exported.name, "wired host component capability");
+            for binding in import_labels(&world, &exported.wit, self.id) {
+                // The component model names an `(implements ..)` import by its
+                // label, so that — not the interface — is the linker instance
+                // that has to be defined for it.
+                let instance = match &binding {
+                    Some(label) => label.as_ref(),
+                    None => exported.name.as_ref(),
+                };
+                add_capabilities_to_linker(
+                    linker,
+                    &self.state,
+                    exported,
+                    instance,
+                    binding.clone(),
+                )?;
+                debug!(
+                    id = self.id,
+                    interface = %exported.name,
+                    binding = binding.as_deref().unwrap_or("<unnamed>"),
+                    "wired host component capability"
+                );
+            }
         }
         Ok(())
     }
+}
+
+/// The bindings a component imports `exported` under: one entry per distinct
+/// `(implements ..)` label, and `None` where it imports the interface plainly.
+///
+/// Taken from the component's own world rather than from the manifest's matched
+/// entries, because the two answer different questions. An entry is the
+/// operator- and manifest-facing declaration of a binding, shared by every item
+/// of the workload; what has to be *defined on this item's linker* is whatever
+/// this component actually imports, under the name it imports it by. A component
+/// that imports plainly while its manifest entry carries a label needs the plain
+/// instance, and would otherwise be left with an unresolved import.
+///
+/// A label equal to the plugin's own id addresses the plugin rather than one of
+/// its bindings, so it reads as unnamed here — the same rule
+/// [`crate::plugin::PluginBindingSet`] applies when it resolves config, and the
+/// two have to agree or a workload would be configured under one binding and
+/// served under another.
+///
+/// Empty only when the component imports nothing of the package, in which case
+/// there is nothing to wire.
+fn import_labels(
+    world: &WitWorld,
+    exported: &WitInterface,
+    plugin_id: &str,
+) -> Vec<Option<Arc<str>>> {
+    let mut labels: Vec<Option<Arc<str>>> = Vec::new();
+    for imported in &world.imports {
+        if !imported.same_package(exported)
+            || !exported
+                .interfaces
+                .iter()
+                .any(|name| imported.interfaces.contains(name))
+        {
+            continue;
+        }
+        let label = match imported.name.as_deref() {
+            Some(name) if name != plugin_id => Some(Arc::from(name)),
+            _ => None,
+        };
+        if !labels.contains(&label) {
+            labels.push(label);
+        }
+    }
+    // Sorted so a component importing one interface under several labels wires
+    // them in the same order every time, and the unnamed instance first.
+    labels.sort();
+    labels
 }
 
 /// Filters `plugins` down to the natives — every entry that is not itself a
@@ -644,6 +727,43 @@ impl HostPlugin for ComponentHostPlugin {
 
     fn world(&self) -> WitWorld {
         self.world.clone()
+    }
+
+    /// Record whether this host serves named bindings of this plugin.
+    ///
+    /// The generic layer has already refused a binding named after the plugin
+    /// itself and any key a closed schema does not know; a component plugin
+    /// declares no schema, so there is nothing else here to parse. What this
+    /// does need from the declaration is the one fact
+    /// [`HostPlugin::supports_named_instances`] cannot ask for on its own:
+    /// whether the operator declared any binding names at all.
+    fn validate_bindings(&self, declared: &crate::plugin::PluginBindingSet) -> anyhow::Result<()> {
+        let named = declared.binding_names().next().is_some();
+        self.named_bindings.store(named, Ordering::Relaxed);
+        if named {
+            debug!(
+                id = self.id,
+                bindings = %declared.binding_names().collect::<Vec<_>>().join(", "),
+                "host component plugin serves named bindings"
+            );
+        }
+        Ok(())
+    }
+
+    /// Whether an `(implements ..)` label routes to this plugin.
+    ///
+    /// True exactly when the operator declared bindings for it. A component
+    /// plugin can always *serve* a label — it wires the labeled linker instance
+    /// to the same store and hands the label to the guest through
+    /// `wasmcloud:host/identity#get-binding-name` — but "can serve" is not the
+    /// question this answers. It decides which plugin a label routes to, and a
+    /// plugin claiming every label unconditionally would take plain, unlabeled
+    /// imports away from the single-backend natives that serve them today
+    /// (`supports_named_instances` defers in both directions). The operator's
+    /// `bindings` block is the statement that this plugin is the one serving
+    /// those names, so it is what turns the routing on.
+    fn supports_named_instances(&self) -> bool {
+        self.named_bindings.load(Ordering::Relaxed)
     }
 
     fn set_workload_failure_sink(&self, sink: crate::plugin::WorkloadFailureSink) {
@@ -1213,12 +1333,17 @@ async fn build_plugin_linker(
     let mut linked = std::collections::HashSet::new();
     for imported in introspect_imports(component)? {
         if exports.iter().any(|e| e.name == imported.name) {
-            add_capabilities_to_linker(&mut linker, state, &imported).with_context(|| {
-                format!(
-                    "failed to wire self-import {} on plugin '{id}'",
-                    imported.name
-                )
-            })?;
+            // A self-import is the plugin calling its own capability, so it
+            // carries no binding: the label an outside caller routed under says
+            // nothing about a call the plugin makes to itself.
+            let instance = Arc::clone(&imported.name);
+            add_capabilities_to_linker(&mut linker, state, &imported, &instance, None)
+                .with_context(|| {
+                    format!(
+                        "failed to wire self-import {} on plugin '{id}'",
+                        imported.name
+                    )
+                })?;
             linked.insert(Arc::clone(&imported.name));
         }
     }
@@ -1326,6 +1451,28 @@ fn install_host_identity(
             },
         )
         .map_err(|e| e.context("failed to define wasmcloud:host/identity#get-component-id"))?;
+    let binding_state = Arc::clone(state);
+    instance
+        .func_new(
+            "get-binding-name",
+            move |mut store, _ty, _params, results| {
+                let root = caller_root_task(&mut store);
+                // `option<string>` rather than the empty string `get-component-id`
+                // is stuck with: a binding genuinely has no name when the caller
+                // imported the interface plainly, and that is the common case
+                // rather than a degradation, so it gets a representation of its
+                // own from the start.
+                let binding = root
+                    .and_then(|task| binding_state.registry()?.caller_for_task(task))
+                    .and_then(|c| c.binding.clone())
+                    .map(|name| Val::String(name.to_string()));
+                if let Some(slot) = results.first_mut() {
+                    *slot = Val::Option(binding.map(Box::new));
+                }
+                Ok(())
+            },
+        )
+        .map_err(|e| e.context("failed to define wasmcloud:host/identity#get-binding-name"))?;
     Ok(())
 }
 
@@ -1409,14 +1556,26 @@ fn install_host_cancel(
 /// plugin's persistent store via the channel held by `state`. Used on a
 /// workload's linker ([`ComponentHostPlugin::on_workload_item_bind`]) and on the
 /// plugin's own linker for self-imports ([`build_plugin_linker`]).
+///
+/// `instance_name` is the name the *caller* imports the interface under, which
+/// is `iface.name` for a plain import and the `(implements ..)` label for a
+/// labeled one — the component model names such an import by its label, so a
+/// definition under the interface's own name would leave it unsatisfied.
+/// `binding` carries that label onward to every call the shims route, so the
+/// plugin can tell one binding's calls from another's
+/// (`wasmcloud:host/identity#get-binding-name`). The interface addressed on the
+/// plugin's own instance is always `iface.name`: the label names a binding of
+/// this plugin, never a different interface.
 fn add_capabilities_to_linker(
     linker: &mut Linker<SharedCtx>,
     state: &Arc<ComponentHostPluginState>,
     iface: &ExportedInterface,
+    instance_name: &str,
+    binding: Option<Arc<str>>,
 ) -> anyhow::Result<()> {
     let mut linker_instance = linker
-        .instance(&iface.name)
-        .map_err(|e| e.context(format!("failed to open linker instance {}", iface.name)))?;
+        .instance(instance_name)
+        .map_err(|e| e.context(format!("failed to open linker instance {instance_name}")))?;
 
     // Register each resource the interface defines as a cross-store proxy. A
     // caller holds an opaque proxy; dropping it here routes a drop of the real
@@ -1435,8 +1594,7 @@ fn add_capabilities_to_linker(
             )
             .map_err(|e| {
                 e.context(format!(
-                    "failed to register proxied resource {}/{}",
-                    iface.name, resource
+                    "failed to register proxied resource {instance_name}/{resource}"
                 ))
             })?;
     }
@@ -1444,6 +1602,7 @@ fn add_capabilities_to_linker(
     for func in &iface.funcs {
         let state = Arc::clone(state);
         let interface = Arc::clone(&iface.name);
+        let call_binding = binding.clone();
         let func_name = Arc::clone(&func.name);
         let param_tys = Arc::clone(&func.param_tys);
         let result_tys = Arc::clone(&func.result_tys);
@@ -1454,13 +1613,14 @@ fn add_capabilities_to_linker(
                 move |accessor, _func_ty, params: &[Val], results: &mut [Val]| {
                     let state = Arc::clone(&state);
                     let interface = Arc::clone(&interface);
+                    let binding = call_binding.clone();
                     let func = Arc::clone(&func_name);
                     let param_tys = Arc::clone(&param_tys);
                     let result_tys = Arc::clone(&result_tys);
                     Box::pin(async move {
                         route_capability_call(
-                            accessor, &state, interface, func, params, &param_tys, result_tys,
-                            results,
+                            accessor, &state, interface, binding, func, params, &param_tys,
+                            result_tys, results,
                         )
                         .await
                     })
@@ -1468,8 +1628,8 @@ fn add_capabilities_to_linker(
             )
             .map_err(|e| {
                 e.context(format!(
-                    "failed to install capability shim for {}/{}",
-                    iface.name, func.name
+                    "failed to install capability shim for {instance_name}/{}",
+                    func.name
                 ))
             })?;
     }
@@ -1520,6 +1680,7 @@ async fn route_capability_call(
     accessor: &Accessor<SharedCtx>,
     state: &ComponentHostPluginState,
     interface: Arc<str>,
+    binding: Option<Arc<str>>,
     func: Arc<str>,
     params: &[Val],
     param_tys: &[Type],
@@ -1539,6 +1700,11 @@ async fn route_capability_call(
                 CallerIdentity {
                     workload_id: Arc::clone(&ctx.workload_id),
                     component_id: Some(Arc::clone(&ctx.component_id)),
+                    // Fixed when the shim was installed, not read from the
+                    // call: one linker instance is one binding, so the label
+                    // the caller imported under is already known here and
+                    // cannot be influenced by anything the guest passes.
+                    binding: binding.clone(),
                 }
             };
             let mut dones = Vec::new();
@@ -2001,6 +2167,86 @@ mod tests {
             *self.seen_id.lock().unwrap() = Some(item.id().to_string());
             Ok(())
         }
+    }
+
+    /// A world importing `wasmcloud:secrets/store` under each of `labels`
+    /// (`None` for a plain import).
+    fn importing(labels: &[Option<&str>]) -> WitWorld {
+        WitWorld {
+            imports: labels
+                .iter()
+                .map(|label| {
+                    let mut wit = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+                    wit.name = label.map(str::to_string);
+                    wit
+                })
+                .collect(),
+            exports: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn a_plain_import_wires_the_interfaces_own_instance() {
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        assert_eq!(
+            import_labels(&importing(&[None]), &served, "k8s-secrets"),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn a_labeled_import_wires_the_label() {
+        // The component model names an `(implements ..)` import by its label, so
+        // that is the linker instance the plugin has to define — defining the
+        // interface's own name would leave the import unresolved.
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        assert_eq!(
+            import_labels(&importing(&[Some("restricted")]), &served, "k8s-secrets"),
+            vec![Some(Arc::from("restricted"))]
+        );
+    }
+
+    #[test]
+    fn a_component_importing_both_gets_both_instances() {
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        assert_eq!(
+            import_labels(
+                &importing(&[None, Some("restricted")]),
+                &served,
+                "k8s-secrets"
+            ),
+            vec![None, Some(Arc::from("restricted"))],
+            "the unnamed instance sorts first, and neither displaces the other"
+        );
+    }
+
+    #[test]
+    fn a_label_equal_to_the_plugin_id_is_the_unnamed_binding() {
+        // Addressing the plugin is not naming one of its bindings. This has to
+        // agree with `PluginBindingSet::binding_name`, or a workload would be
+        // configured under one binding and served under another.
+        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        assert_eq!(
+            import_labels(&importing(&[Some("k8s-secrets")]), &served, "k8s-secrets"),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn an_interface_the_component_does_not_import_wires_nothing() {
+        // A plugin exporting more than the component uses: an entry naming the
+        // package matches the whole plugin, but only what the component
+        // actually imports may be defined on its linker.
+        let served = WitInterface::from("wasmcloud:secrets/reveal@2.1.0");
+        assert!(
+            import_labels(&importing(&[Some("restricted")]), &served, "k8s-secrets").is_empty()
+        );
+    }
+
+    #[test]
+    fn a_different_package_wires_nothing() {
+        let served = WitInterface::from("acme:kv/store@0.1.0");
+        assert!(import_labels(&importing(&[None]), &served, "k8s-secrets").is_empty());
     }
 
     /// Compile `wat` and classify its imports the way plugin construction

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -562,14 +562,14 @@ impl ComponentHostPlugin {
                 .iter()
                 .map(|entry| binding_of(self.id, entry.name.as_deref()))
                 .collect();
-            let named: Vec<&str> = declared.iter().flatten().copied().collect();
             for label in import_labels(&world, &exported.wit) {
                 // The binding a call through this import carries: the matched
                 // entry of the same shape. A labeled import needs an entry
-                // naming its label; a plain import takes the unnamed entry, or
-                // the one named entry when that is all the workload declared.
-                // Anything else is an import the plugin was handed no config
-                // for, refused here rather than left as an unresolved import.
+                // naming its label and a plain import needs the unnamed entry.
+                // A named entry says nothing about a plain import — the host
+                // cannot vouch for a binding the component never asked for by
+                // name — so a mismatch is refused here rather than bound
+                // unnamed or left as an unresolved import.
                 let binding = match binding_of(self.id, label.as_deref()) {
                     Some(name) if declared.contains(&Some(name)) => Some(name),
                     Some(name) => anyhow::bail!(
@@ -584,21 +584,23 @@ impl ComponentHostPlugin {
                         self.id,
                     ),
                     None if declared.contains(&None) => None,
-                    None => match named[..] {
-                        [only] => Some(only),
-                        _ => anyhow::bail!(
-                            "component '{}' imports {} plainly, but every {}:{} entry of workload \
-                             '{}' is named ({}); import it under one of those labels or add an \
-                             unnamed entry (host component plugin '{}')",
-                            item.id(),
-                            exported.name,
-                            exported.wit.namespace,
-                            exported.wit.package,
-                            item.workload_id(),
-                            named.join(", "),
-                            self.id,
-                        ),
-                    },
+                    None => anyhow::bail!(
+                        "component '{}' imports {} plainly, but every {}:{} entry of workload \
+                         '{}' is named ({}); import it under one of those labels or add an \
+                         unnamed entry (host component plugin '{}')",
+                        item.id(),
+                        exported.name,
+                        exported.wit.namespace,
+                        exported.wit.package,
+                        item.workload_id(),
+                        declared
+                            .iter()
+                            .flatten()
+                            .copied()
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        self.id,
+                    ),
                 }
                 .map(Arc::<str>::from);
                 add_capabilities_to_linker(

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -65,8 +65,8 @@
 //! workload a call goes to, and the fallback that sends an unaddressed call back
 //! to the workload whose capability call is being served.
 
-use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -95,6 +95,7 @@ use crate::host::trigger_service::{
     decode_bind_reply,
 };
 use crate::oci::OciConfig;
+use crate::plugin::binding_of;
 use crate::plugin::component_plugin_spec::ComponentPluginSpec;
 use crate::plugin::{HostPlugin, WitInterfaces};
 use crate::sockets::loopback;
@@ -300,17 +301,6 @@ pub struct ComponentHostPlugin {
     network: crate::host::ports::NetworkHandle,
     /// The host-level half of this plugin's socket policy.
     socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
-    /// Whether the operator declared any named binding for this plugin, set
-    /// once from its `host.plugins` entry by
-    /// [`HostPlugin::validate_bindings`] and read by
-    /// [`HostPlugin::supports_named_instances`].
-    ///
-    /// A wasm plugin cannot name its backends in code the way a native
-    /// multiplexer does — it has one store and serves whatever a workload
-    /// imports — so the declaration is what says which labels this host serves.
-    /// Nothing declared means nothing changes: label routing stays off and the
-    /// plugin matches exactly what it did before.
-    named_bindings: AtomicBool,
     state: Arc<ComponentHostPluginState>,
 }
 
@@ -467,7 +457,6 @@ impl ComponentHostPlugin {
             direct_binds: Arc::from(direct_binds),
             network: crate::host::ports::NetworkHandle::new(),
             socket_policy: socket_policy.unwrap_or_default(),
-            named_bindings: AtomicBool::new(false),
             state,
         })
     }
@@ -529,6 +518,10 @@ impl ComponentHostPlugin {
         // here that it really exports it: an item that imports it instead has
         // nobody to serve it, and would otherwise fail later as an unresolved
         // wasmtime import with no mention of this plugin.
+        // The item's own world says what it imports and under which name; the
+        // matched entries say which bindings the workload declared. Both are
+        // needed below, and the world is a recompute, so read it once.
+        let world = item.world();
         for called in self.state.workload_calls.imports() {
             let iface_names: Vec<&str> = called.wit.interfaces.iter().map(String::as_str).collect();
             if !interfaces.contains(&called.wit.namespace, &called.wit.package, &iface_names) {
@@ -538,11 +531,11 @@ impl ComponentHostPlugin {
             // this one included, so an item may be here without touching the
             // interface at all. Only an item that does has anything to answer
             // for below.
-            if !item.world().uses(&called.wit) {
+            if !world.uses(&called.wit) {
                 continue;
             }
             anyhow::ensure!(
-                item.world()
+                world
                     .exports
                     .iter()
                     .any(|exported| exported.contains(&called.wit)),
@@ -555,48 +548,70 @@ impl ComponentHostPlugin {
             );
         }
 
-        // Read before the linker is borrowed mutably: the labels below come from
-        // the component's own type, which is what says how it names each import.
-        let world = item.world();
         let linker = item.linker();
         for exported in self.exports.iter() {
             let iface_names: Vec<&str> =
                 exported.wit.interfaces.iter().map(String::as_str).collect();
             // Only wire interfaces this workload was actually matched on.
-            if !interfaces.contains(&exported.wit.namespace, &exported.wit.package, &iface_names) {
+            let entries =
+                interfaces.matching(&exported.wit.namespace, &exported.wit.package, &iface_names);
+            if entries.is_empty() {
                 continue;
             }
-            for label in import_labels(&world, &exported.wit, self.id) {
-                // The component model names an `(implements ..)` import by its
-                // label, so that — not the interface — is the linker instance
-                // that has to be defined for it.
-                let instance = match &label {
-                    Some(label) => label.as_ref(),
-                    None => exported.name.as_ref(),
-                };
-                // The instance comes from the component's world; the binding
-                // *name* has to come from the entry whose config was resolved,
-                // and the two are not the same question.
-                // [`crate::wit::WitWorld::uses`] ignores labels, so an unnamed
-                // entry matches a labeled import: wire the label, because the
-                // import is unresolved otherwise, but report only a name the
-                // plugin was handed config for at bind time. Reporting the
-                // other would have `get-binding-name` name a binding
-                // `on-workload-bind` never mentioned.
-                let binding = label
-                    .clone()
-                    .filter(|name| entry_named(&interfaces, &exported.wit, name));
+            let declared: BTreeSet<Option<&str>> = entries
+                .iter()
+                .map(|entry| binding_of(self.id, entry.name.as_deref()))
+                .collect();
+            let named: Vec<&str> = declared.iter().flatten().copied().collect();
+            for label in import_labels(&world, &exported.wit) {
+                // The binding a call through this import carries: the matched
+                // entry of the same shape. A labeled import needs an entry
+                // naming its label; a plain import takes the unnamed entry, or
+                // the one named entry when that is all the workload declared.
+                // Anything else is an import the plugin was handed no config
+                // for, refused here rather than left as an unresolved import.
+                let binding = match binding_of(self.id, label.as_deref()) {
+                    Some(name) if declared.contains(&Some(name)) => Some(name),
+                    Some(name) => anyhow::bail!(
+                        "component '{}' imports {} under label `{name}`, but no {}:{} entry of \
+                         workload '{}' names it; add an entry with `name: {name}` (host \
+                         component plugin '{}')",
+                        item.id(),
+                        exported.name,
+                        exported.wit.namespace,
+                        exported.wit.package,
+                        item.workload_id(),
+                        self.id,
+                    ),
+                    None if declared.contains(&None) => None,
+                    None => match named[..] {
+                        [only] => Some(only),
+                        _ => anyhow::bail!(
+                            "component '{}' imports {} plainly, but every {}:{} entry of workload \
+                             '{}' is named ({}); import it under one of those labels or add an \
+                             unnamed entry (host component plugin '{}')",
+                            item.id(),
+                            exported.name,
+                            exported.wit.namespace,
+                            exported.wit.package,
+                            item.workload_id(),
+                            named.join(", "),
+                            self.id,
+                        ),
+                    },
+                }
+                .map(Arc::<str>::from);
                 add_capabilities_to_linker(
                     linker,
                     &self.state,
                     exported,
-                    instance,
+                    label.as_deref(),
                     binding.clone(),
                 )?;
                 debug!(
                     id = self.id,
                     interface = %exported.name,
-                    instance,
+                    instance = label.as_deref().unwrap_or(&exported.name),
                     binding = binding.as_deref().unwrap_or("<unnamed>"),
                     "wired host component capability"
                 );
@@ -606,65 +621,40 @@ impl ComponentHostPlugin {
     }
 }
 
-/// Whether a matched entry for `exported`'s package was declared under `name`.
+/// The names a component imports `exported` under: `None` for a plain import
+/// and each distinct `(implements ..)` label, unnamed first. From the
+/// component's own world, because that is what has to be defined on its
+/// linker; the manifest's entries say which of them are bindings.
 ///
-/// The workload's entries as they reached this bind, so this answers "did the
-/// plugin see a binding called this?" — the one `on-workload-bind` delivered
-/// config for.
-fn entry_named(interfaces: &WitInterfaces<'_>, exported: &WitInterface, name: &str) -> bool {
-    interfaces.iter().any(|entry| {
-        entry.namespace == exported.namespace
-            && entry.package == exported.package
-            && entry.name.as_deref() == Some(name)
-    })
+/// Versions are matched the way wasmtime's linker matches them — same major,
+/// and same minor below 1.0 — since the plain instance is defined under the
+/// plugin's own version and resolved by that rule.
+fn import_labels(world: &WitWorld, exported: &WitInterface) -> BTreeSet<Option<Arc<str>>> {
+    world
+        .imports
+        .iter()
+        .filter(|imported| {
+            imported.namespace == exported.namespace
+                && imported.package == exported.package
+                && versions_compatible(imported.version.as_ref(), exported.version.as_ref())
+                && exported
+                    .interfaces
+                    .iter()
+                    .any(|name| imported.interfaces.contains(name))
+        })
+        .map(|imported| imported.name.as_deref().map(Arc::from))
+        .collect()
 }
 
-/// The bindings a component imports `exported` under: one entry per distinct
-/// `(implements ..)` label, and `None` where it imports the interface plainly.
-///
-/// Taken from the component's own world rather than from the manifest's matched
-/// entries, because the two answer different questions. An entry is the
-/// operator- and manifest-facing declaration of a binding, shared by every item
-/// of the workload; what has to be *defined on this item's linker* is whatever
-/// this component actually imports, under the name it imports it by. A component
-/// that imports plainly while its manifest entry carries a label needs the plain
-/// instance, and would otherwise be left with an unresolved import.
-///
-/// A label equal to the plugin's own id addresses the plugin rather than one of
-/// its bindings, so it reads as unnamed here — the same rule
-/// [`crate::plugin::PluginBindingSet`] applies when it resolves config, and the
-/// two have to agree or a workload would be configured under one binding and
-/// served under another.
-///
-/// Empty only when the component imports nothing of the package, in which case
-/// there is nothing to wire.
-fn import_labels(
-    world: &WitWorld,
-    exported: &WitInterface,
-    plugin_id: &str,
-) -> Vec<Option<Arc<str>>> {
-    let mut labels: Vec<Option<Arc<str>>> = Vec::new();
-    for imported in &world.imports {
-        if !imported.same_package(exported)
-            || !exported
-                .interfaces
-                .iter()
-                .any(|name| imported.interfaces.contains(name))
-        {
-            continue;
+/// Whether two interface versions resolve to one another under the component
+/// model's semver rule; an unversioned side matches anything.
+fn versions_compatible(a: Option<&semver::Version>, b: Option<&semver::Version>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            a.major == b.major && (a.major != 0 || a.minor == b.minor) && a.pre == b.pre
         }
-        let label = match imported.name.as_deref() {
-            Some(name) if name != plugin_id => Some(Arc::from(name)),
-            _ => None,
-        };
-        if !labels.contains(&label) {
-            labels.push(label);
-        }
+        _ => true,
     }
-    // Sorted so a component importing one interface under several labels wires
-    // them in the same order every time, and the unnamed instance first.
-    labels.sort();
-    labels
 }
 
 /// Filters `plugins` down to the natives — every entry that is not itself a
@@ -755,55 +745,10 @@ impl HostPlugin for ComponentHostPlugin {
         self.world.clone()
     }
 
-    /// Record whether this host serves named bindings of this plugin.
-    ///
-    /// The generic layer has already refused a binding named after the plugin
-    /// itself and any key a closed schema does not know; a component plugin
-    /// declares no schema, so there is nothing else here to parse. What this
-    /// does need from the declaration is the one fact
-    /// [`HostPlugin::supports_named_instances`] cannot ask for on its own:
-    /// whether the operator declared any binding names at all.
-    fn validate_bindings(&self, declared: &crate::plugin::PluginBindingSet) -> anyhow::Result<()> {
-        let named = declared.binding_names().next().is_some();
-        self.named_bindings.store(named, Ordering::Relaxed);
-        if named {
-            debug!(
-                id = self.id,
-                bindings = %declared.binding_names().collect::<Vec<_>>().join(", "),
-                "host component plugin serves named bindings"
-            );
-        }
-        Ok(())
-    }
-
-    /// Whether an `(implements ..)` label routes to this plugin.
-    ///
-    /// True exactly when the operator declared bindings for it. A component
-    /// plugin can always *serve* a label — it wires the labeled linker instance
-    /// to the same store and hands the label to the guest through
-    /// `wasmcloud:host/identity#get-binding-name` — but "can serve" is not the
-    /// question this answers. It decides which plugin a label routes to, and a
-    /// plugin claiming every label unconditionally would take plain, unlabeled
-    /// imports away from the single-backend natives that serve them today
-    /// (`supports_named_instances` defers in both directions). The operator's
-    /// `bindings` block is the statement that this plugin is the one serving
-    /// those names, so it is what turns the routing on.
-    fn supports_named_instances(&self) -> bool {
-        self.named_bindings.load(Ordering::Relaxed)
-    }
-
-    /// Never: one store answers a labeled and an unlabeled import alike.
-    ///
-    /// The deferral this turns off is for a multiplexer that routes labels
-    /// between backends it names in code and has no plain one — not for a
-    /// plugin an operator deployed to serve an interface. Left at the default
-    /// it follows [`HostPlugin::supports_named_instances`], and declaring a
-    /// single binding would hand every plain import of every package this
-    /// plugin serves to whichever single-backend native serves it too
-    /// (`wasi:keyvalue`, `wasi:blobstore`, `wasi:config` and
-    /// `wasmcloud:messaging` all have one registered by default). A `bindings`
-    /// block says which labels this plugin answers to; it says nothing about
-    /// the imports it was already serving.
+    /// Never: one store answers a labeled and an unlabeled import alike, so
+    /// declaring a binding must not hand the plain imports this plugin already
+    /// served to a single-backend native. Which labels route here is the
+    /// operator's `host.plugins` declaration, read by the engine.
     fn defers_unnamed_instances(&self) -> bool {
         false
     }
@@ -1374,12 +1319,18 @@ async fn build_plugin_linker(
 
     let mut linked = std::collections::HashSet::new();
     for imported in introspect_imports(component)? {
-        if exports.iter().any(|e| e.name == imported.name) {
-            // A self-import is the plugin calling its own capability, so it
-            // carries no binding: the label an outside caller routed under says
-            // nothing about a call the plugin makes to itself.
-            let instance = Arc::clone(&imported.name);
-            add_capabilities_to_linker(&mut linker, state, &imported, &instance, None)
+        // A self-import, plain or under a label, is the plugin calling its own
+        // capability: it carries no binding, and routes to the export by the
+        // export's name whatever the import is called.
+        let own = exports.iter().find(|e| {
+            e.wit.same_package(&imported.wit)
+                && e.wit
+                    .interfaces
+                    .iter()
+                    .any(|i| imported.wit.interfaces.contains(i))
+        });
+        if let Some(own) = own {
+            add_capabilities_to_linker(&mut linker, state, own, imported.wit.name.as_deref(), None)
                 .with_context(|| {
                     format!(
                         "failed to wire self-import {} on plugin '{id}'",
@@ -1499,17 +1450,14 @@ fn install_host_identity(
             "get-binding-name",
             move |mut store, _ty, _params, results| {
                 let root = caller_root_task(&mut store);
-                // `option<string>` rather than the empty string `get-component-id`
-                // is stuck with: a binding genuinely has no name when the caller
-                // imported the interface plainly, and that is the common case
-                // rather than a degradation, so it gets a representation of its
-                // own from the start.
+                // `option<string>`: a plain import genuinely has no binding,
+                // and that is the common case rather than a degradation.
                 let binding = root
                     .and_then(|task| binding_state.registry()?.caller_for_task(task))
-                    .and_then(|c| c.binding.clone())
-                    .map(|name| Val::String(name.to_string()));
+                    .and_then(|c| c.binding)
+                    .map(|name| Box::new(Val::String(name.to_string())));
                 if let Some(slot) = results.first_mut() {
-                    *slot = Val::Option(binding.map(Box::new));
+                    *slot = Val::Option(binding);
                 }
                 Ok(())
             },
@@ -1599,22 +1547,19 @@ fn install_host_cancel(
 /// workload's linker ([`ComponentHostPlugin::on_workload_item_bind`]) and on the
 /// plugin's own linker for self-imports ([`build_plugin_linker`]).
 ///
-/// `instance_name` is the name the *caller* imports the interface under, which
-/// is `iface.name` for a plain import and the `(implements ..)` label for a
-/// labeled one — the component model names such an import by its label, so a
-/// definition under the interface's own name would leave it unsatisfied.
-/// `binding` carries that label onward to every call the shims route, so the
-/// plugin can tell one binding's calls from another's
-/// (`wasmcloud:host/identity#get-binding-name`). The interface addressed on the
-/// plugin's own instance is always `iface.name`: the label names a binding of
-/// this plugin, never a different interface.
+/// `label` is the `(implements ..)` name the caller imports the interface
+/// under, if any: the component model names such an import by its label, so
+/// that is the linker instance defined, and `iface.name` otherwise. `binding`
+/// rides along on every routed call for `wasmcloud:host/identity#get-binding-name`.
+/// The plugin's own instance is always addressed by `iface.name`.
 fn add_capabilities_to_linker(
     linker: &mut Linker<SharedCtx>,
     state: &Arc<ComponentHostPluginState>,
     iface: &ExportedInterface,
-    instance_name: &str,
+    label: Option<&str>,
     binding: Option<Arc<str>>,
 ) -> anyhow::Result<()> {
+    let instance_name = label.unwrap_or(&iface.name);
     let mut linker_instance = linker
         .instance(instance_name)
         .map_err(|e| e.context(format!("failed to open linker instance {instance_name}")))?;
@@ -1743,10 +1688,8 @@ async fn route_capability_call(
                     workload_id: Arc::clone(&ctx.workload_id),
                     component_id: Some(Arc::clone(&ctx.component_id)),
                     // Fixed when the shim was installed, not read from the
-                    // call: one linker instance is one binding, so the label
-                    // the caller imported under is already known here and
-                    // cannot be influenced by anything the guest passes.
-                    binding: binding.clone(),
+                    // call, so nothing the guest passes can influence it.
+                    binding,
                 }
             };
             let mut dones = Vec::new();
@@ -2211,27 +2154,31 @@ mod tests {
         }
     }
 
-    /// A world importing `wasmcloud:secrets/store` under each of `labels`
-    /// (`None` for a plain import).
+    /// `wasmcloud:secrets/store@2.1.0` under `label` (`None` for plain).
+    fn secrets_store(label: Option<&str>) -> WitInterface {
+        let mut wit = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        wit.name = label.map(str::to_string);
+        wit
+    }
+
+    /// A world importing `wasmcloud:secrets/store` under each of `labels`.
     fn importing(labels: &[Option<&str>]) -> WitWorld {
         WitWorld {
-            imports: labels
-                .iter()
-                .map(|label| {
-                    let mut wit = WitInterface::from("wasmcloud:secrets/store@2.1.0");
-                    wit.name = label.map(str::to_string);
-                    wit
-                })
-                .collect(),
+            imports: labels.iter().map(|l| secrets_store(*l)).collect(),
             exports: HashSet::new(),
         }
     }
 
+    fn labels(world: &WitWorld, served: &str) -> Vec<Option<Arc<str>>> {
+        import_labels(world, &WitInterface::from(served))
+            .into_iter()
+            .collect()
+    }
+
     #[test]
     fn a_plain_import_wires_the_interfaces_own_instance() {
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
         assert_eq!(
-            import_labels(&importing(&[None]), &served, "k8s-secrets"),
+            labels(&importing(&[None]), "wasmcloud:secrets/store@2.1.0"),
             vec![None]
         );
     }
@@ -2239,95 +2186,82 @@ mod tests {
     #[test]
     fn a_labeled_import_wires_the_label() {
         // The component model names an `(implements ..)` import by its label, so
-        // that is the linker instance the plugin has to define — defining the
-        // interface's own name would leave the import unresolved.
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+        // that is the linker instance the plugin has to define.
         assert_eq!(
-            import_labels(&importing(&[Some("restricted")]), &served, "k8s-secrets"),
+            labels(
+                &importing(&[Some("restricted")]),
+                "wasmcloud:secrets/store@2.1.0"
+            ),
             vec![Some(Arc::from("restricted"))]
         );
     }
 
     #[test]
     fn a_component_importing_both_gets_both_instances() {
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
         assert_eq!(
-            import_labels(
+            labels(
                 &importing(&[None, Some("restricted")]),
-                &served,
-                "k8s-secrets"
+                "wasmcloud:secrets/store@2.1.0"
             ),
             vec![None, Some(Arc::from("restricted"))],
             "the unnamed instance sorts first, and neither displaces the other"
         );
     }
 
+    /// A label equal to the plugin id still names the linker instance — the
+    /// import is called that — and only the *binding* reads as unnamed.
     #[test]
-    fn a_label_equal_to_the_plugin_id_is_the_unnamed_binding() {
-        // Addressing the plugin is not naming one of its bindings. This has to
-        // agree with `PluginBindingSet::binding_name`, or a workload would be
-        // configured under one binding and served under another.
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
+    fn a_label_equal_to_the_plugin_id_keeps_its_instance_name() {
         assert_eq!(
-            import_labels(&importing(&[Some("k8s-secrets")]), &served, "k8s-secrets"),
-            vec![None]
+            labels(
+                &importing(&[Some("k8s-secrets")]),
+                "wasmcloud:secrets/store@2.1.0"
+            ),
+            vec![Some(Arc::from("k8s-secrets"))]
+        );
+        assert_eq!(binding_of("k8s-secrets", Some("k8s-secrets")), None);
+        assert_eq!(
+            binding_of("k8s-secrets", Some("restricted")),
+            Some("restricted")
         );
     }
 
     #[test]
     fn an_interface_the_component_does_not_import_wires_nothing() {
-        // A plugin exporting more than the component uses: an entry naming the
-        // package matches the whole plugin, but only what the component
-        // actually imports may be defined on its linker.
-        let served = WitInterface::from("wasmcloud:secrets/reveal@2.1.0");
+        // A plugin exporting more than the component uses: only what the
+        // component actually imports may be defined on its linker.
         assert!(
-            import_labels(&importing(&[Some("restricted")]), &served, "k8s-secrets").is_empty()
+            labels(
+                &importing(&[Some("restricted")]),
+                "wasmcloud:secrets/reveal@2.1.0"
+            )
+            .is_empty()
         );
-    }
-
-    /// One entry per matched binding, the way `on_workload_item_bind` is
-    /// handed them.
-    fn matched(entries: &[Option<&str>]) -> HashSet<WitInterface> {
-        entries
-            .iter()
-            .map(|name| {
-                let mut wit = WitInterface::from("wasmcloud:secrets/store@2.1.0");
-                wit.name = name.map(str::to_string);
-                wit
-            })
-            .collect()
-    }
-
-    #[test]
-    fn a_label_the_workload_declared_is_reported_as_the_binding() {
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
-        let entries = matched(&[Some("restricted")]);
-        assert!(entry_named(
-            &WitInterfaces::new(&entries),
-            &served,
-            "restricted"
-        ));
-    }
-
-    /// `WitWorld::uses` ignores labels, so a plain entry matches a labeled
-    /// import. The label still has to be wired — the import is unresolved
-    /// otherwise — but it is not a binding the plugin was handed config for, so
-    /// `get-binding-name` must not name it.
-    #[test]
-    fn a_label_no_entry_declared_is_not_a_binding() {
-        let served = WitInterface::from("wasmcloud:secrets/store@2.1.0");
-        let entries = matched(&[None]);
-        assert!(!entry_named(
-            &WitInterfaces::new(&entries),
-            &served,
-            "restricted"
-        ));
     }
 
     #[test]
     fn a_different_package_wires_nothing() {
-        let served = WitInterface::from("acme:kv/store@0.1.0");
-        assert!(import_labels(&importing(&[None]), &served, "k8s-secrets").is_empty());
+        assert!(labels(&importing(&[None]), "acme:kv/store@0.1.0").is_empty());
+    }
+
+    /// The plain instance is defined under the plugin's own version and
+    /// wasmtime resolves a compatible import against it, so a patch-level
+    /// skew between plugin and component must still wire.
+    #[test]
+    fn a_compatible_version_still_wires() {
+        assert_eq!(
+            labels(&importing(&[None]), "wasmcloud:secrets/store@2.1.3"),
+            vec![None]
+        );
+        assert!(labels(&importing(&[None]), "wasmcloud:secrets/store@3.0.0").is_empty());
+        let v = |s: &str| semver::Version::parse(s).unwrap();
+        assert!(versions_compatible(Some(&v("0.2.0")), Some(&v("0.2.1"))));
+        assert!(!versions_compatible(Some(&v("0.2.0")), Some(&v("0.3.0"))));
+        assert!(!versions_compatible(
+            Some(&v("0.2.0-draft")),
+            Some(&v("0.2.0"))
+        ));
+        assert!(versions_compatible(None, Some(&v("0.2.0"))));
     }
 
     /// Compile `wat` and classify its imports the way plugin construction

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -467,6 +467,25 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
         false
     }
 
+    /// Whether this plugin hands a plain, *unlabeled* import to a
+    /// single-backend plugin that also serves it.
+    ///
+    /// Defaults to [`HostPlugin::supports_named_instances`], which is the rule
+    /// a closed multiplexer wants: it exists to route `(implements ..)` labels
+    /// between backends it names in code, so where a single-backend plugin
+    /// serves the same interface, that one is the better answer for an import
+    /// carrying no label.
+    ///
+    /// A plugin that serves both off one backend — a host component plugin
+    /// answers a labeled and an unlabeled import from the same store —
+    /// overrides this to `false`. Deferring would hand its plain imports to the
+    /// very native an operator deployed it to replace, and it would happen the
+    /// moment they declared a binding, which says which labels this plugin
+    /// answers to and nothing about the imports it already served.
+    fn defers_unnamed_instances(&self) -> bool {
+        self.supports_named_instances()
+    }
+
     /// Injects metrics into the plugin.
     ///
     /// # Arguments

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -186,7 +186,7 @@ mod roster_tests {
 /// decides whether a workload may write over it.
 pub mod bindings;
 pub use bindings::{
-    BindingSchema, KeyOwnership, PluginBindingSet, PluginBindings, WorkloadConfigPolicy,
+    BindingSchema, KeyOwnership, PluginBindingSet, PluginBindings, WorkloadConfigPolicy, binding_of,
 };
 
 /// Shared `(implements ..)` multiplexing core
@@ -467,21 +467,11 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
         false
     }
 
-    /// Whether this plugin hands a plain, *unlabeled* import to a
-    /// single-backend plugin that also serves it.
-    ///
-    /// Defaults to [`HostPlugin::supports_named_instances`], which is the rule
-    /// a closed multiplexer wants: it exists to route `(implements ..)` labels
-    /// between backends it names in code, so where a single-backend plugin
-    /// serves the same interface, that one is the better answer for an import
-    /// carrying no label.
-    ///
-    /// A plugin that serves both off one backend — a host component plugin
-    /// answers a labeled and an unlabeled import from the same store —
-    /// overrides this to `false`. Deferring would hand its plain imports to the
-    /// very native an operator deployed it to replace, and it would happen the
-    /// moment they declared a binding, which says which labels this plugin
-    /// answers to and nothing about the imports it already served.
+    /// Whether a plain, unlabeled import is handed to another plugin that
+    /// serves it plainly. Defaults to [`HostPlugin::supports_named_instances`]:
+    /// a closed multiplexer routes labels between backends it names in code,
+    /// so a single-backend plugin is the better answer for an import with no
+    /// label. A plugin serving both off one backend returns `false`.
     fn defers_unnamed_instances(&self) -> bool {
         self.supports_named_instances()
     }

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -197,26 +197,14 @@ pub struct WitInterface {
     /// The package name (e.g., "http", "blobstore")
     pub package: String,
     /// The specific interfaces within the package (e.g., "incoming-handler", "types")
-    ///
-    /// Defaulted for the same reason `config` is: an entry naming none of them
-    /// stands for its whole package — the shape `entry_matches` and
-    /// [`WitWorld::uses`] already read — and an operator-declared binding is
-    /// written that way, naming only the binding. Required, it would fail to
-    /// parse with `missing field 'interfaces'`.
-    #[serde(default)]
     pub interfaces: HashSet<String>,
     // TODO: This is a nice way to represent a version, but it doesn't account for
     // compatible versions. We should revisit this and implement https://docs.rs/semver/1.0.27/semver/struct.VersionReq.html
     /// Optional semantic version for the interface
     #[serde(default)]
     pub version: Option<semver::Version>,
-    /// Additional configuration parameters for this interface
-    ///
-    /// Defaulted rather than required: an entry that configures nothing is an
-    /// ordinary shape, and the one an operator-declared binding takes — what
-    /// that binding reads is declared under `host.plugins`, so the manifest
-    /// entry naming it carries only the name. Without a default, writing one in
-    /// a `wash` config file fails to parse with `missing field 'config'`.
+    /// Additional configuration parameters for this interface. Defaulted: an
+    /// entry bound under an operator-declared binding configures nothing here.
     #[serde(default)]
     pub config: HashMap<String, String>,
     /// Optional name identifying this specific instance when multiple entries

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -201,12 +201,22 @@ pub struct WitInterface {
     // TODO: This is a nice way to represent a version, but it doesn't account for
     // compatible versions. We should revisit this and implement https://docs.rs/semver/1.0.27/semver/struct.VersionReq.html
     /// Optional semantic version for the interface
+    #[serde(default)]
     pub version: Option<semver::Version>,
     /// Additional configuration parameters for this interface
+    ///
+    /// Defaulted rather than required: an entry that configures nothing is an
+    /// ordinary shape, and the one an operator-declared binding takes — what
+    /// that binding reads is declared under `host.plugins`, so the manifest
+    /// entry naming it carries only the name. Without a default, writing one in
+    /// a `wash` config file fails to parse with `missing field 'config'`.
+    #[serde(default)]
     pub config: HashMap<String, String>,
     /// Optional name identifying this specific instance when multiple entries
     /// of the same namespace:package exist. Used as the routing key in
-    /// multiplexing plugins (the `identifier` in store::open, etc.).
+    /// multiplexing plugins (the `identifier` in store::open, etc.), and as the
+    /// binding name an operator declares under a `host.plugins` entry.
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -197,6 +197,13 @@ pub struct WitInterface {
     /// The package name (e.g., "http", "blobstore")
     pub package: String,
     /// The specific interfaces within the package (e.g., "incoming-handler", "types")
+    ///
+    /// Defaulted for the same reason `config` is: an entry naming none of them
+    /// stands for its whole package — the shape `entry_matches` and
+    /// [`WitWorld::uses`] already read — and an operator-declared binding is
+    /// written that way, naming only the binding. Required, it would fail to
+    /// parse with `missing field 'interfaces'`.
+    #[serde(default)]
     pub interfaces: HashSet<String>,
     // TODO: This is a nice way to represent a version, but it doesn't account for
     // compatible versions. We should revisit this and implement https://docs.rs/semver/1.0.27/semver/struct.VersionReq.html

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -376,28 +376,6 @@ async fn start_host_with_component_plugin_router(
     plugin_id: &'static str,
     plugin_wasm: &'static [u8],
     max_restarts: Option<u32>,
-) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    start_host_with_component_plugin_router_bindings(
-        addr,
-        router,
-        plugin_id,
-        plugin_wasm,
-        max_restarts,
-        wash_runtime::plugin::PluginBindings::new(),
-    )
-    .await
-}
-
-/// [`start_host_with_component_plugin_router`] plus the operator's
-/// `host.plugins` declaration, which is what turns `(implements ..)` label
-/// routing on for a component plugin.
-#[cfg(feature = "host-component-plugins")]
-async fn start_host_with_component_plugin_router_bindings(
-    addr: &str,
-    router: impl wash_runtime::host::http::Router,
-    plugin_id: &'static str,
-    plugin_wasm: &'static [u8],
-    max_restarts: Option<u32>,
     plugin_bindings: wash_runtime::plugin::PluginBindings,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
@@ -439,7 +417,7 @@ pub async fn start_host_with_component_plugin_bindings(
     plugin_wasm: &'static [u8],
     plugin_bindings: wash_runtime::plugin::PluginBindings,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
-    start_host_with_component_plugin_router_bindings(
+    start_host_with_component_plugin_router(
         addr,
         DevRouter::default(),
         plugin_id,
@@ -465,6 +443,7 @@ pub async fn start_host_with_component_plugin(
         plugin_id,
         plugin_wasm,
         None,
+        wash_runtime::plugin::PluginBindings::new(),
     )
     .await
 }
@@ -485,6 +464,7 @@ pub async fn start_host_with_component_plugin_by_host(
         plugin_id,
         plugin_wasm,
         None,
+        wash_runtime::plugin::PluginBindings::new(),
     )
     .await
 }
@@ -504,6 +484,7 @@ pub async fn start_host_with_component_plugin_max_restarts(
         plugin_id,
         plugin_wasm,
         Some(max_restarts),
+        wash_runtime::plugin::PluginBindings::new(),
     )
     .await
 }

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -171,6 +171,26 @@ pub fn kv_plugin_caller_host_interfaces_with_config(
     ]
 }
 
+/// Interfaces for the `kv-plugin-implements-caller` workload: HTTP ingress plus
+/// three `acme:kv` entries — the plain one and one per `(implements ..)` label
+/// the component imports. One entry per binding, which is what the operator's
+/// declaration is matched against.
+#[cfg(feature = "host-component-plugins")]
+pub fn kv_plugin_implements_caller_host_interfaces(host_header: &str) -> Vec<WitInterface> {
+    vec![
+        http_incoming_handler_interface(host_header, None),
+        acme_kv_interface(),
+        WitInterface {
+            name: Some("tenant-a".to_string()),
+            ..acme_kv_interface()
+        },
+        WitInterface {
+            name: Some("tenant-b".to_string()),
+            ..acme_kv_interface()
+        },
+    ]
+}
+
 /// The `wasmcloud:secrets` capability (store + reveal), served by the native
 /// `wasmcloud-secrets` plugin.
 pub fn secrets_interface(config: HashMap<String, String>) -> WitInterface {
@@ -357,6 +377,29 @@ async fn start_host_with_component_plugin_router(
     plugin_wasm: &'static [u8],
     max_restarts: Option<u32>,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    start_host_with_component_plugin_router_bindings(
+        addr,
+        router,
+        plugin_id,
+        plugin_wasm,
+        max_restarts,
+        wash_runtime::plugin::PluginBindings::new(),
+    )
+    .await
+}
+
+/// [`start_host_with_component_plugin_router`] plus the operator's
+/// `host.plugins` declaration, which is what turns `(implements ..)` label
+/// routing on for a component plugin.
+#[cfg(feature = "host-component-plugins")]
+async fn start_host_with_component_plugin_router_bindings(
+    addr: &str,
+    router: impl wash_runtime::host::http::Router,
+    plugin_id: &'static str,
+    plugin_wasm: &'static [u8],
+    max_restarts: Option<u32>,
+    plugin_bindings: wash_runtime::plugin::PluginBindings,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
     let engine = Engine::builder().build()?;
     let ingress = Ingress::new(router, addr.parse()?).await?;
     let bound_addr = ingress.addr();
@@ -379,9 +422,32 @@ async fn start_host_with_component_plugin_router(
     if let Some(max_restarts) = max_restarts {
         plugin = plugin.with_max_restarts(max_restarts);
     }
-    let host = builder.with_plugin(Arc::new(plugin))?.build()?;
+    let host = builder
+        .with_plugin(Arc::new(plugin))?
+        .with_plugin_bindings(plugin_bindings)
+        .build()?;
     let host = host.start().await.context("Failed to start host")?;
     Ok((bound_addr, host))
+}
+
+/// Start a p3 host with a component plugin whose `host.plugins` entry declares
+/// `bindings`, the way an operator turns label routing on for one.
+#[cfg(feature = "host-component-plugins")]
+pub async fn start_host_with_component_plugin_bindings(
+    addr: &str,
+    plugin_id: &'static str,
+    plugin_wasm: &'static [u8],
+    plugin_bindings: wash_runtime::plugin::PluginBindings,
+) -> Result<(std::net::SocketAddr, impl HostApi)> {
+    start_host_with_component_plugin_router_bindings(
+        addr,
+        DevRouter::default(),
+        plugin_id,
+        plugin_wasm,
+        None,
+        plugin_bindings,
+    )
+    .await
 }
 
 /// Start a p3 host with the standard plugin set plus a [`ComponentHostPlugin`]

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -549,6 +549,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-plugin-implements-caller"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "kv-plugin-service"
 version = "0.0.0"
 dependencies = [

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "bridge-service",
     "kv-plugin",
     "kv-plugin-caller",
+    "kv-plugin-implements-caller",
     "kv-plugin-service",
     "badlifecycle",
     "secrets-caller",

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -8,7 +8,7 @@ package acme:events@0.1.0;
 interface handler {
     /// The host's failure type, so a call it could not complete comes back as a
     /// value rather than trapping the plugin that made it.
-    use wasmcloud:host/types@0.1.3.{call-error};
+    use wasmcloud:host/types@0.1.4.{call-error};
 
     /// Handle one event. Exported by a workload; called by the plugin across
     /// the store boundary. The reply carries the handling workload's own tag,

--- a/crates/wash-runtime/tests/fixtures/acme-kv/store.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-kv/store.wit
@@ -103,4 +103,10 @@ interface store {
     /// `bind:{workload-id}` / `unbind:{workload-id}`. Resets when the plugin
     /// store restarts.
     lifecycle-log: async func() -> list<string>;
+
+    /// The `(implements ..)` label this call arrived on, as the plugin reads it
+    /// from `wasmcloud:host/identity#get-binding-name`; `none` for a plain,
+    /// unlabeled import. Lets a test assert end-to-end that one binding's calls
+    /// are distinguishable from another's on the call itself, not only at bind.
+    whichbinding: async func() -> option<string>;
 }

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -16,10 +16,10 @@ world events-plugin {
     import acme:events/metrics@0.1.0;
     // Names which workload a call goes to, and lists the ones that can be
     // called at all. Unused for `echo`, which inherits its caller.
-    import wasmcloud:host/workload-call@0.1.3;
+    import wasmcloud:host/workload-call@0.1.4;
     export acme:events/control@0.1.0;
     // Lifecycle hooks, used here only to probe what a hook can reach: a
     // workload is callable exactly while it is running, and both hooks land
     // outside that window.
-    export wasmcloud:host/workload-lifecycle@0.1.3;
+    export wasmcloud:host/workload-lifecycle@0.1.4;
 }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/kv_plugin_implements_caller.wasm

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kv-plugin-implements-caller"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/src/lib.rs
@@ -1,0 +1,132 @@
+//! Workload component driving ONE host component plugin through three imports
+//! of the same interface: a plain one and two `(implements ..)` labels.
+//!
+//! - `GET /whichbinding?via=plain|tenant-a|tenant-b` -> `store.whichbinding()`
+//!   through that import -> 200 body = the label the plugin read back, or
+//!   `<none>` for a plain import.
+//! - `GET /set?via=..&key=K&value=V` -> `store.set(K, V)` through that import.
+//! - `GET /get?via=..&key=K`         -> `store.get(K)`, 200 body=V or 404.
+//!
+//! `set`/`get` are here so a test can show the labels reach one store rather
+//! than three: what a label changes is the binding a call carries, not the data
+//! behind it.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "implements-caller", generate_all });
+}
+
+use bindings::acme::kv::store;
+use bindings::exports::wasi::http::handler::Guest as HttpGuest;
+use bindings::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use bindings::{tenant_a, tenant_b};
+
+struct Component;
+
+/// Which of the three imports a request names. Each is a distinct linker
+/// instance, so the call has to be written against the matching bindings module
+/// — there is no runtime dispatch that would let one import stand in for
+/// another.
+enum Via {
+    Plain,
+    TenantA,
+    TenantB,
+}
+
+impl Via {
+    fn parse(query: &str) -> Option<Self> {
+        match query_get(query, "via").as_deref() {
+            Some("plain") | None => Some(Self::Plain),
+            Some("tenant-a") => Some(Self::TenantA),
+            Some("tenant-b") => Some(Self::TenantB),
+            Some(_) => None,
+        }
+    }
+}
+
+impl HttpGuest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let path = request
+            .get_path_with_query()
+            .unwrap_or_else(|| "/".to_string());
+        let (route, query) = match path.split_once('?') {
+            Some((r, q)) => (r, q),
+            None => (path.as_str(), ""),
+        };
+
+        let Some(via) = Via::parse(query) else {
+            return Ok(make_response(400, b"unknown `via`".to_vec()));
+        };
+
+        if route.starts_with("/whichbinding") {
+            let binding = match via {
+                Via::Plain => store::whichbinding().await,
+                Via::TenantA => tenant_a::whichbinding().await,
+                Via::TenantB => tenant_b::whichbinding().await,
+            };
+            // `<none>` rather than an empty body: a plain import genuinely has
+            // no binding name, and a test asserting that must not be reading
+            // the same bytes an empty string would give.
+            let body = binding.unwrap_or_else(|| "<none>".to_string());
+            return Ok(make_response(200, body.into_bytes()));
+        }
+
+        if route.starts_with("/set") {
+            let key = query_get(query, "key").unwrap_or_default();
+            let value = query_get(query, "value").unwrap_or_default().into_bytes();
+            match via {
+                Via::Plain => store::set(key, value).await,
+                Via::TenantA => tenant_a::set(key, value).await,
+                Via::TenantB => tenant_b::set(key, value).await,
+            }
+            return Ok(make_response(200, b"{\"ok\":true}".to_vec()));
+        }
+
+        if route.starts_with("/get") {
+            let key = query_get(query, "key").unwrap_or_default();
+            let found = match via {
+                Via::Plain => store::get(key).await,
+                Via::TenantA => tenant_a::get(key).await,
+                Via::TenantB => tenant_b::get(key).await,
+            };
+            return match found {
+                Some(v) => Ok(make_response(200, v)),
+                None => Ok(make_response(404, Vec::new())),
+            };
+        }
+
+        Ok(make_response(404, Vec::new()))
+    }
+}
+
+/// Return the value of `name` from a `k=v&k2=v2` query string, if present.
+fn query_get(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == name).then(|| v.to_string())
+    })
+}
+
+fn make_response(status: u16, body: Vec<u8>) -> Response {
+    let headers = Fields::new();
+    let _ = headers.set(
+        &"content-type".to_string(),
+        &[b"application/octet-stream".to_vec()],
+    );
+    let (mut tx, rx) = bindings::wit_stream::new();
+    let (trailers_tx, trailers_rx) = bindings::wit_future::new(|| Ok(None));
+    wit_bindgen::spawn_local(async move {
+        tx.write_all(body).await;
+        drop(tx);
+        let _ = trailers_tx.write(Ok(None)).await;
+    });
+    let (response, _result) = Response::new(headers, Some(rx), trailers_rx);
+    let _ = response.set_status_code(status);
+    response
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{bindings, Component};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/wit/world.wit
@@ -1,0 +1,19 @@
+package acme:kvimplementscaller@0.1.0;
+
+/// Workload component importing ONE host component plugin's capability three
+/// ways at once: plainly, and under two `(implements ..)` labels. The component
+/// model names a labeled import by its label, so each of these is a distinct
+/// linker instance the plugin has to define — the labeled ones under the label,
+/// never under the interface's own name.
+///
+/// Both labels reach the same plugin store, so what separates them is not the
+/// data but the binding: each call carries the label it arrived on, which the
+/// plugin reads back through `wasmcloud:host/identity#get-binding-name` and
+/// returns from `whichbinding`.
+world implements-caller {
+    import wasi:http/types@0.3.0;
+    import acme:kv/store@0.1.0;
+    import tenant-a: acme:kv/store@0.1.0;
+    import tenant-b: acme:kv/store@0.1.0;
+    export wasi:http/handler@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin-implements-caller/wkg.toml
@@ -1,0 +1,8 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:http" = { path = "../p3-wit-deps/wasi-http-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:kv" = { path = "../acme-kv" }

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/src/lib.rs
@@ -152,6 +152,10 @@ impl Guest for Component {
         format!("{workload}|{component}")
     }
 
+    async fn whichbinding() -> Option<String> {
+        bindings::wasmcloud::host::identity::get_binding_name()
+    }
+
     async fn slow(millis: u64) -> u64 {
         // Await a timer so this task YIELDS the store's cooperative executor.
         // A concurrent fast call spawned as its own task can therefore run to

--- a/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/kv-plugin/wit/world.wit
@@ -15,10 +15,10 @@ world kv-plugin {
     import wasi:clocks/system-clock@0.3.0;
     // Host identity import: lets the plugin partition state by the calling
     // workload (the host answers based on the in-flight capability call).
-    import wasmcloud:host/identity@0.1.3;
+    import wasmcloud:host/identity@0.1.4;
     // Host cancel import: lets the plugin cancel one of its own in-flight
     // invocations by the host-minted job id, exercised by `begin`/`cancel-job`.
-    import wasmcloud:host/cancel@0.1.3;
+    import wasmcloud:host/cancel@0.1.4;
     // Self-import: the plugin depends on its own capability so `recurse` can
     // re-enter across the store boundary. The host wires this back to the
     // plugin itself.
@@ -27,5 +27,5 @@ world kv-plugin {
     // Lifecycle export: the host calls these as workloads bind/unbind, letting
     // the plugin capture per-workload manifest config eagerly (observed through
     // the store interface's `bound-config`/`bind-info`/`lifecycle-log`).
-    export wasmcloud:host/workload-lifecycle@0.1.3;
+    export wasmcloud:host/workload-lifecycle@0.1.4;
 }

--- a/crates/wash-runtime/tests/integration_component_plugin_implements.rs
+++ b/crates/wash-runtime/tests/integration_component_plugin_implements.rs
@@ -215,19 +215,19 @@ async fn a_plugin_with_no_declaration_does_not_claim_labels() -> Result<()> {
     Ok(())
 }
 
-/// A label the component imports but the *manifest* never named is wired, and
-/// reports no binding.
+/// A label the component imports but the *manifest* never named is refused at
+/// bind, and the refusal names the label.
 ///
 /// `WitWorld::uses` matches an entry to an import by package, ignoring labels,
 /// so a manifest carrying only the plain entry still matches a component that
-/// imports under labels. The labels have to be wired — the import is
-/// unresolved otherwise — but the config was resolved under the unnamed
-/// binding, so naming one here would have `get-binding-name` report a binding
-/// `on-workload-bind` never delivered.
+/// imports under labels. Wiring those labels anyway would let a component
+/// reach the plugin under a name the workload never declared — and the
+/// operator's `bindings` block is checked against declared entries, so that
+/// would sidestep it. The import shape has to match its entry.
 #[tokio::test]
-async fn a_label_the_manifest_never_named_reports_no_binding() -> Result<()> {
+async fn a_label_the_manifest_never_named_is_refused() -> Result<()> {
     let host = "kv-implements-plain-entry";
-    let (addr, h) = start_host_with_component_plugin_bindings(
+    let (_addr, h) = start_host_with_component_plugin_bindings(
         "127.0.0.1:0",
         PLUGIN_ID,
         KV_PLUGIN_WASM,
@@ -253,23 +253,13 @@ async fn a_label_the_manifest_never_named_reports_no_binding() -> Result<()> {
         .workload_status;
     assert_eq!(
         status.workload_state,
-        WorkloadState::Running,
-        "one entry is one binding, so this deploys: {}",
-        status.message
+        WorkloadState::Error,
+        "a component importing under a label its manifest never named must not deploy"
     );
-
-    let client = reqwest::Client::new();
-    for via in ["plain", "tenant-a", "tenant-b"] {
-        let (status, body) = req(&client, &addr, host, &format!("/whichbinding?via={via}")).await?;
-        assert_eq!(
-            status.as_u16(),
-            200,
-            "the {via} import must be wired even though the manifest never named it"
-        );
-        assert_eq!(
-            body, "<none>",
-            "a label no entry declared must not be reported as a binding"
-        );
-    }
+    let msg = status.message;
+    assert!(
+        msg.contains("tenant-a") && msg.contains("name: tenant-a") && msg.contains(PLUGIN_ID),
+        "the refusal must name the label, the entry to add, and the plugin, got: {msg}"
+    );
     Ok(())
 }

--- a/crates/wash-runtime/tests/integration_component_plugin_implements.rs
+++ b/crates/wash-runtime/tests/integration_component_plugin_implements.rs
@@ -1,0 +1,277 @@
+//! Integration test: a workload importing a **host component plugin's**
+//! interface under an `(implements ..)` label.
+//!
+//! The existing `(implements ..)` suites all route labels to *native* plugins
+//! (`wasi:keyvalue`, `wasmcloud:postgres`, `wasmcloud:blobstore`,
+//! `wasmcloud:nats`), and `integration_plugin_imports_native` covers a
+//! component plugin consuming a native's labeled interface. Neither exercises
+//! the direction this covers: a workload's labeled import resolved *by* a
+//! component plugin.
+//!
+//! Three things have to line up for that, and each is asserted here:
+//!
+//!   1. The component model names a labeled import by its **label**, so the
+//!      plugin must define the linker instance under the label rather than
+//!      under the interface's own name. A workload that instantiates at all is
+//!      the proof — a definition under the wrong name leaves the import
+//!      unresolved and `workload_start` fails.
+//!   2. The plain and labeled imports coexist on one linker, so declaring a
+//!      binding must not cost the workload its unlabeled import.
+//!   3. The label reaches the *capability call*, not only `on-workload-bind`:
+//!      `whichbinding` returns what the plugin read from
+//!      `wasmcloud:host/identity#get-binding-name`.
+//!
+//! The operator's `host.plugins` declaration is what turns label routing on
+//! (`supports_named_instances`), so the host here declares `tenant-a` and
+//! `tenant-b` the way an operator's Helm values would.
+
+#![cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasm_component_model_implements"
+))]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use wash_runtime::host::HostApi;
+use wash_runtime::plugin::{PluginBindingSet, PluginBindings};
+use wash_runtime::types::{LocalResources, WorkloadState};
+
+mod common;
+use common::{
+    acme_kv_interface, component_workload_request, http_incoming_handler_interface,
+    kv_plugin_implements_caller_host_interfaces, req, start_host_with_component_plugin_bindings,
+};
+
+const KV_PLUGIN_WASM: &[u8] = include_bytes!("wasm/kv_plugin.wasm");
+const CALLER_WASM: &[u8] = include_bytes!("wasm/kv_plugin_implements_caller.wasm");
+const PLUGIN_ID: &str = "acme-kv-plugin";
+
+/// The operator's declaration: this plugin serves two named bindings. Nothing
+/// is configured under them — what a binding reads is the plugin's business,
+/// and an entry that configures nothing is the shape a declaration-only binding
+/// takes.
+fn declared_bindings() -> PluginBindings {
+    PluginBindings::new().with_plugin(
+        PluginBindingSet::new(PLUGIN_ID)
+            .with_binding("tenant-a", HashMap::new())
+            .with_binding("tenant-b", HashMap::new()),
+    )
+}
+
+fn caller_workload(host: &str) -> wash_runtime::types::WorkloadStartRequest {
+    component_workload_request(
+        "kv-plugin-implements-caller",
+        host,
+        CALLER_WASM,
+        LocalResources::default(),
+        kv_plugin_implements_caller_host_interfaces(host),
+    )
+}
+
+/// Every label the component imports is wired, and each call carries the label
+/// it arrived on. The plain import carries none — that is a real answer, not a
+/// degraded one, which is why the WIT returns `option<string>`.
+#[tokio::test]
+async fn a_labeled_import_reaches_the_plugin_under_its_label() -> Result<()> {
+    let host = "kv-implements";
+    let (addr, h) = start_host_with_component_plugin_bindings(
+        "127.0.0.1:0",
+        PLUGIN_ID,
+        KV_PLUGIN_WASM,
+        declared_bindings(),
+    )
+    .await?;
+    // Instantiating at all proves the labeled instances were defined under
+    // their labels: the component imports `tenant-a`/`tenant-b`, and a
+    // definition under `acme:kv/store` would leave both unresolved.
+    h.workload_start(caller_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    for (via, expected) in [
+        ("plain", "<none>"),
+        ("tenant-a", "tenant-a"),
+        ("tenant-b", "tenant-b"),
+    ] {
+        let (status, body) = req(
+            &client,
+            &addr,
+            host,
+            &format!("/whichbinding?via={via}"),
+        )
+        .await?;
+        assert_eq!(status.as_u16(), 200, "/whichbinding via {via} should be 200");
+        assert_eq!(
+            body, expected,
+            "a call through the {via} import must report {expected} as its binding"
+        );
+    }
+    Ok(())
+}
+
+/// The labels name bindings of one plugin, not separate backends: a value
+/// written through one is readable through the others, because all three
+/// imports route to the same store. What the label changes is the binding a
+/// call carries, and nothing else.
+#[tokio::test]
+async fn labeled_imports_share_the_plugins_one_store() -> Result<()> {
+    let host = "kv-implements-store";
+    let (addr, h) = start_host_with_component_plugin_bindings(
+        "127.0.0.1:0",
+        PLUGIN_ID,
+        KV_PLUGIN_WASM,
+        declared_bindings(),
+    )
+    .await?;
+    h.workload_start(caller_workload(host)).await?;
+    let client = reqwest::Client::new();
+
+    let (status, _) = req(
+        &client,
+        &addr,
+        host,
+        "/set?via=tenant-a&key=shared&value=written-via-a",
+    )
+    .await?;
+    assert!(status.is_success(), "/set via tenant-a should succeed");
+
+    for via in ["plain", "tenant-a", "tenant-b"] {
+        let (status, body) = req(
+            &client,
+            &addr,
+            host,
+            &format!("/get?via={via}&key=shared"),
+        )
+        .await?;
+        assert_eq!(status.as_u16(), 200, "/get via {via} should find the key");
+        assert_eq!(
+            body, "written-via-a",
+            "every binding of one plugin reads the same store"
+        );
+    }
+    Ok(())
+}
+
+/// A label nobody declared is refused, and the refusal names it.
+///
+/// This is the boundary that makes the operator's `bindings` block a grant
+/// rather than a convention: a workload cannot reach a binding by naming one.
+/// The plugin declares `tenant-a` only, and the workload's `tenant-b` entry
+/// stops the deploy.
+#[tokio::test]
+async fn an_undeclared_label_is_refused() -> Result<()> {
+    let host = "kv-implements-undeclared";
+    let only_a = PluginBindings::new().with_plugin(
+        PluginBindingSet::new(PLUGIN_ID).with_binding("tenant-a", HashMap::new()),
+    );
+    let (_addr, h) =
+        start_host_with_component_plugin_bindings("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM, only_a)
+            .await?;
+
+    // A refused bind is reported on the status rather than as an `Err`: the
+    // request was accepted and the workload failed, which is what an operator
+    // reading `workload_state` sees.
+    let status = h.workload_start(caller_workload(host)).await?.workload_status;
+    assert_eq!(
+        status.workload_state,
+        WorkloadState::Error,
+        "a workload naming an undeclared binding must not deploy"
+    );
+    let msg = status.message;
+    assert!(
+        msg.contains("tenant-b") && msg.contains(PLUGIN_ID),
+        "the refusal must name the label and the plugin whose declaration to fix, got: {msg}"
+    );
+    Ok(())
+}
+
+/// Declaring nothing changes nothing: with no `host.plugins` entry this plugin
+/// does not claim labels at all, so a workload declaring three bindings for one
+/// package hits the same refusal any single-instance plugin gives. The
+/// operator's declaration is what turns label routing on, and its absence is
+/// not a silent downgrade.
+#[tokio::test]
+async fn a_plugin_with_no_declaration_does_not_claim_labels() -> Result<()> {
+    let host = "kv-implements-undeclared-plugin";
+    let (_addr, h) = start_host_with_component_plugin_bindings(
+        "127.0.0.1:0",
+        PLUGIN_ID,
+        KV_PLUGIN_WASM,
+        PluginBindings::new(),
+    )
+    .await?;
+
+    let status = h.workload_start(caller_workload(host)).await?.workload_status;
+    assert_eq!(
+        status.workload_state,
+        WorkloadState::Error,
+        "an undeclared plugin must not serve named bindings"
+    );
+    let msg = status.message;
+    assert!(
+        msg.contains("does not support named instances") && msg.contains("acme:kv"),
+        "the refusal must say the plugin serves one instance, got: {msg}"
+    );
+    Ok(())
+}
+
+/// A label the component imports but the *manifest* never named is wired, and
+/// reports no binding.
+///
+/// `WitWorld::uses` matches an entry to an import by package, ignoring labels,
+/// so a manifest carrying only the plain entry still matches a component that
+/// imports under labels. The labels have to be wired — the import is
+/// unresolved otherwise — but the config was resolved under the unnamed
+/// binding, so naming one here would have `get-binding-name` report a binding
+/// `on-workload-bind` never delivered.
+#[tokio::test]
+async fn a_label_the_manifest_never_named_reports_no_binding() -> Result<()> {
+    let host = "kv-implements-plain-entry";
+    let (addr, h) = start_host_with_component_plugin_bindings(
+        "127.0.0.1:0",
+        PLUGIN_ID,
+        KV_PLUGIN_WASM,
+        declared_bindings(),
+    )
+    .await?;
+
+    // Only the plain entry: the operator declared both labels, but this
+    // workload's manifest asks for neither.
+    let plain_only = vec![
+        http_incoming_handler_interface(host, None),
+        acme_kv_interface(),
+    ];
+    let status = h
+        .workload_start(component_workload_request(
+            "kv-plugin-implements-caller",
+            host,
+            CALLER_WASM,
+            LocalResources::default(),
+            plain_only,
+        ))
+        .await?
+        .workload_status;
+    assert_eq!(
+        status.workload_state,
+        WorkloadState::Running,
+        "one entry is one binding, so this deploys: {}",
+        status.message
+    );
+
+    let client = reqwest::Client::new();
+    for via in ["plain", "tenant-a", "tenant-b"] {
+        let (status, body) = req(&client, &addr, host, &format!("/whichbinding?via={via}")).await?;
+        assert_eq!(
+            status.as_u16(),
+            200,
+            "the {via} import must be wired even though the manifest never named it"
+        );
+        assert_eq!(
+            body, "<none>",
+            "a label no entry declared must not be reported as a binding"
+        );
+    }
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_component_plugin_implements.rs
+++ b/crates/wash-runtime/tests/integration_component_plugin_implements.rs
@@ -95,14 +95,12 @@ async fn a_labeled_import_reaches_the_plugin_under_its_label() -> Result<()> {
         ("tenant-a", "tenant-a"),
         ("tenant-b", "tenant-b"),
     ] {
-        let (status, body) = req(
-            &client,
-            &addr,
-            host,
-            &format!("/whichbinding?via={via}"),
-        )
-        .await?;
-        assert_eq!(status.as_u16(), 200, "/whichbinding via {via} should be 200");
+        let (status, body) = req(&client, &addr, host, &format!("/whichbinding?via={via}")).await?;
+        assert_eq!(
+            status.as_u16(),
+            200,
+            "/whichbinding via {via} should be 200"
+        );
         assert_eq!(
             body, expected,
             "a call through the {via} import must report {expected} as its binding"
@@ -138,13 +136,8 @@ async fn labeled_imports_share_the_plugins_one_store() -> Result<()> {
     assert!(status.is_success(), "/set via tenant-a should succeed");
 
     for via in ["plain", "tenant-a", "tenant-b"] {
-        let (status, body) = req(
-            &client,
-            &addr,
-            host,
-            &format!("/get?via={via}&key=shared"),
-        )
-        .await?;
+        let (status, body) =
+            req(&client, &addr, host, &format!("/get?via={via}&key=shared")).await?;
         assert_eq!(status.as_u16(), 200, "/get via {via} should find the key");
         assert_eq!(
             body, "written-via-a",
@@ -163,9 +156,8 @@ async fn labeled_imports_share_the_plugins_one_store() -> Result<()> {
 #[tokio::test]
 async fn an_undeclared_label_is_refused() -> Result<()> {
     let host = "kv-implements-undeclared";
-    let only_a = PluginBindings::new().with_plugin(
-        PluginBindingSet::new(PLUGIN_ID).with_binding("tenant-a", HashMap::new()),
-    );
+    let only_a = PluginBindings::new()
+        .with_plugin(PluginBindingSet::new(PLUGIN_ID).with_binding("tenant-a", HashMap::new()));
     let (_addr, h) =
         start_host_with_component_plugin_bindings("127.0.0.1:0", PLUGIN_ID, KV_PLUGIN_WASM, only_a)
             .await?;
@@ -173,7 +165,10 @@ async fn an_undeclared_label_is_refused() -> Result<()> {
     // A refused bind is reported on the status rather than as an `Err`: the
     // request was accepted and the workload failed, which is what an operator
     // reading `workload_state` sees.
-    let status = h.workload_start(caller_workload(host)).await?.workload_status;
+    let status = h
+        .workload_start(caller_workload(host))
+        .await?
+        .workload_status;
     assert_eq!(
         status.workload_state,
         WorkloadState::Error,
@@ -203,7 +198,10 @@ async fn a_plugin_with_no_declaration_does_not_claim_labels() -> Result<()> {
     )
     .await?;
 
-    let status = h.workload_start(caller_workload(host)).await?.workload_status;
+    let status = h
+        .workload_start(caller_workload(host))
+        .await?
+        .workload_status;
     assert_eq!(
         status.workload_state,
         WorkloadState::Error,

--- a/wit/host/wit/cancel.wit
+++ b/wit/host/wit/cancel.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.3;
+package wasmcloud:host@0.1.4;
 
 /// Host-provided so a component plugin can cooperatively cancel one of its own
 /// in-flight invocations. Job ids are host-minted and opaque. `request-cancel`

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -14,29 +14,13 @@ interface identity {
 
     /// The binding this call arrived on: the `(implements <name>)` label the
     /// caller imported this plugin's interface under, or `none` for a plain,
-    /// unlabeled import.
-    ///
-    /// The label is the routing key an operator declares under a `host.plugins`
-    /// entry's `bindings`, so this is what pairs a call with the configuration
-    /// that binding was given — the config delivered as the matching
-    /// `workload-lifecycle.interface-binding`'s `name`/`config` at bind time.
-    /// Without it a plugin serving two bindings of one workload could tell them
-    /// apart at bind and not on the call that needs it.
+    /// unlabeled import. The label is the name an operator declares under a
+    /// `host.plugins` entry's `bindings`, and the name the matching
+    /// `workload-lifecycle.interface-binding` carried at bind time, so it
+    /// pairs a call with that binding's configuration.
     ///
     /// A label equal to the plugin's own id addresses the plugin rather than
-    /// one of its bindings, and reads as `none` here, exactly as it does in the
-    /// host's own binding resolution.
-    ///
-    /// `none` is also what a lifecycle hook and an unresolvable caller get: a
-    /// hook is delivered about a whole workload rather than on any one
-    /// binding's behalf. Read the `interface-binding` list on `workload-info`
-    /// there instead.
-    ///
-    /// A name here is always one `on-workload-bind` already delivered. A
-    /// workload may import an interface under a label its manifest never
-    /// declared — the entry matching it carries no name — and the host wires
-    /// that label so the import resolves; but no configuration was resolved
-    /// under it, so it reads as `none` rather than naming a binding this plugin
-    /// was never given.
+    /// one of its bindings and reads as `none`. A lifecycle hook reads `none`
+    /// too: it is about a whole workload, so read `workload-info` there.
     get-binding-name: func() -> option<string>;
 }

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.3;
+package wasmcloud:host@0.1.4;
 
 /// Provided by the host to a component plugin so it can partition state by the
 /// workload currently calling it. The host answers based on the in-flight
@@ -31,5 +31,12 @@ interface identity {
     /// hook is delivered about a whole workload rather than on any one
     /// binding's behalf. Read the `interface-binding` list on `workload-info`
     /// there instead.
+    ///
+    /// A name here is always one `on-workload-bind` already delivered. A
+    /// workload may import an interface under a label its manifest never
+    /// declared — the entry matching it carries no name — and the host wires
+    /// that label so the import resolves; but no configuration was resolved
+    /// under it, so it reads as `none` rather than naming a binding this plugin
+    /// was never given.
     get-binding-name: func() -> option<string>;
 }

--- a/wit/host/wit/identity.wit
+++ b/wit/host/wit/identity.wit
@@ -11,4 +11,25 @@ interface identity {
     get-workload-id: func() -> workload-id;
     /// The component id of the caller currently invoking this plugin.
     get-component-id: func() -> component-id;
+
+    /// The binding this call arrived on: the `(implements <name>)` label the
+    /// caller imported this plugin's interface under, or `none` for a plain,
+    /// unlabeled import.
+    ///
+    /// The label is the routing key an operator declares under a `host.plugins`
+    /// entry's `bindings`, so this is what pairs a call with the configuration
+    /// that binding was given — the config delivered as the matching
+    /// `workload-lifecycle.interface-binding`'s `name`/`config` at bind time.
+    /// Without it a plugin serving two bindings of one workload could tell them
+    /// apart at bind and not on the call that needs it.
+    ///
+    /// A label equal to the plugin's own id addresses the plugin rather than
+    /// one of its bindings, and reads as `none` here, exactly as it does in the
+    /// host's own binding resolution.
+    ///
+    /// `none` is also what a lifecycle hook and an unresolvable caller get: a
+    /// hook is delivered about a whole workload rather than on any one
+    /// binding's behalf. Read the `interface-binding` list on `workload-info`
+    /// there instead.
+    get-binding-name: func() -> option<string>;
 }

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -83,11 +83,10 @@ interface workload-lifecycle {
         /// imports the interface under that `(implements ..)` label; the name
         /// then reaches this hook with the binding's resolved `config`, and
         /// every call the label routes as
-        /// `wasmcloud:host/identity#get-binding-name`. A plain import takes
-        /// the unnamed entry, or the one named entry when that is all the
-        /// workload declared. An import matching no entry — a label no entry
-        /// names, or a plain import beside several named entries — fails the
-        /// bind rather than binding unnamed.
+        /// `wasmcloud:host/identity#get-binding-name`. An import matching no
+        /// entry of its shape — a label no entry names, or a plain import
+        /// where every entry is named — fails the bind rather than binding
+        /// unnamed.
         ///
         /// Declare nothing and the plugin serves plain imports as before, and
         /// a workload naming more than one binding of a package is refused.

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -77,24 +77,22 @@ interface workload-lifecycle {
         /// same namespace:package, if any. Component-facing: what the component
         /// calls this import.
         ///
-        /// For a **wasm** host component plugin this is live in both
-        /// directions, and the operator's `host.plugins` entry is what turns
-        /// it on: declare a name under that entry's `bindings` and a workload
-        /// may import the plugin's interface under that `(implements ..)`
-        /// label, as many of them as the entry declares. The label reaches the
-        /// hook here with the binding's resolved `config`, and it reaches every
-        /// capability call the label routes as
-        /// `wasmcloud:host/identity#get-binding-name` — so state keyed by
-        /// binding at bind time is reachable from the call that needs it.
+        /// For a **wasm** host component plugin, a label routes here when the
+        /// operator declares it under the plugin's `host.plugins` entry's
+        /// `bindings`. The workload names it on an entry and the component
+        /// imports the interface under that `(implements ..)` label; the name
+        /// then reaches this hook with the binding's resolved `config`, and
+        /// every call the label routes as
+        /// `wasmcloud:host/identity#get-binding-name`. A plain import takes
+        /// the unnamed entry, or the one named entry when that is all the
+        /// workload declared. An import matching no entry — a label no entry
+        /// names, or a plain import beside several named entries — fails the
+        /// bind rather than binding unnamed.
         ///
-        /// Declare nothing and nothing changes: a plugin with no `bindings`
-        /// entry serves plain, unlabeled imports exactly as it did before, and
-        /// this field arrives as `none`.
-        ///
-        /// One gap remains, and it is not specific to wasm plugins: two
-        /// *unnamed* entries of the same namespace:package are one binding, so
-        /// a plugin cannot serve them differently. Give them labels — which is
-        /// what labels are for.
+        /// Declare nothing and the plugin serves plain imports as before, and
+        /// a workload naming more than one binding of a package is refused.
+        /// Two *unnamed* entries of one namespace:package are one binding, for
+        /// any plugin; give them labels.
         name: option<string>,
         /// Platform-facing id the binding was declared with, if any — what the
         /// platform's configuration calls the same instance.

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.3;
+package wasmcloud:host@0.1.4;
 
 /// Optionally exported by a host component plugin. The host calls these as
 /// workloads that import the plugin's capabilities are bound and unbound,

--- a/wit/host/wit/lifecycle.wit
+++ b/wit/host/wit/lifecycle.wit
@@ -77,20 +77,24 @@ interface workload-lifecycle {
         /// same namespace:package, if any. Component-facing: what the component
         /// calls this import.
         ///
-        /// Two gaps for a **wasm** host component plugin specifically (a
-        /// Rust built-in plugin doesn't have either): a workload with more
-        /// than one *named* binding on the same namespace:package is
-        /// rejected before bind unless the plugin implements
-        /// `supports_named_instances()` — no wasm plugin can opt into that
-        /// today, so this field only ever arrives as at most one populated
-        /// `name` per namespace:package per workload in practice. And even
-        /// where it is populated, it reaches `on-workload-bind` but is not
-        /// threaded through to the capability call itself — nothing on a
-        /// later `store.get`-style call says which binding it's for, only
-        /// `wasmcloud:host/identity`'s workload/component id. A plugin that
-        /// needs to serve two *unnamed* bindings of the same
-        /// namespace:package differently has no way to disambiguate them at
-        /// all today.
+        /// For a **wasm** host component plugin this is live in both
+        /// directions, and the operator's `host.plugins` entry is what turns
+        /// it on: declare a name under that entry's `bindings` and a workload
+        /// may import the plugin's interface under that `(implements ..)`
+        /// label, as many of them as the entry declares. The label reaches the
+        /// hook here with the binding's resolved `config`, and it reaches every
+        /// capability call the label routes as
+        /// `wasmcloud:host/identity#get-binding-name` — so state keyed by
+        /// binding at bind time is reachable from the call that needs it.
+        ///
+        /// Declare nothing and nothing changes: a plugin with no `bindings`
+        /// entry serves plain, unlabeled imports exactly as it did before, and
+        /// this field arrives as `none`.
+        ///
+        /// One gap remains, and it is not specific to wasm plugins: two
+        /// *unnamed* entries of the same namespace:package are one binding, so
+        /// a plugin cannot serve them differently. Give them labels — which is
+        /// what labels are for.
         name: option<string>,
         /// Platform-facing id the binding was declared with, if any — what the
         /// platform's configuration calls the same instance.

--- a/wit/host/wit/types.wit
+++ b/wit/host/wit/types.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.3;
+package wasmcloud:host@0.1.4;
 
 /// The identifiers every other `wasmcloud:host` interface names a workload and
 /// its components by, defined once so they mean the same thing in all of them:

--- a/wit/host/wit/workload.wit
+++ b/wit/host/wit/workload.wit
@@ -1,4 +1,4 @@
-package wasmcloud:host@0.1.3;
+package wasmcloud:host@0.1.4;
 
 /// Provided by the host to a component plugin that *imports* an interface a
 /// workload exports, so the plugin can call into that workload — the reverse of

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -144,6 +144,7 @@ const P3_FIXTURES: &[&str] = &[
     "http-webgpu",
     "kv-plugin",
     "kv-plugin-caller",
+    "kv-plugin-implements-caller",
     "kv-plugin-service",
     "badlifecycle",
     "secrets-caller",


### PR DESCRIPTION
# (FEAT) Host component plugin bindings

#5517 gave every plugin a generic `bindings:` block, but a **host component
plugin** (not a native host built-in plugin) could not use one. Three
things stood in the way, and `wit/host/wit/lifecycle.wit` documented two of them
in place as known gaps:

1. `ComponentHostPlugin::supports_named_instances()` was hardcoded `false`, so an
   `(implements ..)` labeled interface was deferred to a built-in that supports
   named instances — for `wasmcloud:secrets`, the built-in plugin, which resolves
   it against bind-time config instead.
2. `add_capabilities_to_linker` defined its linker instance under the
   *interface's* name. The component model names a labeled import by its **label**,
   so the workload's import was left unresolved even when the plugin was matched.
3. The label reached `on-workload-bind` and stopped there. Nothing on a later
   `store.get`-style call said which binding it was for, so a plugin could tell
   two bindings apart at bind time and not on the call that needed it.

## What this does

**Declaring no `bindings:` changes nothing.** A plugin with no `host.plugins`
entry serves plain, unlabeled imports exactly as before; the operator's
declaration is what turns label routing on.

- **`wasmcloud:host/identity` gains `get-binding-name: func() -> option<string>`**
  — the label the current call arrived on, `none` for a plain import and for a
  lifecycle hook. `CallerIdentity` carries it, fixed when the linker shim is
  installed rather than read from the call, so nothing a guest passes can
  influence it.
- **`ComponentHostPlugin` wires one linker instance per label the component
  actually imports.** `import_labels` derives them from the *component's own
  world*, not from the manifest's matched entries: an entry is the operator- and
  manifest-facing declaration, while what has to be defined on this item's linker
  is whatever this component imports, under the name it imports it by. A label
  equal to the plugin's own id reads as unnamed, agreeing with
  `PluginBindingSet::binding_name`.
- **`supports_named_instances()` returns true exactly when the operator declared
  bindings**, recorded in `validate_bindings` at host build. A wasm plugin cannot
  name its backends in code the way a native multiplexer does — it has one store
  and serves whatever a workload imports — so the declaration is the statement
  that these are the names this host serves. Claiming every label
  unconditionally would take plain imports away from the single-backend natives
  that serve them today, since the deferral runs in both directions.
- **`WitInterface`'s `version`/`config`/`name` get `#[serde(default)]`.** An entry
  that configures nothing is the shape an operator-declared binding takes — what
  it reads is declared under `host.plugins`, so the manifest entry carries only
  the name. Without this, writing one in a `wash` config file failed to parse
  with `missing field 'config'`.

`wit/host/wit/lifecycle.wit`'s `interface-binding.name` doc is rewritten to
describe what now works. One gap is called out as remaining, and it is not
specific to wasm plugins: two *unnamed* entries of one namespace:package are one
binding, so a plugin cannot serve them differently. Give them labels.

## Testing

Unit tests for `import_labels` cover a plain import, a labeled one, a component
importing both, a label equal to the plugin id, an interface the component does
not import, and a different package. `cargo clippy -p wash-runtime --features
host-component-plugins --lib` is clean.

End to end on a local **kind** cluster, with a Kubernetes Secrets host component plugin (This will be in awesome-wasmcloud repo once testing is done) . The host group ran an image built
with `CARGO_FEATURES=host-component-plugins`. Helm values:

```yaml
      plugins:
        - id: kubernetes-secrets
          image: <registry>/kubernetes-secrets-plugin:0.1.0
          allowedHosts: [kubernetes.default.svc]
          config:
            api-server: https://kubernetes.default.svc
          secretFrom: [wasmcloud-host-token]
          workloadConfig: deny
          hostOwnedKeys: [token, key]
          bindings:
            restricted:
              config:
                key: not-for-this-workload/password
                namespace: secrets-demo
```

One workload reached the plugin through two bindings — its plain
`store`/`reveal` entry, and `restricted`, a `wasmcloud:secrets/secret` import
under an `(implements ..)` label whose manifest entry carries **no config at
all**:

```yaml
      hostInterfaces:
        - namespace: wasmcloud
          package: secrets
          interfaces: [store, reveal]
          version: "2.1.0"
          config:
            namespace: secrets-demo
            secrets: db-creds,api-keys
        - namespace: wasmcloud
          package: secrets
          interfaces: [secret]
          version: "2.1.0"
          name: restricted
```

Results:

```console
$ curl .../secrets/db-creds/password             # plain binding, allowlisted
s3cret-from-k8s

$ curl .../secrets/not-for-this-workload/password  # plain binding, not allowlisted
no secret at "not-for-this-workload/password"

$ curl .../restricted                             # the same Secret, operator's binding
another-workloads-secret
```

The label routed to the component plugin rather than the built-in
(`INFO plugin bindings resolved ... plugin_id="kubernetes-secrets"
workload_config="deny" bindings="restricted"`), the operator's
`bindings.restricted.config` — not the manifest — decided what it resolved to,
and rotating that Secret with `kubectl patch` was visible on the next call
through the binding, with no redeploy.

Both refusals that make this a boundary rather than a convention were checked as
failed deploys:

- a manifest setting the host-owned `key`: *"it sets `key`, which belong to the
  operator; a manifest that set them could point itself at another backend or
  widen its own grant"*
- a manifest naming a binding nobody declared: *"this plugin declares bindings;
  it serves `restricted` and `undeclared-name` is not among them; add it under
  `host.plugins` entry `kubernetes-secrets`'s `bindings`"*

The same workload and plugin were also run under `wash dev` against the plugin's
in-memory backend — no cluster, no `kubectl` — and answered identically.

## Note for anyone reproducing this

A guest importing an interface under an `(implements ..)` label needs
`wasm-component-ld` **0.5.24 or later** in the toolchain that builds it. Older
linkers fail with `invalid leading byte (0x2) for import name`.

Labeling `wasmcloud:secrets/store` does not work and is worth knowing: `store`
*defines* the `secret` resource, so a labeled instance defines its own, distinct
from the one an unlabeled `reveal` accepts — a guest type error before anything
runs. `secret` and `reveal` only `use` the type, which is why `secret` is the
interface meant to be imported under a label. Nothing here is specific to
`wasmcloud:secrets`; the same rule applies to any package whose labeled
interface defines a resource its unlabeled siblings take.

---

Signed-off-by: Jeremy Fleitz <jeremy@cosmonic.com>
