### PR TITLE
Thundering herd test suite

### DIFF
--- a/.github/workflows/runtime-operator.yml
+++ b/.github/workflows/runtime-operator.yml
@@ -170,6 +170,10 @@ jobs:
           SKIP_IMAGE_BUILD: "true"
           PROMETHEUS_INSTALL_SKIP: "true"
           CERT_MANAGER_INSTALL_SKIP: "true"
+          # The runner takes the cluster with it, so the suite's teardown has
+          # nothing to leave clean for. It also empties the namespace before the
+          # diagnostics below can read it.
+          E2E_SKIP_TEARDOWN: "true"
           KIND_CLUSTER_NAME: wasmcloud-e2e
       - name: Dump diagnostics
         if: failure()

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -565,6 +565,10 @@ jobs:
           E2E_FIXTURES_DIR: ${{ runner.temp }}/e2e-fixtures
           PROMETHEUS_INSTALL_SKIP: "true"
           CERT_MANAGER_INSTALL_SKIP: "true"
+          # The runner takes the cluster with it, so the suite's teardown has
+          # nothing to leave clean for. It also empties the namespace before the
+          # diagnostics below can read it.
+          E2E_SKIP_TEARDOWN: "true"
           KIND_CLUSTER_NAME: wasmcloud-e2e
       - name: Dump diagnostics
         if: failure()

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: health
               containerPort: 8082
               protocol: TCP
-          {{- with .Values.operator.startupProbe }}
+          {{- with .Values.operator.probes.startup }}
           {{- if .enabled }}
           startupProbe:
             httpGet:
@@ -92,19 +92,28 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
+          {{- with .Values.operator.probes.liveness }}
+          {{- if .enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            failureThreshold: 3
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.operator.probes.readiness }}
+          {{- if .enabled }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.operator.securityContext | nindent 12 }}
       dnsPolicy: ClusterFirst

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -82,15 +82,16 @@ spec:
             - name: health
               containerPort: 8082
               protocol: TCP
-          # `mgr.Start` binds this port, and it runs after the operator has
-          # connected to NATS — a wait of up to `NatsInitialConnectWindow`
-          # (60s). This suspends liveness until then; 24 × 5s covers it.
+          {{- with .Values.operator.startupProbe }}
+          {{- if .enabled }}
           startupProbe:
             httpGet:
               path: /healthz
               port: health
-            periodSeconds: 5
-            failureThreshold: 24
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -82,19 +82,9 @@ spec:
             - name: health
               containerPort: 8082
               protocol: TCP
-          # Nothing answers on this port until `mgr.Start` binds it, and that
-          # runs after the operator has connected to NATS — which it will wait
-          # up to `wasmbus.NatsInitialConnectWindow` (60s) to do, because a
-          # manager deployed beside its NATS has no ordering against it. The
-          # liveness probe below would reach 3 failures at ~55s and restart the
-          # container mid-wait, so the wait could never be spent: the operator
-          # would be killed for the startup race it was waiting out, on every
-          # install where NATS is slow.
-          #
-          # A startup probe suspends the other two until it passes. 24 × 5s
-          # covers the NATS window with room for the manager's own start; a pod
-          # that never binds is still failed, just on this budget rather than
-          # on liveness's.
+          # `mgr.Start` binds this port, and it runs after the operator has
+          # connected to NATS — a wait of up to `NatsInitialConnectWindow`
+          # (60s). This suspends liveness until then; 24 × 5s covers it.
           startupProbe:
             httpGet:
               path: /healthz

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -82,6 +82,25 @@ spec:
             - name: health
               containerPort: 8082
               protocol: TCP
+          # Nothing answers on this port until `mgr.Start` binds it, and that
+          # runs after the operator has connected to NATS — which it will wait
+          # up to `wasmbus.NatsInitialConnectWindow` (60s) to do, because a
+          # manager deployed beside its NATS has no ordering against it. The
+          # liveness probe below would reach 3 failures at ~55s and restart the
+          # container mid-wait, so the wait could never be spent: the operator
+          # would be killed for the startup race it was waiting out, on every
+          # install where NATS is slow.
+          #
+          # A startup probe suspends the other two until it passes. 24 × 5s
+          # covers the NATS window with room for the manager's own start; a pod
+          # that never binds is still failed, just on this budget rather than
+          # on liveness's.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 24
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -32,8 +32,30 @@
        beside it: a group may turn it off or move it without restating the
        chart-wide default. */}}
 {{- $endpoint := include "runtime-operator.hostProbe" (merge (dict "name" "endpoint") $probeArgs) | fromJson }}
-{{- if and $endpoint.enabled .http .http.enabled (eq (int $endpoint.port) (int .http.port)) }}
-{{- fail (printf "host group %s: probes.endpoint.port and http.port are both %v; the host would fail to bind the second" .name $endpoint.port) }}
+{{- /* Every port the chart renders itself, checked against each other and
+       against the group's own `ports`. Two of these are bound by the host and
+       collide at runtime; a third way to collide is re-listing one under
+       `ports`, which renders a duplicate containerPort and is refused by the
+       API server with a message naming an array index rather than a port. All
+       three are the same mistake, so they are caught in one place and named. */}}
+{{- $groupName := .name }}
+{{- $reserved := dict }}
+{{- if and .http .http.enabled }}
+{{- $_ := set $reserved (toString (int .http.port)) "http.port" }}
+{{- end }}
+{{- if $endpoint.enabled }}
+{{- $probePort := toString (int $endpoint.port) }}
+{{- if hasKey $reserved $probePort }}
+{{- fail (printf "host group %s: probes.endpoint.port and http.port are both %v; the host would fail to bind the second" $groupName $endpoint.port) }}
+{{- end }}
+{{- $_ := set $reserved $probePort "probes.endpoint.port" }}
+{{- end }}
+{{- range .ports }}
+{{- $port := toString (int .containerPort) }}
+{{- $clash := index $reserved $port }}
+{{- if $clash }}
+{{- fail (printf "host group %s: ports[] re-lists containerPort %s, which the chart already renders from %s; drop it from ports[]" $groupName $port $clash) }}
+{{- end }}
 {{- end }}
 {{- $liveness := include "runtime-operator.hostProbe" (merge (dict "name" "liveness") $probeArgs) | fromJson }}
 {{- $readiness := include "runtime-operator.hostProbe" (merge (dict "name" "readiness") $probeArgs) | fromJson }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -37,22 +37,32 @@
        a duplicate containerPort by array index. */}}
 {{- $groupName := .name }}
 {{- $reserved := dict }}
+{{- $reservedNames := dict }}
 {{- if and .http .http.enabled }}
 {{- $_ := set $reserved (toString (int .http.port)) "http.port" }}
+{{- $_ := set $reservedNames "http" "http.port" }}
 {{- end }}
 {{- if $endpoint.enabled }}
 {{- $probePort := toString (int $endpoint.port) }}
-{{- if hasKey $reserved $probePort }}
+{{- with index $reserved $probePort }}
 {{- fail (printf "host group %s: probes.endpoint.port and http.port are both %v; the host would fail to bind the second" $groupName $endpoint.port) }}
 {{- end }}
 {{- $_ := set $reserved $probePort "probes.endpoint.port" }}
+{{- $_ := set $reservedNames "probes" "probes.endpoint.port" }}
 {{- end }}
 {{- range .ports }}
 {{- $port := toString (int .containerPort) }}
-{{- $clash := index $reserved $port }}
-{{- if $clash }}
-{{- fail (printf "host group %s: ports[] re-lists containerPort %s, which the chart already renders from %s; drop it from ports[]" $groupName $port $clash) }}
+{{- $name := toString .name }}
+{{- $portClash := index $reserved $port }}
+{{- if $portClash }}
+{{- fail (printf "host group %s: ports[] gives containerPort %s, already rendered from %s; drop it" $groupName $port $portClash) }}
 {{- end }}
+{{- $nameClash := index $reservedNames $name }}
+{{- if $nameClash }}
+{{- fail (printf "host group %s: ports[] gives the name %q, already rendered from %s; rename it" $groupName $name $nameClash) }}
+{{- end }}
+{{- $_ := set $reserved $port (printf "ports[].%s" $name) }}
+{{- $_ := set $reservedNames $name (printf "ports[].%s" $name) }}
 {{- end }}
 {{- $liveness := include "runtime-operator.hostProbe" (merge (dict "name" "liveness") $probeArgs) | fromJson }}
 {{- $readiness := include "runtime-operator.hostProbe" (merge (dict "name" "readiness") $probeArgs) | fromJson }}
@@ -272,6 +282,9 @@ spec:
             - "--oci-cache-dir=/oci-cache"
             {{- with $top.Values.runtime.drainDelaySeconds }}
             - "--drain-delay={{ . }}s"
+            {{- end }}
+            {{- with $top.Values.runtime.natsConnectTimeoutSeconds }}
+            - "--nats-connect-timeout={{ . }}s"
             {{- end }}
             {{- if $endpoint.enabled }}
             - "--probe-addr=0.0.0.0:{{ $endpoint.port }}"

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -57,12 +57,15 @@
 {{- if $portClash }}
 {{- fail (printf "host group %s: ports[] gives containerPort %s, already rendered from %s; drop it" $groupName $port $portClash) }}
 {{- end }}
+{{- $_ := set $reserved $port (printf "ports[].%s" $name) }}
+{{- /* A container port may be unnamed, and two of those are not a clash. */}}
+{{- if .name }}
 {{- $nameClash := index $reservedNames $name }}
 {{- if $nameClash }}
 {{- fail (printf "host group %s: ports[] gives the name %q, already rendered from %s; rename it" $groupName $name $nameClash) }}
 {{- end }}
-{{- $_ := set $reserved $port (printf "ports[].%s" $name) }}
 {{- $_ := set $reservedNames $name (printf "ports[].%s" $name) }}
+{{- end }}
 {{- end }}
 {{- $liveness := include "runtime-operator.hostProbe" (merge (dict "name" "liveness") $probeArgs) | fromJson }}
 {{- $readiness := include "runtime-operator.hostProbe" (merge (dict "name" "readiness") $probeArgs) | fromJson }}

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -32,12 +32,9 @@
        beside it: a group may turn it off or move it without restating the
        chart-wide default. */}}
 {{- $endpoint := include "runtime-operator.hostProbe" (merge (dict "name" "endpoint") $probeArgs) | fromJson }}
-{{- /* Every port the chart renders itself, checked against each other and
-       against the group's own `ports`. Two of these are bound by the host and
-       collide at runtime; a third way to collide is re-listing one under
-       `ports`, which renders a duplicate containerPort and is refused by the
-       API server with a message naming an array index rather than a port. All
-       three are the same mistake, so they are caught in one place and named. */}}
+{{- /* The ports and names this chart renders itself. A group that claims one
+       again fails here, by name, rather than at the API server, which rejects
+       a duplicate containerPort by array index. */}}
 {{- $groupName := .name }}
 {{- $reserved := dict }}
 {{- if and .http .http.enabled }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -434,10 +434,8 @@ runtime:
     # start on an argument it does not know, so leaving it on there is a
     # CrashLoopBackOff rather than a degraded probe.
     #
-    # `runtime.drainDelaySeconds` is the other flag of that vintage and is
-    # rendered independently of this one, so a group pinned to an older image
-    # has to be given both: turning this off alone still leaves
-    # `--drain-delay` on the command line whenever that value is set.
+    # `runtime.drainDelaySeconds` renders `--drain-delay` independently of this
+    # setting, so a group pinned to an older image needs both cleared.
     endpoint:
       enabled: true
       port: 8081

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -428,11 +428,13 @@ runtime:
     #
     # Turning it off falls the timings back to a TCP connect on `http.port`.
     #
-    # Requires a host image carrying `--probe-addr`, which arrived with this
-    # chart's appVersion. A host group pinning an older `image.tag` must set
+    # Requires a host image carrying `--probe-addr` *and* `--drain-delay`, both
+    # of which arrived with this chart's appVersion and both of which this
+    # setting renders. A host group pinning an older `image.tag` must set
     # `probes.endpoint.enabled: false` for that group — `wash host` refuses to
     # start on an argument it does not know, so leaving it on there is a
-    # CrashLoopBackOff rather than a degraded probe.
+    # CrashLoopBackOff rather than a degraded probe. Turning it off drops both
+    # arguments, so there is one switch to find rather than two.
     endpoint:
       enabled: true
       port: 8081

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -150,6 +150,14 @@ operator:
   service:
     type: ClusterIP
     port: 8443
+  # -- Startup probe for the operator, which suspends the liveness probe until
+  # it passes. `mgr.Start` binds `/healthz`, and it runs only after the operator
+  # has connected to NATS — a wait of up to `NatsInitialConnectWindow`. Size
+  # `periodSeconds` × `failureThreshold` to cover that wait plus manager start.
+  startupProbe:
+    enabled: true
+    periodSeconds: 5
+    failureThreshold: 24
   # -- This section builds out the service account.
   # See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/service-accounts/).
   serviceAccount:
@@ -440,9 +448,9 @@ runtime:
       enabled: true
       port: 8081
       # -- How many 5s attempts the host gets to bind the probe port before the
-      # kubelet gives up. It binds after the host has waited for NATS (up to
-      # `--nats-connect-timeout`, 60s) and after plugin pulls and compiles, so
-      # this is the startup budget for all three: 60 is five minutes.
+      # kubelet gives up. It binds after `runtime.natsConnectTimeoutSeconds` of
+      # waiting for NATS and after plugin pulls and compiles, so this is the
+      # startup budget for all three: 60 is five minutes.
       startupFailureThreshold: 60
     readiness:
       enabled: true
@@ -479,6 +487,12 @@ runtime:
   # It has to fit inside `terminationGracePeriodSeconds` alongside the 5s
   # command drain that follows it; the chart refuses to render if it does not.
   drainDelaySeconds: 5
+  # -- How long a starting host keeps retrying NATS before it gives up, across
+  # the scheduler and data connections together. A host pod and its NATS come
+  # up with no ordering between them, so a refusal here is a race to wait out
+  # rather than a reason to exit and spend a pod restart. Zero fails on the
+  # first refusal. `probes.endpoint.startupFailureThreshold` has to cover this.
+  natsConnectTimeoutSeconds: 60
   # -- How long a terminating host pod has to shut down before it is killed.
   #
   # Three numbers in sequence, and this is the budget for all of them:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -150,14 +150,26 @@ operator:
   service:
     type: ClusterIP
     port: 8443
-  # -- Startup probe for the operator, which suspends the liveness probe until
-  # it passes. `mgr.Start` binds `/healthz`, and it runs only after the operator
-  # has connected to NATS — a wait of up to `NatsInitialConnectWindow`. Size
-  # `periodSeconds` × `failureThreshold` to cover that wait plus manager start.
-  startupProbe:
-    enabled: true
-    periodSeconds: 5
-    failureThreshold: 24
+  # -- Probes for the operator container, answered by the manager on the health
+  # port. The manager binds them only once it has connected to NATS, so the
+  # startup budget (`periodSeconds` × `failureThreshold`) has to cover
+  # `NatsInitialConnectWindow` plus manager start; while it runs, the other two
+  # are suspended. Each can be turned off on its own.
+  probes:
+    startup:
+      enabled: true
+      periodSeconds: 5
+      failureThreshold: 24
+    liveness:
+      enabled: true
+      initialDelaySeconds: 15
+      periodSeconds: 20
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 3
   # -- This section builds out the service account.
   # See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/service-accounts/).
   serviceAccount:

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -437,8 +437,9 @@ runtime:
       enabled: true
       port: 8081
       # -- How many 5s attempts the host gets to bind the probe port before the
-      # kubelet gives up. It binds after plugin pulls and compiles, so this is
-      # the startup budget: 60 is five minutes.
+      # kubelet gives up. It binds after the host has waited for NATS (up to
+      # `--nats-connect-timeout`, 60s) and after plugin pulls and compiles, so
+      # this is the startup budget for all three: 60 is five minutes.
       startupFailureThreshold: 60
     readiness:
       enabled: true

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -428,13 +428,16 @@ runtime:
     #
     # Turning it off falls the timings back to a TCP connect on `http.port`.
     #
-    # Requires a host image carrying `--probe-addr` *and* `--drain-delay`, both
-    # of which arrived with this chart's appVersion and both of which this
-    # setting renders. A host group pinning an older `image.tag` must set
+    # Requires a host image carrying `--probe-addr`, which arrived with this
+    # chart's appVersion. A host group pinning an older `image.tag` must set
     # `probes.endpoint.enabled: false` for that group — `wash host` refuses to
     # start on an argument it does not know, so leaving it on there is a
-    # CrashLoopBackOff rather than a degraded probe. Turning it off drops both
-    # arguments, so there is one switch to find rather than two.
+    # CrashLoopBackOff rather than a degraded probe.
+    #
+    # `runtime.drainDelaySeconds` is the other flag of that vintage and is
+    # rendered independently of this one, so a group pinned to an older image
+    # has to be given both: turning this off alone still leaves
+    # `--drain-delay` on the command line whenever that value is set.
     endpoint:
       enabled: true
       port: 8081

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -454,8 +454,9 @@ runtime:
     # start on an argument it does not know, so leaving it on there is a
     # CrashLoopBackOff rather than a degraded probe.
     #
-    # `runtime.drainDelaySeconds` renders `--drain-delay` independently of this
-    # setting, so a group pinned to an older image needs both cleared.
+    # `runtime.drainDelaySeconds` and `runtime.natsConnectTimeoutSeconds` render
+    # their own flags independently of this setting, so a group pinned to an
+    # older image needs all three cleared, not just this one.
     endpoint:
       enabled: true
       port: 8081

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -267,6 +267,10 @@ name = "integration_router_dynamic"
 required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
 
 [[test]]
+name = "integration_thundering_herd"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
 name = "integration_secrets_plugin"
 required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
 

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -294,6 +294,14 @@ pub struct Engine {
     // wasmtime engine
     pub(crate) inner: wasmtime::Engine,
     pub(crate) cache: Cache<CacheKey, CacheValue>,
+    /// Compiles that actually ran on this engine.
+    ///
+    /// Test-only, and there is no way to do without it: what the digest-keyed
+    /// cache buys is that a herd of replicas shares one compile, and from
+    /// outside, one compile and fifteen racing to insert the same key leave
+    /// exactly the same single cache entry.
+    #[cfg(test)]
+    pub(crate) compiles: Arc<std::sync::atomic::AtomicUsize>,
     /// Host-level socket policy every workload on this engine inherits:
     /// enforcement mode, address ranges, whether the host-loopback door is open,
     /// the host's port table, and the connection budget. The workload-level half
@@ -709,8 +717,12 @@ impl Engine {
                 let bytes_ref = bytes.as_ref();
                 let heap = self.effective_heap_memory();
 
+                #[cfg(test)]
+                let compiles = Arc::clone(&self.compiles);
                 self.cache
                     .try_get_with(key, || {
+                        #[cfg(test)]
+                        compiles.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                         Component::new(inner, bytes_ref)
                             .map_err(|e| explain_compile_failure(e, heap))
                             .context("failed to compile component from bytes")
@@ -1289,6 +1301,8 @@ impl EngineBuilder {
         Ok(Engine {
             inner,
             cache,
+            #[cfg(test)]
+            compiles: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             socket_policy: self.socket_policy.unwrap_or_default(),
             host_memory,
             guest_memory: {
@@ -1670,6 +1684,56 @@ mod tests {
 
         let engine = Engine::builder().build().expect("engine should build");
         Component::new(&engine.inner, &bytes).expect("map component should compile");
+    }
+
+    // A scheduler placing N replicas of one image sends N starts carrying one
+    // digest, and the herd is affordable only because they share a compile.
+    // Keying the cache on anything that differs between replicas — a workload
+    // id, a component name — would put a Cranelift compile behind every one of
+    // them, and nothing in a deployment's behaviour would say so.
+    #[test]
+    fn a_herd_of_replicas_shares_one_compiled_component() {
+        const HERD: usize = 15;
+        const DIGEST: &str = "sha256:one-image";
+
+        let bytes = wat::parse_str("(component)").expect("component should assemble");
+        let engine = Engine::builder().build().expect("engine should build");
+
+        std::thread::scope(|scope| {
+            for _ in 0..HERD {
+                scope.spawn(|| {
+                    engine
+                        .load_component_bytes(&bytes, Some(DIGEST))
+                        .map(|_| ())
+                        .expect("every member of the herd should load");
+                });
+            }
+        });
+
+        // The claim is that the herd shares a compile, not merely that it ends
+        // up with one entry: a loader that compiled per caller and let them
+        // race to insert the same key would leave one entry too, and this test
+        // would have said nothing about the cost it exists to prevent.
+        assert_eq!(
+            engine.compiles.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "{HERD} replicas of one image ran more than one compile"
+        );
+
+        engine.cache.run_pending_tasks();
+        assert_eq!(
+            engine.cache.entry_count(),
+            1,
+            "{HERD} replicas of one image left more than one cache entry"
+        );
+
+        // A hit is served without looking at the bytes, so bytes that could
+        // never compile are what prove the entry came back from the cache
+        // rather than from a compile of its own.
+        engine
+            .load_component_bytes(b"definitely not a wasm component", Some(DIGEST))
+            .map(|_| ())
+            .expect("a digest the herd already compiled should be served from the cache");
     }
 
     // A compile failure that goes through the cache reports everything the

--- a/crates/wash-runtime/src/host/accept.rs
+++ b/crates/wash-runtime/src/host/accept.rs
@@ -202,8 +202,16 @@ mod tests {
     /// unpaced, spinning a core with nothing in the log to say why.
     #[test]
     fn a_listener_that_has_stopped_working_paces_the_loop() {
-        // EBADF, EINVAL, ENOTSOCK: the same three on Linux and macOS.
-        for raw in [9, 22, 38] {
+        // `EBADF` and `EINVAL` are 9 and 22 everywhere; `ENOTSOCK` is not, and
+        // it is the one the classifier's own reasoning names, so it is worth
+        // exercising the number the platform actually uses rather than one that
+        // happens to fall through the same way.
+        #[cfg(target_os = "linux")]
+        const NOTSOCK: i32 = 88;
+        #[cfg(not(target_os = "linux"))]
+        const NOTSOCK: i32 = 38;
+
+        for raw in [9, 22, NOTSOCK] {
             let mut backoff = AcceptBackoff::default();
             let broken = std::io::Error::from_raw_os_error(raw);
             for _ in 0..=FAILURES_BEFORE_BACKOFF {

--- a/crates/wash-runtime/src/host/accept.rs
+++ b/crates/wash-runtime/src/host/accept.rs
@@ -17,7 +17,6 @@
 //! their *rate*.
 
 use core::time::Duration;
-#[cfg(any(not(unix), test))]
 use std::io::ErrorKind;
 use std::time::Instant;
 
@@ -31,36 +30,63 @@ const FAILURE_WINDOW: Duration = Duration::from_secs(1);
 const RETRY_MIN: Duration = Duration::from_millis(5);
 const RETRY_MAX: Duration = Duration::from_secs(1);
 
-/// Whether this error is the process's own rather than one connection's.
-///
-/// Named by errno, not by kind: `EMFILE` and the per-connection errors
-/// `accept(2)` says to retry like `EAGAIN` — `EPROTO`, `ENOPROTOOPT`,
-/// `ENETRESET` — all reach Rust as `ErrorKind::Uncategorized`, so a kind cannot
-/// tell them apart. These four leave the connection queued, which is what makes
-/// the next call fail identically.
-#[cfg(unix)]
-fn concerns_the_process(e: &std::io::Error) -> bool {
-    use rustix::io::Errno;
-    e.raw_os_error().is_some_and(|raw| {
-        let errno = Errno::from_raw_os_error(raw);
-        matches!(
-            errno,
-            Errno::MFILE | Errno::NFILE | Errno::NOBUFS | Errno::NOMEM
-        )
-    })
-}
-
-/// Without errnos to name, keep the kinds that are definitely one connection's
-/// and treat the rest as the process's.
-#[cfg(not(unix))]
-fn concerns_the_process(e: &std::io::Error) -> bool {
-    !matches!(
-        e.kind(),
+/// Kinds that are one connection's on any platform, for the errors that reach
+/// Rust with a kind of their own.
+fn kind_concerns_one_connection(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
         ErrorKind::ConnectionAborted
             | ErrorKind::ConnectionReset
             | ErrorKind::Interrupted
             | ErrorKind::WouldBlock
+            | ErrorKind::TimedOut
     )
+}
+
+/// Whether this error is the process's own rather than one connection's.
+///
+/// Named by errno as well as kind: `EMFILE` and the per-connection errors
+/// `accept(2)` says to retry like `EAGAIN` — `EPROTO`, `ENOPROTOOPT`,
+/// `ENETRESET` — all reach Rust as `ErrorKind::Uncategorized`, so a kind alone
+/// cannot tell them apart.
+///
+/// What is listed is what is definitely one connection's; everything else is
+/// the process's. That polarity is the safe one, and it is the only one that
+/// holds for an errno this list has never heard of. A listener whose descriptor
+/// has become invalid returns `EBADF` — or `EINVAL`, or `ENOTSOCK` — on every
+/// call, dequeuing nothing: naming the process's errnos instead would leave
+/// those unpaced, and the loop would spin a core forever without ever reaching
+/// the threshold that logs why. Misjudging the other way costs a bounded pause
+/// on a loop that is already failing.
+#[cfg(unix)]
+fn concerns_the_process(e: &std::io::Error) -> bool {
+    use rustix::io::Errno;
+    if kind_concerns_one_connection(e.kind()) {
+        return false;
+    }
+    let Some(raw) = e.raw_os_error() else {
+        // No errno and no kind that names a connection. Pace it rather than
+        // spin on it.
+        return true;
+    };
+    !matches!(
+        Errno::from_raw_os_error(raw),
+        // The connection is dequeued and done with; the next call proceeds.
+        Errno::CONNABORTED | Errno::CONNRESET | Errno::TIMEDOUT | Errno::AGAIN | Errno::INTR
+        // A firewall verdict on that one connection.
+        | Errno::PERM
+        // Linux reports an error already pending on the new socket through
+        // `accept`; accept(2) says to treat these as `EAGAIN` and carry on.
+        // (`ENONET` belongs here too, but only Linux names it.)
+        | Errno::PROTO | Errno::NOPROTOOPT | Errno::NETDOWN | Errno::NETUNREACH
+        | Errno::NETRESET | Errno::HOSTDOWN | Errno::HOSTUNREACH | Errno::OPNOTSUPP
+    )
+}
+
+/// Without errnos to name, the kinds are all there is to go on.
+#[cfg(not(unix))]
+fn concerns_the_process(e: &std::io::Error) -> bool {
+    !kind_concerns_one_connection(e.kind())
 }
 
 /// Tracks how fast an accept loop is failing, and how long it should wait.
@@ -168,6 +194,31 @@ mod tests {
         }
         assert_eq!(backoff.pause(), None, "a reset storm must not pause anyone");
         assert_eq!(backoff.failures(), 0);
+    }
+
+    /// A listener whose descriptor has stopped being one fails identically on
+    /// every call and dequeues nothing — the exact shape this module paces.
+    /// Naming only the errnos known to be the process's would leave these
+    /// unpaced, spinning a core with nothing in the log to say why.
+    #[test]
+    fn a_listener_that_has_stopped_working_paces_the_loop() {
+        // EBADF, EINVAL, ENOTSOCK: the same three on Linux and macOS.
+        for raw in [9, 22, 38] {
+            let mut backoff = AcceptBackoff::default();
+            let broken = std::io::Error::from_raw_os_error(raw);
+            for _ in 0..=FAILURES_BEFORE_BACKOFF {
+                backoff.failed(&broken);
+            }
+            assert!(
+                backoff.failed(&broken),
+                "errno {raw} repeats forever and must be reported"
+            );
+            assert_eq!(
+                backoff.pause(),
+                Some(RETRY_MIN),
+                "errno {raw} repeats forever and must be paced"
+            );
+        }
     }
 
     #[test]

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1662,6 +1662,12 @@ const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 /// connection's protocol otherwise is.
 const FIRST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Free connections, as a percentage of the ceiling, at which the host stops
+/// claiming it can take more work — and the higher one at which it starts
+/// claiming so again. The gap between them is the hysteresis.
+const READY_LOW_WATER_PERCENT: usize = 10;
+const READY_HIGH_WATER_PERCENT: usize = 25;
+
 /// The ingress connection ceiling, the permits enforcing it, and the counter
 /// reporting it.
 ///
@@ -1676,6 +1682,10 @@ pub struct ConnectionLimit {
     /// indistinguishable from a listener that stopped accepting, and the second
     /// is the more urgent of the two.
     accepting: Arc<AtomicBool>,
+    /// Which side of the hysteresis below readiness is currently on. Shared,
+    /// because the probe handler and the accept loop hold separate clones of
+    /// the same limit.
+    has_headroom: Arc<AtomicBool>,
     offered: opentelemetry::metrics::Counter<u64>,
     /// Built once. `error.type` marks the refusals inside the one series, so a
     /// shed rate is a filter on it rather than a second counter to keep in step.
@@ -1688,6 +1698,7 @@ impl ConnectionLimit {
             max,
             permits: Arc::new(Semaphore::new(max)),
             accepting: Arc::new(AtomicBool::new(true)),
+            has_headroom: Arc::new(AtomicBool::new(true)),
             offered: opentelemetry::global::meter("wash-runtime")
                 .u64_counter("http.ingress.connections")
                 .with_description(
@@ -1747,9 +1758,47 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
         }
     }
 
+    /// Refuses before the shedding starts, and recovers only once there is real
+    /// room again.
+    ///
+    /// Reporting ready down to the last permit means the endpoint is pulled
+    /// only after the host is already turning connections away, and another
+    /// `periodSeconds` × `failureThreshold` of shedding passes before anything
+    /// acts on it. Recovering on one freed permit is the same mistake
+    /// mirrored: a host sitting at its ceiling would re-enter rotation on every
+    /// probe and be full again before the next one.
+    ///
+    /// The two marks are what separate those. Below the low one it stops
+    /// claiming capacity it is about to run out of; it claims it again only
+    /// above the high one.
     fn ready(&self) -> bool {
-        self.accepting.load(std::sync::atomic::Ordering::Relaxed)
-            && self.permits.available_permits() > 0
+        use std::sync::atomic::Ordering::Relaxed;
+        if !self.accepting.load(Relaxed) {
+            return false;
+        }
+        // At least one either way, so a ceiling too small to have percentages
+        // still has a gap between the marks rather than collapsing to "empty".
+        let low = (self.max * READY_LOW_WATER_PERCENT / 100).max(1);
+        let high = (self.max * READY_HIGH_WATER_PERCENT / 100).max(low + 1);
+        let free = self.permits.available_permits();
+        let ready = if self.has_headroom.load(Relaxed) {
+            free > low
+        } else {
+            free >= high
+        };
+        self.has_headroom.store(ready, Relaxed);
+        ready
+    }
+
+    /// Saturation passes; an accept loop that has ended does not.
+    ///
+    /// Nothing brings the loop back without a restart, and readiness alone does
+    /// not remove this host from anything that places work: the scheduler reads
+    /// the Host CR's heartbeat-driven condition, which a host with a dead
+    /// listener goes on satisfying. Left to readiness, it keeps being given
+    /// workloads that report Ready and are unreachable.
+    fn terminal(&self) -> bool {
+        !self.accepting.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -3179,6 +3228,54 @@ mod tests {
     /// parks there. Holding a ceiling slot the whole time turns a handful of
     /// silent peers into a host that reports itself full, which the readiness
     /// check then reports to Kubernetes as a reason to take it out of service.
+    /// Readiness has to turn over before the shedding starts and stay turned
+    /// over until there is real room, or the two probe intervals it takes to
+    /// act on it are spent refusing connections — and one freed slot puts the
+    /// host back in rotation to fill again immediately.
+    #[test]
+    fn readiness_leaves_and_returns_at_different_marks() {
+        use crate::host::probes::ReadinessCheck as _;
+
+        let limit = ConnectionLimit::new(100);
+        let mut held = Vec::new();
+        assert!(limit.ready(), "an idle host takes work");
+
+        // Down to the low mark: still ready at 11 free, refusing at 10.
+        while limit.permits.available_permits() > 11 {
+            held.push(limit.permits.clone().try_acquire_owned().unwrap());
+        }
+        assert!(limit.ready(), "11 free of 100 is above the low mark");
+        held.push(limit.permits.clone().try_acquire_owned().unwrap());
+        assert!(!limit.ready(), "10 free of 100 is the low mark");
+
+        // Back up past the low mark but under the high one: still refusing,
+        // which is the whole point of the gap.
+        while limit.permits.available_permits() < 24 {
+            held.pop();
+        }
+        assert!(
+            !limit.ready(),
+            "24 free is over the low mark but under the high one"
+        );
+
+        held.pop();
+        assert!(limit.ready(), "25 free of 100 is the high mark");
+    }
+
+    /// A ceiling too small for percentages still needs the two marks to differ,
+    /// or the hysteresis collapses back to "ready until the last permit".
+    #[test]
+    fn a_tiny_ceiling_still_has_a_gap() {
+        use crate::host::probes::ReadinessCheck as _;
+
+        let limit = ConnectionLimit::new(2);
+        assert!(limit.ready());
+        let first = limit.permits.clone().try_acquire_owned().unwrap();
+        assert!(!limit.ready(), "one free of two is at the low mark");
+        drop(first);
+        assert!(limit.ready(), "two free of two clears the high mark");
+    }
+
     #[tokio::test(start_paused = true)]
     async fn a_connection_that_never_speaks_gives_its_slot_back() {
         use tokio::io::AsyncWriteExt;

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1972,6 +1972,17 @@ async fn run_http_server<T: Router>(
                             let mut expired = false;
                             let result = loop {
                                 tokio::select! {
+                                    // Biased, so the connection is always polled
+                                    // before the deadline is acted on. `requested`
+                                    // is set from inside the service, which only
+                                    // runs while `serve` is being polled — with
+                                    // the arms chosen at random, a request that
+                                    // arrived in the same instant the deadline
+                                    // fired had not been seen yet, and the
+                                    // connection was dropped with that request
+                                    // unanswered and unread. Polling first is what
+                                    // makes "sent no request" mean it.
+                                    biased;
                                     result = &mut serve => break result,
                                     () = &mut deadline, if !expired => {
                                         expired = true;
@@ -3228,13 +3239,6 @@ mod tests {
         );
     }
 
-    /// A connection that never asks for anything must give its slot back.
-    ///
-    /// hyper decides h1 vs h2 by reading up to 24 preface bytes, and that read
-    /// has no timeout of its own — a peer sending nothing, or half a preface,
-    /// parks there. Holding a ceiling slot the whole time turns a handful of
-    /// silent peers into a host that reports itself full, which the readiness
-    /// check then reports to Kubernetes as a reason to take it out of service.
     /// Readiness has to turn over before the shedding starts and stay turned
     /// over until there is real room, or the two probe intervals it takes to
     /// act on it are spent refusing connections — and one freed slot puts the
@@ -3299,6 +3303,13 @@ mod tests {
         assert!(limit.ready(), "and free again");
     }
 
+    /// A connection that never asks for anything must give its slot back.
+    ///
+    /// hyper decides h1 vs h2 by reading up to 24 preface bytes, and that read
+    /// has no timeout of its own — a peer sending nothing, or half a preface,
+    /// parks there. Holding a ceiling slot the whole time turns a handful of
+    /// silent peers into a host that reports itself full, which the readiness
+    /// check then reports to Kubernetes as a reason to take it out of service.
     #[tokio::test(start_paused = true)]
     async fn a_connection_that_never_speaks_gives_its_slot_back() {
         use tokio::io::AsyncWriteExt;

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1662,11 +1662,15 @@ const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 /// connection's protocol otherwise is.
 const FIRST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Free connections, as a percentage of the ceiling, at which the host stops
-/// claiming it can take more work — and the higher one at which it starts
-/// claiming so again. The gap between them is the hysteresis.
-const READY_LOW_WATER_PERCENT: usize = 10;
-const READY_HIGH_WATER_PERCENT: usize = 25;
+/// Free connections a saturated host has to get back before it claims capacity
+/// again, as a percentage of its ceiling.
+///
+/// Only the recovery side is a chosen number. What takes a host out of the
+/// Service is having no room at all, which needs no threshold and cannot fire
+/// on a host that is merely busy. This decides how much room is enough to stop
+/// it returning into the same wall, so getting it wrong costs a saturated host
+/// a little longer out of rotation and nothing else.
+const READY_RECOVER_PERCENT: usize = 10;
 
 /// The ingress connection ceiling, the permits enforcing it, and the counter
 /// reporting it.
@@ -1758,40 +1762,32 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
         }
     }
 
-    /// Refuses before the shedding starts, and recovers only once there is real
-    /// room again.
+    /// Not-ready means this host has no room, not that it is busy.
     ///
-    /// Reporting ready down to the last permit means the endpoint is pulled
-    /// only after the host is already turning connections away, and another
-    /// `periodSeconds` × `failureThreshold` of shedding passes before anything
-    /// acts on it. Recovering on one freed permit is the same mistake
-    /// mirrored: a host sitting at its ceiling would re-enter rotation on every
-    /// probe and be full again before the next one.
+    /// A threshold on utilisation would take a healthy host out of the Service:
+    /// a ceiling of 256 and a tenth-free mark pulls it at 231 connections while
+    /// it is still serving every one of them, and replicas at similar load
+    /// cross it together. So the departure is absolute — no permits left, which
+    /// is the host actually turning connections away.
     ///
-    /// The two marks are what separate those. Below the low one it stops
-    /// claiming capacity it is about to run out of; it claims it again only
-    /// above the high one.
+    /// Recovery is the part that needs a margin. Returning on a single freed
+    /// permit puts a saturated host back a probe before it is full again, so it
+    /// waits for [`READY_RECOVER_PERCENT`] of its ceiling to come back.
     fn ready(&self) -> bool {
         use std::sync::atomic::Ordering::Relaxed;
         if !self.accepting.load(Relaxed) {
             return false;
         }
-        // A gap either way, so a ceiling too small to have percentages does not
-        // collapse to "ready until empty" — and, at the other end, so a ceiling
-        // of one is not unready from the moment it starts: the low mark has to
-        // leave at least one free connection above it that still counts as
-        // room, or nothing ever clears it.
-        let low = (self.max * READY_LOW_WATER_PERCENT / 100)
+        // Never above the ceiling, so a host too small for the percentage still
+        // has a reachable recovery mark.
+        let recover = (self.max * READY_RECOVER_PERCENT / 100)
             .max(1)
-            .min(self.max.saturating_sub(1));
-        let high = (self.max * READY_HIGH_WATER_PERCENT / 100)
-            .max(low + 1)
             .min(self.max);
         let free = self.permits.available_permits();
         let ready = if self.has_headroom.load(Relaxed) {
-            free > low
+            free > 0
         } else {
-            free >= high
+            free >= recover
         };
         self.has_headroom.store(ready, Relaxed);
         ready
@@ -3239,60 +3235,52 @@ mod tests {
         );
     }
 
-    /// Readiness has to turn over before the shedding starts and stay turned
-    /// over until there is real room, or the two probe intervals it takes to
-    /// act on it are spent refusing connections — and one freed slot puts the
-    /// host back in rotation to fill again immediately.
+    /// A busy host is not an unready one. The mark that takes it out of the
+    /// Service is having nothing left to give, so a host serving every
+    /// connection it holds stays in rotation however close to the ceiling it
+    /// is — otherwise replicas at similar load leave together and the Service
+    /// empties while every one of them is healthy.
     #[test]
-    fn readiness_leaves_and_returns_at_different_marks() {
+    fn a_host_with_room_stays_ready_however_busy() {
         use crate::host::probes::ReadinessCheck as _;
 
         let limit = ConnectionLimit::new(100);
         let mut held = Vec::new();
-        assert!(limit.ready(), "an idle host takes work");
-
-        // Down to the low mark: still ready at 11 free, refusing at 10.
-        while limit.permits.available_permits() > 11 {
+        while limit.permits.available_permits() > 1 {
             held.push(limit.permits.clone().try_acquire_owned().unwrap());
         }
-        assert!(limit.ready(), "11 free of 100 is above the low mark");
-        held.push(limit.permits.clone().try_acquire_owned().unwrap());
-        assert!(!limit.ready(), "10 free of 100 is the low mark");
-
-        // Back up past the low mark but under the high one: still refusing,
-        // which is the whole point of the gap.
-        while limit.permits.available_permits() < 24 {
-            held.pop();
-        }
         assert!(
-            !limit.ready(),
-            "24 free is over the low mark but under the high one"
+            limit.ready(),
+            "99 of 100 connections in use is busy, not full"
         );
 
-        held.pop();
-        assert!(limit.ready(), "25 free of 100 is the high mark");
+        held.push(limit.permits.clone().try_acquire_owned().unwrap());
+        assert!(!limit.ready(), "no permits left is the host refusing work");
     }
 
-    /// A ceiling too small for percentages still needs the two marks to differ,
-    /// or the hysteresis collapses back to "ready until the last permit".
+    /// Recovery waits for real room. One freed permit would put a saturated
+    /// host back into rotation a probe before it is full again.
     #[test]
-    fn a_tiny_ceiling_still_has_a_gap() {
+    fn a_saturated_host_waits_for_room_before_returning() {
         use crate::host::probes::ReadinessCheck as _;
 
-        let limit = ConnectionLimit::new(2);
-        assert!(limit.ready());
-        let first = limit.permits.clone().try_acquire_owned().unwrap();
-        assert!(!limit.ready(), "one free of two is at the low mark");
-        drop(first);
-        assert!(limit.ready(), "two free of two clears the high mark");
+        let limit = ConnectionLimit::new(100);
+        let mut held = Vec::new();
+        while limit.permits.available_permits() > 0 {
+            held.push(limit.permits.clone().try_acquire_owned().unwrap());
+        }
+        assert!(!limit.ready());
+
+        held.truncate(held.len() - 9);
+        assert!(!limit.ready(), "9 free of 100 is not yet the recovery mark");
+        held.truncate(held.len() - 1);
+        assert!(limit.ready(), "10 free of 100 clears it");
     }
 
-    /// The smallest ceiling there is. A low mark that does not leave at least
-    /// one free connection above it is one nothing can ever clear, and a host
-    /// started with a ceiling of one would report not-ready from the moment it
-    /// came up and never join the Service.
+    /// The smallest ceiling there is. Its recovery mark has to be reachable, or
+    /// a host started with one connection never returns after its first.
     #[test]
-    fn a_ceiling_of_one_is_ready_when_it_is_idle() {
+    fn a_ceiling_of_one_recovers() {
         use crate::host::probes::ReadinessCheck as _;
 
         let limit = ConnectionLimit::new(1);

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1800,7 +1800,7 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
     /// the Host CR's heartbeat-driven condition, which a host with a dead
     /// listener goes on satisfying. Left to readiness, it keeps being given
     /// workloads that report Ready and are unreachable.
-    fn terminal(&self) -> bool {
+    fn unrecoverable(&self) -> bool {
         !self.accepting.load(std::sync::atomic::Ordering::Relaxed)
     }
 }

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1776,10 +1776,17 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
         if !self.accepting.load(Relaxed) {
             return false;
         }
-        // At least one either way, so a ceiling too small to have percentages
-        // still has a gap between the marks rather than collapsing to "empty".
-        let low = (self.max * READY_LOW_WATER_PERCENT / 100).max(1);
-        let high = (self.max * READY_HIGH_WATER_PERCENT / 100).max(low + 1);
+        // A gap either way, so a ceiling too small to have percentages does not
+        // collapse to "ready until empty" — and, at the other end, so a ceiling
+        // of one is not unready from the moment it starts: the low mark has to
+        // leave at least one free connection above it that still counts as
+        // room, or nothing ever clears it.
+        let low = (self.max * READY_LOW_WATER_PERCENT / 100)
+            .max(1)
+            .min(self.max.saturating_sub(1));
+        let high = (self.max * READY_HIGH_WATER_PERCENT / 100)
+            .max(low + 1)
+            .min(self.max);
         let free = self.permits.available_permits();
         let ready = if self.has_headroom.load(Relaxed) {
             free > low
@@ -3274,6 +3281,22 @@ mod tests {
         assert!(!limit.ready(), "one free of two is at the low mark");
         drop(first);
         assert!(limit.ready(), "two free of two clears the high mark");
+    }
+
+    /// The smallest ceiling there is. A low mark that does not leave at least
+    /// one free connection above it is one nothing can ever clear, and a host
+    /// started with a ceiling of one would report not-ready from the moment it
+    /// came up and never join the Service.
+    #[test]
+    fn a_ceiling_of_one_is_ready_when_it_is_idle() {
+        use crate::host::probes::ReadinessCheck as _;
+
+        let limit = ConnectionLimit::new(1);
+        assert!(limit.ready(), "idle with its one connection free");
+        let only = limit.permits.clone().try_acquire_owned().unwrap();
+        assert!(!limit.ready(), "its one connection is in use");
+        drop(only);
+        assert!(limit.ready(), "and free again");
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1991,7 +1991,20 @@ async fn run_http_server<T: Router>(
                             };
 
                             if let Err(e) = result {
-                                error!(addr = ?client_addr, err = ?e, "error serving HTTP client");
+                                // A timeout is the peer not sending, which is
+                                // what the deadline above closes connections
+                                // for. Both bound that same condition, so
+                                // whichever fires first decides nothing about
+                                // what happened — and `ERROR` here would put a
+                                // probe, a port scan or a forwarded port whose
+                                // far end went away beside real serving
+                                // failures, in the one place an operator looks
+                                // for them.
+                                if ended_in_timeout(&*e) {
+                                    debug!(addr = ?client_addr, err = ?e, "closing a connection that sent no request");
+                                } else {
+                                    error!(addr = ?client_addr, err = ?e, "error serving HTTP client");
+                                }
                             }
                         });
                     }
@@ -2008,6 +2021,17 @@ async fn run_http_server<T: Router>(
     }
 
     Ok(())
+}
+
+/// Whether a served connection ended because the peer stopped sending.
+///
+/// The connection future is boxed by the protocol-detecting builder, so the
+/// hyper error carrying that answer can be at any depth of the chain.
+fn ended_in_timeout(e: &(dyn std::error::Error + 'static)) -> bool {
+    if let Some(hyper) = e.downcast_ref::<hyper::Error>() {
+        return hyper.is_timeout();
+    }
+    e.source().is_some_and(ended_in_timeout)
 }
 
 /// Build an error response with the given status code.
@@ -3289,6 +3313,37 @@ mod tests {
         assert!(!limit.ready(), "its one connection is in use");
         drop(only);
         assert!(limit.ready(), "and free again");
+    }
+
+    /// The connection future is boxed, and a real serving failure has to stay
+    /// an `ERROR` however deep the chain gets. Only the hyper error at the
+    /// bottom of it decides, and a chain that has none is not a timeout.
+    #[test]
+    fn a_served_error_that_is_not_a_timeout_stays_an_error() {
+        #[derive(Debug)]
+        struct Wrapped(std::io::Error);
+        impl std::fmt::Display for Wrapped {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "wrapped")
+            }
+        }
+        impl std::error::Error for Wrapped {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let reset = std::io::Error::from(std::io::ErrorKind::ConnectionReset);
+        assert!(!ended_in_timeout(&reset), "a reset is not a timeout");
+        assert!(
+            !ended_in_timeout(&Wrapped(std::io::Error::from(
+                std::io::ErrorKind::ConnectionReset
+            ))),
+            "and neither is one behind a wrapper"
+        );
+        // A chain with no hyper error in it must terminate rather than recurse
+        // on itself.
+        assert!(!ended_in_timeout(&Wrapped(std::io::Error::other("x"))));
     }
 
     /// A connection that never asks for anything must give its slot back.

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -42,12 +42,8 @@ const MAX_PROBE_CONNECTIONS: usize = 512;
 /// How long one probe connection may live. Each serves a single request and
 /// closes, so holding a slot open is not something a caller has a reason to do.
 ///
-/// The only bound, deliberately. A separate header-read timeout was set on the
-/// hyper builder beside this one and could never fire, because it was the
-/// longer of the two and this wraps the whole connection — it read as a second,
-/// looser limit while contributing nothing. One connection lifetime covers the
-/// case a header timeout is for: a peer that opens a socket and says nothing
-/// still loses its slot here.
+/// The only deadline here, and it wraps the whole connection: a peer that opens
+/// a socket and says nothing loses its slot on this alone.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A monotonic "still turning" signal, beaten by whatever owns the host's main

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -128,7 +128,7 @@ pub trait ReadinessCheck: Send + Sync + std::fmt::Debug {
     /// It earns its place only where readiness alone leaves a host that will
     /// never serve again — running, heartbeating, and still being scheduled
     /// onto, because nothing that places work reads readiness.
-    fn terminal(&self) -> bool {
+    fn unrecoverable(&self) -> bool {
         false
     }
 }
@@ -191,7 +191,7 @@ impl ProbeState {
         !self
             .checks
             .iter()
-            .any(|check| check.terminal() && !check.ready())
+            .any(|check| check.unrecoverable() && !check.ready())
     }
 
     /// The checks currently refusing, empty when the host is ready.
@@ -325,7 +325,7 @@ mod tests {
     struct Gate {
         name: &'static str,
         ready: AtomicBool,
-        terminal: bool,
+        unrecoverable: bool,
     }
 
     impl ReadinessCheck for Gate {
@@ -335,8 +335,8 @@ mod tests {
         fn ready(&self) -> bool {
             self.ready.load(Ordering::Relaxed)
         }
-        fn terminal(&self) -> bool {
-            self.terminal
+        fn unrecoverable(&self) -> bool {
+            self.unrecoverable
         }
     }
 
@@ -344,16 +344,16 @@ mod tests {
         Arc::new(Gate {
             name,
             ready: AtomicBool::new(ready),
-            terminal: false,
+            unrecoverable: false,
         })
     }
 
     /// A check whose refusal the host cannot recover from.
-    fn terminal_gate(name: &'static str, ready: bool) -> Arc<Gate> {
+    fn unrecoverable_gate(name: &'static str, ready: bool) -> Arc<Gate> {
         Arc::new(Gate {
             name,
             ready: AtomicBool::new(ready),
-            terminal: true,
+            unrecoverable: true,
         })
     }
 
@@ -378,7 +378,7 @@ mod tests {
     /// this is the case where a restart is the lesser loss.
     #[test]
     fn a_host_whose_ingress_stopped_is_not_live() {
-        let stopped = terminal_gate("http_ingress_stopped", false);
+        let stopped = unrecoverable_gate("http_ingress_stopped", false);
         let state = ProbeState::default().with_readiness(stopped);
         state.started();
 
@@ -388,8 +388,8 @@ mod tests {
 
     /// The same check, satisfied, says nothing about liveness.
     #[test]
-    fn a_terminal_check_that_is_satisfied_leaves_the_host_live() {
-        let state = ProbeState::default().with_readiness(terminal_gate("ingress", true));
+    fn an_unrecoverable_check_that_is_satisfied_leaves_the_host_live() {
+        let state = ProbeState::default().with_readiness(unrecoverable_gate("ingress", true));
         state.started();
         assert!(state.live());
         assert!(state.not_ready().is_empty());
@@ -401,7 +401,7 @@ mod tests {
     #[test]
     fn a_draining_host_stays_live_even_with_its_ingress_stopped() {
         let state =
-            ProbeState::default().with_readiness(terminal_gate("http_ingress_stopped", false));
+            ProbeState::default().with_readiness(unrecoverable_gate("http_ingress_stopped", false));
         state.started();
         state.drain();
 

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -31,9 +31,6 @@ use crate::host::accept::AcceptBackoff;
 const LIVEZ: &str = "/livez";
 const READYZ: &str = "/readyz";
 
-/// How long a peer has to send its request line and headers.
-const HEADER_READ_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Connections this listener will hold at once.
 ///
 /// It needs a ceiling because its port is reachable from the whole cluster and
@@ -44,6 +41,13 @@ const MAX_PROBE_CONNECTIONS: usize = 512;
 
 /// How long one probe connection may live. Each serves a single request and
 /// closes, so holding a slot open is not something a caller has a reason to do.
+///
+/// The only bound, deliberately. A separate header-read timeout was set on the
+/// hyper builder beside this one and could never fire, because it was the
+/// longer of the two and this wraps the whole connection — it read as a second,
+/// looser limit while contributing nothing. One connection lifetime covers the
+/// case a header timeout is for: a peer that opens a socket and says nothing
+/// still loses its slot here.
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A monotonic "still turning" signal, beaten by whatever owns the host's main
@@ -118,6 +122,19 @@ pub trait ReadinessCheck: Send + Sync + std::fmt::Debug {
 
     /// `true` when this check is satisfied.
     fn ready(&self) -> bool;
+
+    /// Whether a refusal from this check is one the host cannot recover from
+    /// on its own, so `/livez` should fail with it and the host be restarted.
+    ///
+    /// Almost nothing qualifies, and the default says so: failing liveness
+    /// takes every workload on the host and hands the scheduler all of them at
+    /// once, which is far worse than a host that is briefly not taking work.
+    /// It earns its place only where readiness alone leaves a host that will
+    /// never serve again — running, heartbeating, and still being scheduled
+    /// onto, because nothing that places work reads readiness.
+    fn terminal(&self) -> bool {
+        false
+    }
 }
 
 /// The state [`serve`] reports, and the handle a host drives it through.
@@ -166,7 +183,19 @@ impl ProbeState {
     }
 
     fn live(&self) -> bool {
-        self.liveness.as_ref().is_none_or(|l| l.alive())
+        if !self.liveness.as_ref().is_none_or(|l| l.alive()) {
+            return false;
+        }
+        // A draining host stops accepting because it was told to. Reading that
+        // as "restart me" would kill it mid-drain, which is the one thing
+        // `drain` exists to avoid.
+        if self.draining.load(Ordering::Relaxed) {
+            return true;
+        }
+        !self
+            .checks
+            .iter()
+            .any(|check| check.terminal() && !check.ready())
     }
 
     /// The checks currently refusing, empty when the host is ready.
@@ -273,9 +302,9 @@ pub async fn serve(
                     let mut builder = hyper::server::conn::http1::Builder::new();
                     builder
                         .timer(TokioTimer::new())
-                        .header_read_timeout(HEADER_READ_TIMEOUT)
                         // One request per connection: a slot held open is a
-                        // slot the kubelet cannot have.
+                        // slot the kubelet cannot have. `CONNECTION_TIMEOUT`
+                        // below is the only deadline; see its comment.
                         .keep_alive(false);
                     let served = tokio::time::timeout(
                         CONNECTION_TIMEOUT,
@@ -300,6 +329,7 @@ mod tests {
     struct Gate {
         name: &'static str,
         ready: AtomicBool,
+        terminal: bool,
     }
 
     impl ReadinessCheck for Gate {
@@ -309,12 +339,25 @@ mod tests {
         fn ready(&self) -> bool {
             self.ready.load(Ordering::Relaxed)
         }
+        fn terminal(&self) -> bool {
+            self.terminal
+        }
     }
 
     fn gate(name: &'static str, ready: bool) -> Arc<Gate> {
         Arc::new(Gate {
             name,
             ready: AtomicBool::new(ready),
+            terminal: false,
+        })
+    }
+
+    /// A check whose refusal the host cannot recover from.
+    fn terminal_gate(name: &'static str, ready: bool) -> Arc<Gate> {
+        Arc::new(Gate {
+            name,
+            ready: AtomicBool::new(ready),
+            terminal: true,
         })
     }
 
@@ -330,6 +373,44 @@ mod tests {
 
         assert!(state.live(), "saturation is not a reason to restart");
         assert_eq!(state.not_ready(), vec!["http_ingress_saturated"]);
+    }
+
+    /// The other side of that distinction. An accept loop that has ended is
+    /// not coming back, and nothing that places work reads readiness — the
+    /// scheduler goes by the Host CR's heartbeat, which this host still sends.
+    /// Left to readiness alone it keeps taking workloads it can never serve, so
+    /// this is the case where a restart is the lesser loss.
+    #[test]
+    fn a_host_whose_ingress_stopped_is_not_live() {
+        let stopped = terminal_gate("http_ingress_stopped", false);
+        let state = ProbeState::default().with_readiness(stopped);
+        state.started();
+
+        assert!(!state.live(), "an ingress that cannot recover must restart");
+        assert_eq!(state.not_ready(), vec!["http_ingress_stopped"]);
+    }
+
+    /// The same check, satisfied, says nothing about liveness.
+    #[test]
+    fn a_terminal_check_that_is_satisfied_leaves_the_host_live() {
+        let state = ProbeState::default().with_readiness(terminal_gate("ingress", true));
+        state.started();
+        assert!(state.live());
+        assert!(state.not_ready().is_empty());
+    }
+
+    /// A host on its way out stops accepting because it was told to. Reading
+    /// that as "restart me" would kill it mid-drain, which is the one thing
+    /// draining exists to avoid.
+    #[test]
+    fn a_draining_host_stays_live_even_with_its_ingress_stopped() {
+        let state =
+            ProbeState::default().with_readiness(terminal_gate("http_ingress_stopped", false));
+        state.started();
+        state.drain();
+
+        assert!(state.live(), "a draining host must not be restarted");
+        assert_eq!(state.not_ready(), vec!["draining"]);
     }
 
     /// Draining is the same shape and the more common one: leave the Service,

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -507,6 +507,19 @@ pub struct NatsConnectionOptions {
     pub tls_cert: Option<PathBuf>,
     /// Path to NATS TLS private key file
     pub tls_key: Option<PathBuf>,
+    /// How long to keep retrying a refused *initial* connection before giving
+    /// up. `None` gives up on the first refusal.
+    ///
+    /// Only the first connection needs this: once established, async-nats
+    /// reconnects on its own and buffers through the gap. A host deployed
+    /// beside its NATS has no ordering guarantee between the two, so without a
+    /// window here it exits, and the pod restarts until NATS happens to be up
+    /// first — which is a slower, noisier way to wait, and it spends the
+    /// restart count that would otherwise mean something.
+    ///
+    /// Left unset by a command run against a NATS the operator already has up
+    /// (`wash dev`), where a refusal is the answer rather than a race.
+    pub connect_retry: Option<Duration>,
 }
 
 #[instrument(skip_all)]
@@ -555,9 +568,49 @@ pub async fn connect_nats(
         }
     });
 
-    opts.connect(addr)
-        .await
-        .context("failed to connect to NATS")
+    let Some(window) = options.connect_retry else {
+        return opts
+            .connect(addr)
+            .await
+            .context("failed to connect to NATS");
+    };
+
+    // `to_server_addrs` here rather than per attempt: the addresses are what
+    // the retry is over, and resolving them once means a malformed URL is
+    // reported as one instead of being retried for the whole window.
+    let addrs = addr
+        .to_server_addrs()
+        .context("failed to parse NATS server address")?
+        .collect::<Vec<_>>();
+
+    let deadline = tokio::time::Instant::now() + window;
+    let mut backoff = Duration::from_millis(250);
+    loop {
+        let err = match opts.clone().connect(addrs.clone()).await {
+            Ok(client) => return Ok(client),
+            Err(err) => err,
+        };
+        // The window is for a server that is not up yet. A credential the
+        // server refuses, or a TLS setup it will not accept, reads the same on
+        // the last attempt as the first — waiting it out turns an accurate
+        // error into a minute of silence followed by that same error, with the
+        // host looking like it is still starting.
+        use async_nats::ConnectErrorKind;
+        if !matches!(
+            err.kind(),
+            ConnectErrorKind::Io | ConnectErrorKind::TimedOut | ConnectErrorKind::Dns
+        ) {
+            return Err(anyhow::Error::new(err)).context("failed to connect to NATS");
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(anyhow::Error::new(err))
+                .with_context(|| format!("failed to connect to NATS within {window:?}"));
+        }
+        tracing::warn!(%err, retry_in = ?backoff, "NATS is not accepting connections yet");
+        tokio::time::sleep(backoff.min(remaining)).await;
+        backoff = (backoff * 2).min(Duration::from_secs(5));
+    }
 }
 
 pub fn host_subject(host_id: &str) -> String {
@@ -1103,6 +1156,56 @@ mod tests {
     use super::*;
     use crate::host::allowed_hosts::AllowedHost;
     use crate::host::allowed_ip_name::AllowedIpName;
+
+    /// Port 1 is privileged and nothing in a test environment listens on it, so
+    /// a connection there is refused rather than left hanging.
+    const REFUSED: &str = "nats://127.0.0.1:1";
+
+    /// A host and its NATS come up together with no ordering between them, so a
+    /// refusal at startup is a race to wait out. Exiting instead spends a pod
+    /// restart on it, and restarts are the signal that something went wrong.
+    #[tokio::test]
+    async fn a_refused_connection_is_retried_for_the_whole_window() {
+        const WINDOW: Duration = Duration::from_millis(700);
+
+        let started = std::time::Instant::now();
+        let err = connect_nats(
+            REFUSED,
+            NatsConnectionOptions {
+                connect_retry: Some(WINDOW),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("nothing is listening on port 1");
+
+        assert!(
+            started.elapsed() >= WINDOW,
+            "gave up after {:?}, before the {WINDOW:?} window was out",
+            started.elapsed()
+        );
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("within"),
+            "the error should say the window it exhausted: {message}"
+        );
+    }
+
+    /// Waiting is for the deployment that cannot order its own startup. A
+    /// command run against a NATS the operator already has up wants the
+    /// refusal, not a minute of patience.
+    #[tokio::test]
+    async fn without_a_window_a_refused_connection_is_reported_at_once() {
+        let started = std::time::Instant::now();
+        connect_nats(REFUSED, NatsConnectionOptions::default())
+            .await
+            .expect_err("nothing is listening on port 1");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "a refusal with no window took {:?}, so it was retried",
+            started.elapsed()
+        );
+    }
 
     /// A host always keeps a start it can run and a core it can serve on.
     #[test]

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -330,7 +330,38 @@ impl ClusterHost {
                 // a service nothing tears down.
                 let mut commands = tokio::task::JoinSet::new();
 
-                let mut oci_cleanup_timer = tokio::time::interval(cleanup_interval);
+                // Read once. Nothing changes the host's config after it is
+                // built, so a host with no cache directory has none for its
+                // whole life and gets no timer at all rather than one that
+                // wakes to reach the same answer. The path is behind an `Arc`
+                // so each tick hands it to a task without copying it.
+                let mut oci_cleanup = host
+                    .config()
+                    .oci_cache_dir
+                    .clone()
+                    .map(|dir| (Arc::new(dir), tokio::time::interval(cleanup_interval)));
+
+                // Heartbeats and cache cleanup run as their own tasks, for the
+                // reason commands already do: `select!` runs one branch to
+                // completion, so anything awaited in one stops the loop turning
+                // — and the loop turning is the whole of what `/livez` reports.
+                //
+                // A heartbeat publish ends in a send on async-nats' bounded
+                // command channel, which stops draining while NATS is
+                // unreachable. Awaited here, an outage would hold the loop past
+                // the liveness budget and the kubelet would restart the host:
+                // every workload on it lost, every host in the fleet at once
+                // because they all watch the same NATS, and none of it a thing
+                // a restart can fix. Cache cleanup is a filesystem walk, the
+                // same shape with a slower fuse.
+                //
+                // One at a time each, and a tick that finds the previous still
+                // running is dropped rather than queued: a heartbeat that has
+                // not gone out is not improved by a second behind it, and two
+                // in flight can arrive out of order. The permit lives in the
+                // task, so it comes back however the task ends.
+                let heartbeat_slot = Arc::new(tokio::sync::Semaphore::new(1));
+                let cleanup_slot = Arc::new(tokio::sync::Semaphore::new(1));
 
                 loop {
                     // Every turn, whichever branch woke it. The heartbeat timer
@@ -412,31 +443,56 @@ impl ClusterHost {
                             }
                         }
                         // OCI cache cleanup
-                        _ = oci_cleanup_timer.tick() => {
-                            if let Some(cache_dir) = host.config().oci_cache_dir.as_ref() &&
-                            let Err(e) = oci::cleanup_cache(cache_dir, self.cleanup_age).await {
-                                error!("error during OCI cache cleanup: {e}");
+                        cache_dir = next_cache_cleanup(&mut oci_cleanup) => {
+                            if let Ok(slot) = Arc::clone(&cleanup_slot).try_acquire_owned() {
+                                let age = self.cleanup_age;
+                                tokio::spawn(async move {
+                                    let _slot = slot;
+                                    if let Err(e) = oci::cleanup_cache(&*cache_dir, age).await {
+                                        error!("error during OCI cache cleanup: {e}");
+                                    }
+                                });
                             }
                         }
                         // Send heartbeat
                         _ = heartbeat_timer.tick() => {
-                            // Returning here would drop `commands`, aborting
+                            // Dropped rather than queued when the last one is
+                            // still going. Nothing here returns on failure:
+                            // returning would drop `commands`, aborting
                             // in-flight starts after they have reserved their
                             // ids, and skip the `host.stop()` that unbinds
                             // their plugins. A missed heartbeat is worth none
                             // of that; the next tick tries again.
-                            match host_heartbeat(&host).await.and_then(|heartbeat| {
-                                serde_json::to_vec(&heartbeat).context("failed to serialize heartbeat")
-                            }) {
-                                Ok(heartbeat_bytes) => {
-                                    if let Err(e) = nats_client
-                                        .publish(heartbeat_subject.clone(), heartbeat_bytes.into())
-                                        .await
-                                    {
-                                        error!("failed to publish heartbeat: {e}");
-                                    }
+                            match Arc::clone(&heartbeat_slot).try_acquire_owned() {
+                                Ok(slot) => {
+                                    let host = host.clone();
+                                    let nats_client = nats_client.clone();
+                                    let subject = heartbeat_subject.clone();
+                                    tokio::spawn(async move {
+                                        let _slot = slot;
+                                        match host_heartbeat(&host).await.and_then(|heartbeat| {
+                                            serde_json::to_vec(&heartbeat).context("failed to serialize heartbeat")
+                                        }) {
+                                            Ok(heartbeat_bytes) => {
+                                                if let Err(e) = nats_client
+                                                    .publish(subject, heartbeat_bytes.into())
+                                                    .await
+                                                {
+                                                    error!("failed to publish heartbeat: {e}");
+                                                }
+                                            }
+                                            Err(e) => error!("failed to build heartbeat: {e}"),
+                                        }
+                                    });
                                 }
-                                Err(e) => error!("failed to build heartbeat: {e}"),
+                                // Every tick this reports is one the operator
+                                // did not hear, which is what its unreachable
+                                // window is for. Said out loud because the
+                                // cause — a NATS that is not draining — is
+                                // otherwise visible only as a host going quiet.
+                                Err(_) => warn!(
+                                    "previous heartbeat has not finished publishing; skipping this one"
+                                ),
                             }
                         }
                         // Handle API requests
@@ -611,6 +667,23 @@ pub async fn connect_nats(
         tokio::time::sleep(backoff.min(remaining)).await;
         backoff = (backoff * 2).min(Duration::from_secs(5));
     }
+}
+
+/// The directory to clean when the next cleanup falls due, or never for a host
+/// with no cache directory.
+///
+/// A `select!` branch needs a future whether or not there is anything to wait
+/// for. This gives the branch one that simply never completes, which is what a
+/// host with nothing to clean should do, rather than arming a timer and testing
+/// a condition that was settled before the loop began.
+async fn next_cache_cleanup(
+    cleanup: &mut Option<(Arc<PathBuf>, tokio::time::Interval)>,
+) -> Arc<PathBuf> {
+    let Some((cache_dir, timer)) = cleanup else {
+        return std::future::pending().await;
+    };
+    timer.tick().await;
+    Arc::clone(cache_dir)
 }
 
 pub fn host_subject(host_id: &str) -> String {

--- a/crates/wash-runtime/tests/integration_thundering_herd.rs
+++ b/crates/wash-runtime/tests/integration_thundering_herd.rs
@@ -1,0 +1,331 @@
+//! Integration tests for a scheduling thundering herd: a whole deployment's
+//! worth of workloads arriving at one host at once.
+//!
+//! A scheduler placing many workloads on one host issues every
+//! `workload_start` together, and each one compiles a component, binds its
+//! plugins and registers its route before it can report `Running`. These tests
+//! pin that the host admits the whole herd rather than losing, mis-binding or
+//! serialising part of it.
+//!
+//! Driven through [`HostApi`] rather than the washlet, so the whole herd
+//! arrives at once: the washlet's `max_concurrent_starts` permit is what caps
+//! this in a deployed host, and it is covered by
+//! `integration_washlet_api::concurrent_workload_starts_are_bounded`. What is
+//! left to pin is what the host does when a herd is let through uncapped.
+//!
+//! Covers:
+//! - 15 concurrent starts of distinct workloads: every one reports `Running`,
+//!   every one is individually reachable over HTTP, and the host counts
+//!   exactly the herd.
+//! - Stopping all 15 under the same concurrency: every route goes, every id
+//!   goes, and the host is left empty.
+//! - A workload already serving traffic keeps answering throughout the herd,
+//!   in a fraction of the time the herd itself takes — compilation must not
+//!   occupy the runtime the HTTP server is on.
+//! - 15 concurrent starts of the *same* workload id: exactly one is admitted
+//!   and the other fourteen are refused, with nothing left half-started.
+//!
+//! Every herd here carries no digest, so no two members share a compile: this
+//! is the cost of a herd whose components are all different, which is the
+//! worse of the two shapes by a wide margin. The other shape — N replicas of
+//! one image, which share one compile through the digest-keyed cache — is
+//! pinned by `engine::tests::a_herd_of_replicas_shares_one_compiled_component`.
+
+use anyhow::{Context, Result};
+use futures::future::join_all;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use wash_runtime::{
+    host::HostApi,
+    types::{
+        WorkloadStartRequest, WorkloadStartResponse, WorkloadState, WorkloadStatusRequest,
+        WorkloadStopRequest,
+    },
+};
+
+mod common;
+use common::{
+    component_workload_request, default_counter_resources, get_status,
+    http_counter_host_interfaces, start_host_with_dynamic_router,
+};
+
+const HTTP_COUNTER_WASM: &[u8] = include_bytes!("wasm/http_counter.wasm");
+
+/// Enough workloads for the herd to cost something real: fifteen components to
+/// compile, fifteen plugin bindings and fifteen route registrations, all
+/// issued at once.
+const HERD: usize = 15;
+
+/// The least a request to an already-serving workload is allowed, however fast
+/// the herd was. A herd that finishes in well under a second leaves too small
+/// a share to hold anything to.
+const RESPONSIVE_FLOOR: Duration = Duration::from_secs(1);
+
+fn herd_host(i: usize) -> String {
+    format!("herd-{i}.local")
+}
+
+/// A member of the herd carrying no digest, so it compiles on its own — the
+/// cost of a herd whose components are all different.
+fn herd_request(host_header: &str) -> WorkloadStartRequest {
+    component_workload_request(
+        "http-counter.wasm",
+        "herd-workload",
+        HTTP_COUNTER_WASM,
+        default_counter_resources(),
+        http_counter_host_interfaces(host_header),
+    )
+}
+
+/// Report every start that did not reach `Running`, named by its position in
+/// the herd, so a failure says which ones fell out and why.
+fn not_running(responses: Vec<Result<WorkloadStartResponse>>) -> Vec<String> {
+    responses
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, response)| match response {
+            Ok(response) if response.workload_status.workload_state == WorkloadState::Running => {
+                None
+            }
+            Ok(response) => Some(format!(
+                "{i}: {:?} — {}",
+                response.workload_status.workload_state, response.workload_status.message
+            )),
+            Err(e) => Some(format!("{i}: start errored — {e:#}")),
+        })
+        .collect()
+}
+
+/// Fifteen distinct workloads started at once must all come up, all serve, and
+/// all stop — under the same concurrency they started with.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_herd_starts_all_run_and_serve() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    let requests: Vec<WorkloadStartRequest> =
+        (0..HERD).map(|i| herd_request(&herd_host(i))).collect();
+    let ids: Vec<String> = requests.iter().map(|r| r.workload_id.clone()).collect();
+
+    let started = Instant::now();
+    let responses = join_all(requests.into_iter().map(|r| host.workload_start(r))).await;
+    eprintln!(
+        "{HERD} concurrent starts settled in {:?}",
+        started.elapsed()
+    );
+
+    let failures = not_running(responses);
+    assert!(
+        failures.is_empty(),
+        "{} of {HERD} concurrent starts did not run: {failures:?}",
+        failures.len()
+    );
+
+    // `Running` is what each start reported; this is what the host still holds.
+    for (i, id) in ids.iter().enumerate() {
+        let status = host
+            .workload_status(WorkloadStatusRequest {
+                workload_id: id.clone(),
+            })
+            .await?
+            .workload_status;
+        assert_eq!(
+            status.workload_state,
+            WorkloadState::Running,
+            "workload {i} ({id}) is {:?} after the herd: {}",
+            status.workload_state,
+            status.message
+        );
+    }
+    assert_eq!(host.heartbeat().await?.workload_count, HERD as u64);
+
+    // Bound and routed, not just bookkept: every member of the herd answers on
+    // its own hostname.
+    let client = reqwest::Client::new();
+    let hostnames: Vec<String> = (0..HERD).map(herd_host).collect();
+    let served = join_all(
+        hostnames
+            .iter()
+            .map(|hostname| get_status(&client, addr, hostname)),
+    )
+    .await;
+    for (i, status) in served.into_iter().enumerate() {
+        assert_eq!(
+            status.with_context(|| format!("request to {} failed", herd_host(i)))?,
+            reqwest::StatusCode::OK,
+            "workload {i} did not serve after the herd"
+        );
+    }
+
+    // Tear the herd down the way it came up.
+    let stopped = join_all(ids.iter().map(|id| {
+        host.workload_stop(WorkloadStopRequest {
+            workload_id: id.clone(),
+        })
+    }))
+    .await;
+    for (i, response) in stopped.into_iter().enumerate() {
+        assert_eq!(
+            response?.workload_status.workload_state,
+            WorkloadState::Stopping,
+            "workload {i} did not stop cleanly"
+        );
+    }
+
+    for (i, id) in ids.iter().enumerate() {
+        assert_eq!(
+            host.workload_status(WorkloadStatusRequest {
+                workload_id: id.clone(),
+            })
+            .await?
+            .workload_status
+            .workload_state,
+            WorkloadState::NotFound,
+            "workload {i} ({id}) outlived its stop"
+        );
+    }
+    assert_eq!(host.heartbeat().await?.workload_count, 0);
+
+    // Every route went with its workload.
+    let after = join_all(
+        hostnames
+            .iter()
+            .map(|hostname| get_status(&client, addr, hostname)),
+    )
+    .await;
+    for (i, status) in after.into_iter().enumerate() {
+        assert_eq!(
+            status?,
+            reqwest::StatusCode::NOT_FOUND,
+            "workload {i}'s route outlived its stop"
+        );
+    }
+
+    Ok(())
+}
+
+/// The herd must not take the host off the air. Compiling fifteen components
+/// occupies fifteen blocking threads; run on the runtime instead, it would
+/// stop the HTTP server answering for as long as the herd took.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_herd_keeps_a_running_workload_serving() -> Result<()> {
+    let (addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    host.workload_start(herd_request("steady.local")).await?;
+    let client = reqwest::Client::new();
+    assert_eq!(
+        get_status(&client, addr, "steady.local").await?,
+        reqwest::StatusCode::OK,
+        "the steady workload must serve before the herd arrives"
+    );
+
+    let herd_done = Arc::new(AtomicBool::new(false));
+    let requests: Vec<WorkloadStartRequest> =
+        (0..HERD).map(|i| herd_request(&herd_host(i))).collect();
+
+    let herd = async {
+        let started = Instant::now();
+        let responses = join_all(requests.into_iter().map(|r| host.workload_start(r))).await;
+        let took = started.elapsed();
+        herd_done.store(true, Ordering::SeqCst);
+        (responses, took)
+    };
+
+    // A request is kept in flight for the whole herd, so a runtime that stalls
+    // is measured by a request already waiting on it.
+    let steady = async {
+        let mut worst = Duration::ZERO;
+        let mut served = 0u32;
+        while !herd_done.load(Ordering::SeqCst) {
+            let sent = Instant::now();
+            let status = get_status(&client, addr, "steady.local").await?;
+            let took = sent.elapsed();
+            assert_eq!(
+                status,
+                reqwest::StatusCode::OK,
+                "the steady workload stopped serving during the herd"
+            );
+            worst = worst.max(took);
+            served += 1;
+        }
+        anyhow::Ok((worst, served))
+    };
+
+    let ((responses, herd_took), steady) = tokio::join!(herd, steady);
+    let (worst, served) = steady?;
+    eprintln!(
+        "herd took {herd_took:?}; steady workload served {served} requests during it, worst {worst:?}"
+    );
+
+    let failures = not_running(responses);
+    assert!(
+        failures.is_empty(),
+        "{} of {HERD} concurrent starts did not run: {failures:?}",
+        failures.len()
+    );
+    // How many requests got through is the sharp measure, and it needs no
+    // fixed budget: a slower machine takes longer over the herd, which is more
+    // time to serve, not less. Compiling on the runtime instead drops this to
+    // single digits — the requests that happen to be in flight between one
+    // compile and the next.
+    assert!(
+        served as usize >= HERD,
+        "the steady workload served only {served} requests across a {herd_took:?} herd"
+    );
+    // Second reading of the same thing, from the other end: no one request may
+    // spend anything like the herd waiting for a runtime the herd has taken
+    // over.
+    let ceiling = (herd_took / 2).max(RESPONSIVE_FLOOR);
+    assert!(
+        worst < ceiling,
+        "the steady workload took {worst:?} to answer during a {herd_took:?} herd, over the {ceiling:?} ceiling"
+    );
+
+    Ok(())
+}
+
+/// A scheduler retrying a start it already issued sends the same id again.
+/// Fifteen of those at once must leave exactly one workload, not fifteen
+/// half-bound ones sharing an id.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_herd_of_one_id_admits_exactly_one() -> Result<()> {
+    let (_addr, host) = start_host_with_dynamic_router("127.0.0.1:0").await?;
+
+    let template = herd_request("duplicate.local");
+    let requests: Vec<WorkloadStartRequest> = (0..HERD)
+        .map(|_| WorkloadStartRequest {
+            workload_id: template.workload_id.clone(),
+            workload: template.workload.clone(),
+        })
+        .collect();
+
+    let responses = join_all(requests.into_iter().map(|r| host.workload_start(r)))
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+    let states: Vec<WorkloadState> = responses
+        .into_iter()
+        .map(|r| r.workload_status.workload_state)
+        .collect();
+    assert_eq!(
+        states
+            .iter()
+            .filter(|state| **state == WorkloadState::Running)
+            .count(),
+        1,
+        "exactly one of {HERD} starts of one id may be admitted, got {states:?}"
+    );
+    assert_eq!(
+        states
+            .iter()
+            .filter(|state| **state == WorkloadState::Error)
+            .count(),
+        HERD - 1,
+        "every start that lost the race must be refused, got {states:?}"
+    );
+    assert_eq!(host.heartbeat().await?.workload_count, 1);
+
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_thundering_herd.rs
+++ b/crates/wash-runtime/tests/integration_thundering_herd.rs
@@ -63,6 +63,11 @@ const HERD: usize = 15;
 /// a share to hold anything to.
 const RESPONSIVE_FLOOR: Duration = Duration::from_secs(1);
 
+/// Requests the steady workload has to complete while the herd starts. Healthy
+/// runs are in the hundreds and a runtime the herd has taken over manages
+/// single digits, so anything between them separates the two.
+const STEADY_REQUESTS_FLOOR: u32 = 20;
+
 fn herd_host(i: usize) -> String {
     format!("herd-{i}.local")
 }
@@ -264,13 +269,12 @@ async fn test_concurrent_herd_keeps_a_running_workload_serving() -> Result<()> {
         "{} of {HERD} concurrent starts did not run: {failures:?}",
         failures.len()
     );
-    // How many requests got through is the sharp measure, and it needs no
-    // fixed budget: a slower machine takes longer over the herd, which is more
-    // time to serve, not less. Compiling on the runtime instead drops this to
-    // single digits — the requests that happen to be in flight between one
-    // compile and the next.
+    // How many requests got through is the sharp measure. A floor rather than
+    // anything scaled to the herd, which this has nothing to do with: healthy
+    // runs serve hundreds, and compiling on the runtime instead drops it to the
+    // handful that happen to be in flight between one compile and the next.
     assert!(
-        served as usize >= HERD,
+        served >= STEADY_REQUESTS_FLOOR,
         "the steady workload served only {served} requests across a {herd_took:?} herd"
     );
     // Second reading of the same thing, from the other end: no one request may

--- a/crates/wash-runtime/tests/integration_washlet_api.rs
+++ b/crates/wash-runtime/tests/integration_washlet_api.rs
@@ -572,6 +572,88 @@ async fn concurrent_workload_starts_are_bounded() -> Result<()> {
     harness.shutdown().await
 }
 
+/// The shape a scheduler actually produces: a whole deployment's worth of
+/// `workload.start` messages landing together, several times over the cap. The
+/// permit holds most of them back, and what has to survive the wait is the
+/// host itself — it stays heard from, it answers, and it has claimed every id
+/// in the burst, so a stop arriving for a still-queued workload finds it.
+///
+/// The host's own behaviour once a herd is let through — no permit, every
+/// start running at once — is `integration_thundering_herd`, which drives
+/// `HostApi` directly because this permit is exactly what stops that herd
+/// forming here.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_burst_of_starts_keeps_the_host_answering() -> Result<()> {
+    const BURST: usize = 15;
+    const LIMIT: usize = 2;
+    const HEARTBEAT: Duration = Duration::from_millis(200);
+
+    let mut harness = TestHarness::builder()
+        .with_heartbeat_interval(HEARTBEAT)
+        .with_max_concurrent_starts(LIMIT)
+        .start()
+        .await?;
+    let registry = StallingRegistry::bind().await?;
+
+    let ids: Vec<String> = (0..BURST)
+        .map(|i| format!("washlet-api-e2e-burst-{i}"))
+        .collect();
+    // Every one of them hangs on its pull, so the whole burst is outstanding at
+    // once: `LIMIT` holding permits, the rest queued behind them.
+    let inflight: Vec<_> = ids
+        .iter()
+        .map(|id| registry.spawn_start(&harness, id))
+        .collect();
+
+    wait_for(Duration::from_secs(30), || registry.reached() >= LIMIT)
+        .await
+        .context("the permitted starts never reached the registry")?;
+    let reached = registry.reached();
+    assert!(
+        reached <= LIMIT,
+        "{reached} of a {BURST}-start burst reached the registry at once, past the cap of {LIMIT}"
+    );
+
+    // Drop the heartbeats published before the burst: they sit in the
+    // subscriber's buffer and would count toward the window on their own.
+    while let Ok(Some(_)) =
+        tokio::time::timeout(Duration::from_millis(50), harness.heartbeat_sub.next()).await
+    {}
+
+    let window = HEARTBEAT * 6;
+    let deadline = tokio::time::Instant::now() + window;
+    let mut heard = 0usize;
+    while let Ok(Some(_)) = tokio::time::timeout_at(deadline, harness.heartbeat_sub.next()).await {
+        heard += 1;
+    }
+    assert!(
+        heard >= 3,
+        "only {heard} heartbeats in {window:?} while a {BURST}-start burst was outstanding; \
+         the operator reaps a host it stops hearing from"
+    );
+
+    // Queued behind a permit is still claimed. Every id in the burst has to
+    // report as something other than NOT_FOUND, because NOT_FOUND is what tells
+    // the operator a teardown is already complete.
+    for id in &ids {
+        let status = tokio::time::timeout(Duration::from_secs(5), harness.status(id))
+            .await
+            .with_context(|| format!("status for {id} queued behind the burst"))??;
+        assert_ne!(
+            status.workload_state(),
+            v2::WorkloadState::NotFound,
+            "{id} was not claimed while its start was queued: {}",
+            status.message
+        );
+    }
+
+    for task in inflight {
+        task.abort();
+    }
+    harness.shutdown().await
+}
+
 /// A start waiting for a concurrency permit has claimed its id too. The wait is
 /// time like any other in which a stop can arrive, and a stop that finds no
 /// workload tells the operator the teardown is done — so the record goes while

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -23,6 +23,14 @@ pub struct HostCommand {
     #[arg(long = "scheduler-nats-url", default_value = "nats://localhost:4222")]
     pub scheduler_nats_url: String,
 
+    /// How long to keep retrying NATS at startup before giving up.
+    ///
+    /// A host brought up beside its NATS has no ordering guarantee against it,
+    /// and exiting on the first refusal makes the pod restart until the race
+    /// happens to go the other way. Zero restores that: fail on first refusal.
+    #[arg(long = "nats-connect-timeout", default_value = "60s", value_parser = humantime::parse_duration)]
+    pub nats_connect_timeout: Duration,
+
     /// Path to TLS CA certificate file for NATS Scheduler connection
     #[arg(long = "scheduler-nats-tls-ca")]
     pub scheduler_nats_tls_ca: Option<PathBuf>,
@@ -629,6 +637,11 @@ impl CliCommand for HostCommand {
             load_config::<crate::config::Config>(&ctx.user_config_path(), Some(project_dir), None)
                 .context("failed to load config for wash host")?;
 
+        // Zero means the flag was used to ask for the old behaviour: give up on
+        // the first refusal.
+        let connect_retry =
+            (!self.nats_connect_timeout.is_zero()).then_some(self.nats_connect_timeout);
+
         let scheduler_nats_client = wash_runtime::washlet::connect_nats(
             self.scheduler_nats_url.clone(),
             wash_runtime::washlet::NatsConnectionOptions {
@@ -637,6 +650,7 @@ impl CliCommand for HostCommand {
                 tls_first: self.scheduler_nats_tls_first,
                 tls_cert: self.scheduler_nats_tls_cert.clone(),
                 tls_key: self.scheduler_nats_tls_key.clone(),
+                connect_retry,
             },
         )
         .await
@@ -650,6 +664,7 @@ impl CliCommand for HostCommand {
                 tls_first: self.data_nats_tls_first,
                 tls_cert: self.data_nats_tls_cert.clone(),
                 tls_key: self.data_nats_tls_key.clone(),
+                connect_retry,
             },
         )
         .await

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -23,12 +23,15 @@ pub struct HostCommand {
     #[arg(long = "scheduler-nats-url", default_value = "nats://localhost:4222")]
     pub scheduler_nats_url: String,
 
-    /// How long to keep retrying NATS at startup before giving up.
+    /// How long to keep retrying NATS at startup before giving up, across both
+    /// the scheduler and data connections together.
     ///
-    /// A host brought up beside its NATS has no ordering guarantee against it,
-    /// and exiting on the first refusal makes the pod restart until the race
-    /// happens to go the other way. Zero restores that: fail on first refusal.
-    #[arg(long = "nats-connect-timeout", default_value = "60s", value_parser = humantime::parse_duration)]
+    /// A host brought up beside its NATS has no ordering against it, and
+    /// exiting on the first refusal makes the pod restart until the race
+    /// happens to go the other way. The chart sets this; zero — the default —
+    /// fails on the first refusal, which is what someone running `wash host`
+    /// against a NATS they start themselves wants to see.
+    #[arg(long = "nats-connect-timeout", default_value = "0s", value_parser = humantime::parse_duration)]
     pub nats_connect_timeout: Duration,
 
     /// Path to TLS CA certificate file for NATS Scheduler connection
@@ -637,7 +640,11 @@ impl CliCommand for HostCommand {
             load_config::<crate::config::Config>(&ctx.user_config_path(), Some(project_dir), None)
                 .context("failed to load config for wash host")?;
 
-        // Zero asks to give up on the first refusal.
+        // One budget for both connections below, not one each: the flag says
+        // how long startup may spend waiting for NATS, and two windows in
+        // series would spend twice that with the second URL down. Zero asks to
+        // give up on the first refusal.
+        let connect_deadline = tokio::time::Instant::now() + self.nats_connect_timeout;
         let connect_retry =
             (!self.nats_connect_timeout.is_zero()).then_some(self.nats_connect_timeout);
 
@@ -663,7 +670,10 @@ impl CliCommand for HostCommand {
                 tls_first: self.data_nats_tls_first,
                 tls_cert: self.data_nats_tls_cert.clone(),
                 tls_key: self.data_nats_tls_key.clone(),
-                connect_retry,
+                // Whatever the scheduler connection left of the budget.
+                connect_retry: connect_retry.map(|_| {
+                    connect_deadline.saturating_duration_since(tokio::time::Instant::now())
+                }),
             },
         )
         .await

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -637,8 +637,7 @@ impl CliCommand for HostCommand {
             load_config::<crate::config::Config>(&ctx.user_config_path(), Some(project_dir), None)
                 .context("failed to load config for wash host")?;
 
-        // Zero means the flag was used to ask for the old behaviour: give up on
-        // the first refusal.
+        // Zero asks to give up on the first refusal.
         let connect_retry =
             (!self.nats_connect_timeout.is_zero()).then_some(self.nats_connect_timeout);
 

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -1239,6 +1239,54 @@ host:
     }
 }
 
+#[cfg(test)]
+mod shutdown_tests {
+    use std::time::Duration;
+
+    use clap::Parser;
+
+    use super::HostCommand;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        host: HostCommand,
+    }
+
+    fn parse(args: &[&str]) -> HostCommand {
+        TestCli::parse_from(std::iter::once("wash-host").chain(args.iter().copied())).host
+    }
+
+    /// The chart renders this in whole seconds with a unit suffix. It has to
+    /// parse as written there.
+    #[test]
+    fn the_chart_spelling_of_the_drain_delay_parses() {
+        assert_eq!(
+            parse(&["--drain-delay=15s"]).drain_delay,
+            Duration::from_secs(15)
+        );
+    }
+
+    /// Nothing is watching a host outside Kubernetes, and the wait would only
+    /// be a person's Ctrl-C taking longer.
+    #[test]
+    fn no_one_waits_for_a_drain_by_default() {
+        assert!(parse(&[]).drain_delay.is_zero());
+    }
+
+    /// The wait is not conditional on the probe listener: a host behind
+    /// something that health-checks it by other means still has traffic to stop
+    /// arriving, and a flag that parsed and then did nothing would say nothing
+    /// about it.
+    #[test]
+    fn a_drain_delay_stands_on_its_own() {
+        assert_eq!(
+            parse(&["--drain-delay=30s"]).drain_delay,
+            Duration::from_secs(30)
+        );
+    }
+}
+
 #[cfg(all(test, feature = "host-component-plugins"))]
 mod tests {
     use super::host_plugin_registry_credentials;

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -670,9 +670,13 @@ impl CliCommand for HostCommand {
                 tls_first: self.data_nats_tls_first,
                 tls_cert: self.data_nats_tls_cert.clone(),
                 tls_key: self.data_nats_tls_key.clone(),
-                // Whatever the scheduler connection left of the budget.
-                connect_retry: connect_retry.map(|_| {
-                    connect_deadline.saturating_duration_since(tokio::time::Instant::now())
+                // Whatever the scheduler connection left of the budget. A
+                // budget already spent becomes `None`, so the failure reads as
+                // the refusal it is rather than as a timeout of no length.
+                connect_retry: connect_retry.and_then(|_| {
+                    let left =
+                        connect_deadline.saturating_duration_since(tokio::time::Instant::now());
+                    (!left.is_zero()).then_some(left)
                 }),
             },
         )

--- a/runtime-operator/operator.go
+++ b/runtime-operator/operator.go
@@ -88,7 +88,7 @@ func NewEmbeddedOperator(
 		cfg.HeartbeatTTL = MinHeartbeatTTL
 	}
 
-	nc, err := wasmbus.NatsConnect(cfg.NatsURL, cfg.NatsOptions...)
+	nc, err := wasmbus.NatsConnectContext(ctx, cfg.NatsURL, cfg.NatsOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime-operator/pkg/wasmbus/nats.go
+++ b/runtime-operator/pkg/wasmbus/nats.go
@@ -2,8 +2,11 @@ package wasmbus
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/nats-io/nats-server/v2/server"
@@ -22,9 +25,26 @@ var _ Bus = (*NatsBus)(nil)
 // NatsOption is an option for configuring a NATS connection.
 type NatsOption = nats.Option
 
+// NatsInitialConnectWindow is how long [NatsConnect] keeps retrying a refused
+// or timed-out *first* connection before giving up.
+//
+// Only the first one needs this. Once established, the options below reconnect
+// forever and buffer through the gap — but nats.Connect itself fails outright
+// if the server is not there yet, and the operator is deployed beside its NATS
+// with no ordering between them. Without a window the operator exits, and the
+// pod restarts until the race happens to go the other way; that spends the
+// restart count, which is the signal something is actually wrong.
+//
+// A window rather than nats.RetryOnFailedConnect so a genuinely unreachable
+// or misconfigured URL is still reported, instead of leaving an operator that
+// runs forever and reconciles nothing.
+var NatsInitialConnectWindow = 60 * time.Second
+
 // NatsConnect connects to a NATS server at the given URL.
 // The URL should be in the form of "nats://host:port".
-// This helper function sets some default options and calls `nats.Connect`.
+// This helper function sets some default options and calls `nats.Connect`,
+// retrying a first connection that is refused for up to
+// [NatsInitialConnectWindow].
 func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
 	opts := append([]nats.Option{
 		nats.PingInterval(1 * time.Minute),    // default is 2m
@@ -41,12 +61,48 @@ func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
 		nats.ReconnectJitter(100*time.Millisecond, 1*time.Second), // spread reconnect storms
 	}, options...)
 
-	nc, err := nats.Connect(url, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrTransport, err)
+	deadline := time.Now().Add(NatsInitialConnectWindow)
+	backoff := 250 * time.Millisecond
+	for {
+		nc, err := nats.Connect(url, opts...)
+		if err == nil {
+			return nc, nil
+		}
+		if !worthRetrying(err) {
+			return nil, fmt.Errorf("%w: %v", ErrTransport, err)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("%w: %v (no connection within %s)", ErrTransport, err, NatsInitialConnectWindow)
+		}
+		time.Sleep(min(backoff, remaining))
+		backoff = min(backoff*2, 5*time.Second)
 	}
+}
 
-	return nc, nil
+// worthRetrying reports whether a failed connection is the startup race the
+// window exists for, rather than an answer that will not change.
+//
+// Only "the server is not there yet" is waited out. A rejected credential or a
+// URL that does not parse reads the same on the last attempt as the first, and
+// spending the window on it turns an immediate, accurate error into a minute of
+// silence followed by that same error.
+func worthRetrying(err error) bool {
+	var dnsErr *net.DNSError
+	switch {
+	case errors.Is(err, nats.ErrNoServers),
+		errors.Is(err, nats.ErrTimeout),
+		errors.Is(err, syscall.ECONNREFUSED),
+		errors.Is(err, syscall.EHOSTUNREACH),
+		errors.Is(err, syscall.ENETUNREACH):
+		return true
+	case errors.As(err, &dnsErr):
+		// A Service's DNS record does not exist until the Service does, which
+		// is the same race one layer down.
+		return true
+	default:
+		return false
+	}
 }
 
 func NatsDefaultServerOptions() *server.Options {

--- a/runtime-operator/pkg/wasmbus/nats.go
+++ b/runtime-operator/pkg/wasmbus/nats.go
@@ -40,12 +40,21 @@ type NatsOption = nats.Option
 // runs forever and reconciles nothing.
 var NatsInitialConnectWindow = 60 * time.Second
 
-// NatsConnect connects to a NATS server at the given URL.
+// NatsConnect connects to a NATS server at the given URL, waiting out a
+// startup race for up to [NatsInitialConnectWindow].
+//
+// Prefer [NatsConnectContext] anywhere a context is in hand: this one cannot be
+// cancelled, so a signal arriving during the wait is not acted on until it ends.
+func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
+	return NatsConnectContext(context.Background(), url, options...)
+}
+
+// NatsConnectContext connects to a NATS server at the given URL.
 // The URL should be in the form of "nats://host:port".
 // This helper function sets some default options and calls `nats.Connect`,
 // retrying a first connection that is refused for up to
-// [NatsInitialConnectWindow].
-func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
+// [NatsInitialConnectWindow] or until `ctx` is done.
+func NatsConnectContext(ctx context.Context, url string, options ...NatsOption) (*nats.Conn, error) {
 	opts := append([]nats.Option{
 		nats.PingInterval(1 * time.Minute),    // default is 2m
 		nats.MaxPingsOutstanding(1),           // default is 2
@@ -75,7 +84,16 @@ func NatsConnect(url string, options ...NatsOption) (*nats.Conn, error) {
 		if remaining <= 0 {
 			return nil, fmt.Errorf("%w: %v (no connection within %s)", ErrTransport, err, NatsInitialConnectWindow)
 		}
-		time.Sleep(min(backoff, remaining))
+		// Selected on rather than slept through: this runs before the manager
+		// starts, so nothing else is watching for a signal, and a plain sleep
+		// outlives a grace period shorter than the window.
+		timer := time.NewTimer(min(backoff, remaining))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("%w: %v (gave up waiting for NATS: %v)", ErrTransport, err, ctx.Err())
+		case <-timer.C:
+		}
 		backoff = min(backoff*2, 5*time.Second)
 	}
 }
@@ -97,9 +115,14 @@ func worthRetrying(err error) bool {
 		errors.Is(err, syscall.ENETUNREACH):
 		return true
 	case errors.As(err, &dnsErr):
-		// A Service's DNS record does not exist until the Service does, which
-		// is the same race one layer down.
-		return true
+		// A Service's record does not exist until the Service does, which is
+		// the same race one layer down, and a resolver that is itself starting
+		// answers temporarily. Anything else from DNS — a name that cannot be
+		// parsed, a refused query — will read the same on the last attempt.
+		//
+		// A misspelt Service is indistinguishable from one that has not been
+		// created yet, so it costs the whole window before it is reported.
+		return dnsErr.IsNotFound || dnsErr.IsTemporary
 	default:
 		return false
 	}

--- a/runtime-operator/pkg/wasmbus/nats_reconnect_test.go
+++ b/runtime-operator/pkg/wasmbus/nats_reconnect_test.go
@@ -1,9 +1,11 @@
 package wasmbus
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"go.wasmcloud.dev/runtime-operator/v2/pkg/wasmbus/wasmbustest"
 )
 
@@ -113,4 +115,76 @@ func TestNatsRecoversFromServerRestart(t *testing.T) {
 	})
 	publish("after")
 	expect("after")
+}
+
+// TestNatsConnectWaitsOutAStartupRace pins the other half of that contract: the
+// *first* connection. nats.Connect fails outright when the server is not up
+// yet, and the operator is deployed beside its NATS with no ordering between
+// them — so a refused first connection is a race to wait out rather than a
+// reason to exit and spend a pod restart saying so.
+func TestNatsConnectWaitsOutAStartupRace(t *testing.T) {
+	type result struct {
+		nc  *nats.Conn
+		err error
+	}
+	// Started against a server that does not exist yet.
+	done := make(chan result, 1)
+	go func() {
+		nc, err := NatsConnect(NatsDefaultURL)
+		done <- result{nc, err}
+	}()
+
+	// Long enough that the connect above has certainly been refused at least
+	// once before anything is listening.
+	time.Sleep(500 * time.Millisecond)
+	defer wasmbustest.MustStartNats(t)()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("gave up on a NATS that came up during the window: %v", got.err)
+		}
+		got.nc.Close()
+	case <-time.After(30 * time.Second):
+		t.Fatal("NatsConnect never connected after the server came up")
+	}
+}
+
+// The window is for the server not being up yet. An answer that will not
+// change has to be reported when it arrives: spending a minute on a malformed
+// URL turns an immediate, accurate error into a minute of silence followed by
+// that same error, during which the operator looks like it is starting.
+func TestNatsConnectDoesNotWaitOutAPermanentFailure(t *testing.T) {
+	restore := NatsInitialConnectWindow
+	NatsInitialConnectWindow = 30 * time.Second
+	defer func() { NatsInitialConnectWindow = restore }()
+
+	started := time.Now()
+	_, err := NatsConnect("://not-a-url")
+	if err == nil {
+		t.Fatal("expected a failure on a malformed URL")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("a malformed URL took %s to report, so it was retried", elapsed)
+	}
+}
+
+// Waiting is for the startup race. A URL nothing will ever answer has to be
+// reported, or the operator runs forever reconciling nothing.
+func TestNatsConnectGivesUpOnAServerThatNeverArrives(t *testing.T) {
+	restore := NatsInitialConnectWindow
+	NatsInitialConnectWindow = time.Second
+	defer func() { NatsInitialConnectWindow = restore }()
+
+	started := time.Now()
+	_, err := NatsConnect(NatsDefaultURL)
+	if err == nil {
+		t.Fatal("expected a failure with no NATS running")
+	}
+	if elapsed := time.Since(started); elapsed < NatsInitialConnectWindow {
+		t.Fatalf("gave up after %s, before the %s window was out", elapsed, NatsInitialConnectWindow)
+	}
+	if !strings.Contains(err.Error(), "no connection within") {
+		t.Fatalf("the error should say the window it exhausted, got: %v", err)
+	}
 }

--- a/runtime-operator/pkg/wasmbus/nats_test.go
+++ b/runtime-operator/pkg/wasmbus/nats_test.go
@@ -17,6 +17,13 @@ func TestNatsConnect(t *testing.T) {
 		defer nc.Close()
 	})
 	t.Run("error", func(t *testing.T) {
+		// Shortened from the deployment default: with nothing ever going to
+		// answer, this subtest would otherwise sit out the whole startup-race
+		// window. What the window itself does is TestNatsConnectWaitsOutAStartupRace.
+		restore := NatsInitialConnectWindow
+		NatsInitialConnectWindow = 100 * time.Millisecond
+		defer func() { NatsInitialConnectWindow = restore }()
+
 		_, err := NatsConnect(NatsDefaultURL)
 		if err == nil {
 			t.Fatal("expected error")

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -500,10 +500,79 @@ func buildBaseHelmSets() []string {
 	return sets
 }
 
+// suiteNamespaces are the namespaces the specs create for themselves, in
+// addition to the release's own. Torn down with it, or the next run against
+// this cluster fails on `AlreadyExists`.
+var suiteNamespaces = []string{"namespace-a", "scoped-watched", "scoped-unwatched"}
+
 var _ = AfterSuite(func() {
+	// Before the release goes, while the operator is still running to process
+	// them. Its finalizers are on these objects, and `helm delete` takes away
+	// the only thing that can clear them — after which the namespace holding
+	// them wedges in `Terminating` forever, and the next run against this
+	// cluster fails creating a namespace that is still going away.
+	//
+	// WorkloadDeployments only: the ReplicaSets and Workloads under them are
+	// owned, so the cascade reaches them, and Hosts go when their pods do.
+	// Best-effort throughout — this is teardown, and a failure here must not
+	// mask the suite's own result.
+	By("deleting the workloads while the operator can still finalize them")
+	for _, ns := range append([]string{namespace}, suiteNamespaces...) {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "workloaddeployments.runtime.wasmcloud.dev",
+			"--all", "-n", ns, "--ignore-not-found=true", "--timeout=60s"))
+	}
+	// The host *pods* are what matters here, not the Host CRs. The operator
+	// puts `runtime.wasmcloud.dev/pod-host-finalizer` on each one, and a pod
+	// still carrying it is undeletable content in its namespace — so a
+	// namespace holding one never leaves `Terminating`, however cleanly
+	// everything else went. Waiting for the pods themselves is the only step
+	// that has to finish before the release takes the operator away.
+	By("removing the host groups and waiting for their pods to finalize")
+	for _, ns := range append([]string{namespace}, suiteNamespaces...) {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "deployments.apps",
+			"-l", "wasmcloud.com/name=hostgroup", "-n", ns,
+			"--ignore-not-found=true", "--timeout=60s"))
+	}
+	for _, ns := range append([]string{namespace}, suiteNamespaces...) {
+		_, _ = utils.Run(exec.Command("kubectl", "wait", "--for=delete",
+			"pod", "-l", "wasmcloud.com/name=hostgroup", "-n", ns, "--timeout=90s"))
+	}
+
 	By("uninstalling the Helm release")
 	cmd := exec.Command("helm", "delete", "-n", namespace, "operator-e2e")
 	_, _ = utils.Run(cmd)
+
+	// Whatever the wait above did not reach. `HostPodReconciler` only clears
+	// its finalizer on pods it can see, and its informer is scoped to
+	// `operator.hostNamespaces` — which a later spec's `helm upgrade` narrows,
+	// leaving the tenant namespace's host pod outside the set. Nothing will
+	// ever clear that one: the operator did not watch it at the end, and now
+	// the operator is gone. A pod still carrying a finalizer is undeletable
+	// content, and its namespace stays in `Terminating` for good.
+	//
+	// So the finalizer comes off by hand, which is what a person does to
+	// recover a wedged cluster. Safe here precisely because the operator is
+	// already uninstalled: there is no reconciler left to race, and nothing
+	// downstream of this suite depends on these pods.
+	By("clearing host pod finalizers nothing is left to reconcile")
+	for _, ns := range append([]string{namespace}, suiteNamespaces...) {
+		out, err := utils.Run(exec.Command("kubectl", "get", "pods", "-n", ns,
+			"-l", "wasmcloud.com/name=hostgroup", "--ignore-not-found",
+			"-o", "jsonpath={range .items[*]}{.metadata.name} {end}"))
+		if err != nil {
+			continue
+		}
+		for _, pod := range strings.Fields(out) {
+			_, _ = utils.Run(exec.Command("kubectl", "patch", "pod", pod, "-n", ns,
+				"--type=merge", "-p", `{"metadata":{"finalizers":null}}`))
+		}
+	}
+
+	By("deleting the namespaces the specs created")
+	for _, ns := range suiteNamespaces {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "namespace", ns,
+			"--ignore-not-found=true", "--timeout=120s"))
+	}
 
 	// Teardown Prometheus and CertManager after the suite if not skipped and if they were not already installed
 	if !skipPrometheusInstall && !isPrometheusOperatorAlreadyInstalled {

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -328,6 +328,20 @@ func registryRef(name string) string {
 	return fmt.Sprintf("oci-registry.%s.svc/fixtures/%s:%s", namespace, name, registryImageTag)
 }
 
+// gatewayURL builds a URL for `path` against the gateway's NodePort as
+// published on this host.
+//
+// 80 is what deploy/kind/kind-config.yaml maps and what CI uses. It is a
+// variable because a kind cluster brought up alongside another that already
+// holds 80 has to map it elsewhere, and a hard-coded 80 then sends every HTTP
+// spec to whichever cluster got there first — which answers, so the specs fail
+// against a stranger rather than reporting the collision.
+func gatewayURL(path string) string {
+	return fmt.Sprintf("http://localhost:%s%s", gatewayHostPort, path)
+}
+
+var gatewayHostPort = envOrDefault("E2E_GATEWAY_HOST_PORT", "80")
+
 // envOrDefault returns the env var value, or def when unset/empty.
 func envOrDefault(key, def string) string {
 	if v := os.Getenv(key); v != "" {

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -568,6 +568,25 @@ var _ = AfterSuite(func() {
 		}
 	}
 
+	// A Host CR that outlives the release is worse than untidy. The gateway
+	// routes by the pod IP recorded on it, so the next run's gateway can be
+	// handed the address of a pod that no longer exists and send traffic there
+	// — which shows up as a workload that deploys, reports Ready, and cannot be
+	// reached. Their finalizers belong to controllers that are now gone, so
+	// they come off the same way the pods' did.
+	By("clearing Host records the release left behind")
+	out, err := utils.Run(exec.Command("kubectl", "get", "hosts.runtime.wasmcloud.dev",
+		"-n", namespace, "--ignore-not-found",
+		"-o", "jsonpath={range .items[*]}{.metadata.name} {end}"))
+	if err == nil {
+		for _, host := range strings.Fields(out) {
+			_, _ = utils.Run(exec.Command("kubectl", "patch", "hosts.runtime.wasmcloud.dev", host,
+				"-n", namespace, "--type=merge", "-p", `{"metadata":{"finalizers":null}}`))
+		}
+	}
+	_, _ = utils.Run(exec.Command("kubectl", "delete", "hosts.runtime.wasmcloud.dev",
+		"--all", "-n", namespace, "--ignore-not-found=true", "--timeout=60s"))
+
 	By("deleting the namespaces the specs created")
 	for _, ns := range suiteNamespaces {
 		_, _ = utils.Run(exec.Command("kubectl", "delete", "namespace", ns,

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -495,6 +495,7 @@ func buildBaseHelmSets() []string {
 			// branch's own host and exercises them.
 			"runtime.probes.endpoint.enabled=false",
 			"runtime.drainDelaySeconds=0",
+			"runtime.natsConnectTimeoutSeconds=0",
 		)
 	}
 	return sets

--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -506,7 +506,23 @@ func buildBaseHelmSets() []string {
 // this cluster fails on `AlreadyExists`.
 var suiteNamespaces = []string{"namespace-a", "scoped-watched", "scoped-unwatched"}
 
+// skipTeardown leaves the cluster as the suite found it, for a caller that is
+// about to throw the cluster away.
+//
+// Everything below exists so a second run against the same cluster starts from
+// a clean one, and none of it is asserted on. A GitHub runner destroys the
+// cluster with the VM the moment the job ends, so there it is a minute and a
+// half spent tidying something nothing will look at again. It also empties the
+// namespace before the workflow's `if: failure()` diagnostics can read it.
+var skipTeardown = os.Getenv("E2E_SKIP_TEARDOWN") == envBoolTrue
+
 var _ = AfterSuite(func() {
+	if skipTeardown {
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"E2E_SKIP_TEARDOWN is set; leaving the release and its namespaces in place\n")
+		return
+	}
+
 	// Before the release goes, while the operator is still running to process
 	// them. Its finalizers are on these objects, and `helm delete` takes away
 	// the only thing that can clear them — after which the namespace holding

--- a/runtime-operator/test/e2e/e2e_test.go
+++ b/runtime-operator/test/e2e/e2e_test.go
@@ -237,7 +237,7 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("curl", "-s", "-o", "/dev/null",
 					"-w", "%{http_code}",
 					"-H", "Host: hello.localhost.direct",
-					"http://localhost:80")
+					gatewayURL(""))
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("200"))
@@ -329,7 +329,7 @@ var _ = Describe("Manager", Ordered, func() {
 				cmd := exec.Command("curl", "-s", "-o", "/dev/null",
 					"-w", "%{http_code}",
 					"-H", "Host: hello-workload.default",
-					"http://localhost:80")
+					gatewayURL(""))
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("200"))

--- a/runtime-operator/test/e2e/host_plugin_test.go
+++ b/runtime-operator/test/e2e/host_plugin_test.go
@@ -211,7 +211,7 @@ spec:
 		Eventually(func(g Gomega) {
 			out, err := utils.Run(exec.Command("curl", "-s", "-o", "/dev/null",
 				"-w", "%{http_code}", "-H", "Host: "+workloadHost,
-				"http://localhost:80/set?key=greeting&value=hello"))
+				gatewayURL("/set?key=greeting&value=hello")))
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(out).To(Equal("200"), "/set should route through the plugin")
 		}).WithTimeout(2 * time.Minute).Should(Succeed())
@@ -219,7 +219,7 @@ spec:
 		By("reading it back (/get) — the value survived in the plugin's store")
 		Eventually(func(g Gomega) {
 			out, err := utils.Run(exec.Command("curl", "-s", "-H", "Host: "+workloadHost,
-				"http://localhost:80/get?key=greeting"))
+				gatewayURL("/get?key=greeting")))
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(strings.TrimSpace(out)).To(Equal("hello"),
 				"the value must round-trip through the component plugin's persistent store")

--- a/runtime-operator/test/e2e/thundering_herd_test.go
+++ b/runtime-operator/test/e2e/thundering_herd_test.go
@@ -45,6 +45,7 @@ import (
 // that stops heartbeating is deleted by the operator, and every workload on it
 // goes too — so a herd that silences its own host takes out the very workloads
 // it was placing.
+
 // herdWorkload is one Workload CR of a herd, reduced to what the spec asserts on.
 type herdWorkload struct {
 	name   string

--- a/runtime-operator/test/e2e/thundering_herd_test.go
+++ b/runtime-operator/test/e2e/thundering_herd_test.go
@@ -1,0 +1,422 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.wasmcloud.dev/runtime-operator/v2/test/utils"
+)
+
+// End-to-end coverage for a scheduling thundering herd: one WorkloadDeployment
+// asking for a deployment's worth of replicas, all of which land on one host.
+//
+// The herd is real rather than arranged. `reconcileScaleUp` creates every
+// missing Workload in one pass, so all `replicas` CRs appear together; and
+// `findFreeHost` shuffles the schedulable hosts and takes the first *available*
+// one, with no capacity accounting of any kind — so with a single-replica
+// hostgroup every one of them is placed on the same host, whatever the herd's
+// size.
+//
+// What the layers below already cover, and why neither substitutes for this:
+//
+//   - crates/wash-runtime/tests/integration_thundering_herd.rs drives `HostApi`
+//     directly, so the whole herd starts at once. That is the host's own
+//     concurrency, with no admission control in front of it.
+//   - integration_washlet_api.rs covers the NATS command path — the
+//     `max_concurrent_starts` permit, and that heartbeats survive a burst — but
+//     every start there hangs on a stalling registry, so nothing in it reaches
+//     Running.
+//
+// Neither runs in a container. This is the only place the herd meets the
+// resource limits a real host pod is given, and those limits are what decide
+// how much of it runs at once: `max_concurrent_starts` is
+// `available_parallelism() - 1` clamped to 4, and `available_parallelism()`
+// reads the pod's CPU quota — 500m here, so the host works through the herd
+// one start at a time. The question this spec answers is whether the deployment
+// still converges, and whether the host stays heard from while it does. A host
+// that stops heartbeating is deleted by the operator, and every workload on it
+// goes too — so a herd that silences its own host takes out the very workloads
+// it was placing.
+// herdWorkload is one Workload CR of a herd, reduced to what the spec asserts on.
+type herdWorkload struct {
+	name   string
+	ready  string
+	hostID string
+}
+
+// herdHostGroup is the host group the herd is placed on. Every reading below
+// is scoped to it: the `registry` group beside it runs a different workload on
+// a different image and its health is not this spec's subject.
+const herdHostGroup = "default"
+
+// herdHostPods selects the pods of the host group the herd lands on.
+var herdHostPods = "wasmcloud.com/name=hostgroup,wasmcloud.com/hostgroup=" + herdHostGroup
+
+// hostPodRestarts maps each of the herd host group's pods to how many times its
+// containers have restarted.
+//
+// Read as a delta rather than an absolute: a host pod exits when NATS is not up
+// yet ("failed to connect to NATS Scheduler URL"), so a freshly installed
+// release routinely carries a restart or two that has nothing to do with any
+// workload.
+func hostPodRestarts() map[string]string {
+	out, err := utils.Run(exec.Command("kubectl", "get", "pods", "-n", namespace,
+		"-l", herdHostPods,
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].restartCount}{"\t"}{.status.containerStatuses[*].lastState.terminated.reason}{"\n"}{end}`))
+	if err != nil {
+		return nil
+	}
+	restarts := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) < 3 {
+			continue
+		}
+		restarts[fields[0]] = fields[1] + " (last termination: " + fields[2] + ")"
+	}
+	return restarts
+}
+
+// herdWorkloads returns the Workload CRs belonging to `deployment`, matched on
+// the `<deployment>-<replicaset hash>-<workload hash>` name the controllers
+// generate. Nothing labels a Workload with the deployment it came from, and
+// listing the namespace unfiltered would pick up whatever another spec left.
+func herdWorkloads(deployment string) []herdWorkload {
+	out, err := utils.Run(exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
+		"-n", namespace,
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.status.hostID}{"\n"}{end}`))
+	if err != nil {
+		return nil
+	}
+	var rows []herdWorkload
+	for _, line := range strings.Split(out, "\n") {
+		// Split to a fixed width rather than trimming: a row whose workload is
+		// placed but not yet Ready ends in empty fields, and trimming the line
+		// would drop them and take the row with them.
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) < 3 || !strings.HasPrefix(fields[0], deployment+"-") {
+			continue
+		}
+		rows = append(rows, herdWorkload{name: fields[0], ready: fields[1], hostID: fields[2]})
+	}
+	return rows
+}
+
+var _ = Describe("Thundering Herd", Ordered, func() {
+	const (
+		deploymentName = "herd"
+		workloadHost   = "herd.localhost.direct"
+		// The published hello-world component, so this spec does not need the
+		// in-cluster registry and runs on every leg.
+		image = "ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0"
+
+		// Generous: the host serializes the herd's compiles on half a core.
+		// This is a convergence bound, not a performance one — what it rules
+		// out is a herd that never finishes.
+		converge = 5 * time.Minute
+	)
+
+	// A deployment's worth, many times the host's start permit. Measured on
+	// kind: 15 converge in 6s and 100 in 29s, so the cost is sub-linear and 50
+	// buys a much wider fan-out for a few seconds of a job that already runs
+	// for minutes. E2E_HERD_REPLICAS goes further when the question is where
+	// convergence starts to hurt.
+	//
+	// Parsed here rather than with a Gomega assertion: this runs while Ginkgo
+	// builds the spec tree, where `Fail` is not valid and aborts the whole
+	// suite with a message about the wrong thing.
+	replicas := 50
+	if v := os.Getenv("E2E_HERD_REPLICAS"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			panic(fmt.Sprintf("E2E_HERD_REPLICAS must be a number, got %q: %v", v, err))
+		}
+		replicas = parsed
+	}
+
+	AfterEach(func() {
+		if !CurrentSpecReport().Failed() {
+			return
+		}
+		dump := func(label string, args ...string) {
+			out, err := utils.Run(exec.Command("kubectl", args...))
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s ===\n%s\n", label, out)
+			} else {
+				_, _ = fmt.Fprintf(GinkgoWriter, "=== %s (FAILED: %s) ===\n", label, err)
+			}
+		}
+		dump("Hosts", "get", "hosts.runtime.wasmcloud.dev", "-n", namespace, "-o", "wide")
+		dump("Workloads", "get", "workloads.runtime.wasmcloud.dev", "-n", namespace, "-o", "wide")
+		dump("Events", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+		dump("Hostgroup logs", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=hostgroup", "--tail=400", "--prefix=true")
+	})
+
+	AfterAll(func() {
+		_ = exec.Command("kubectl", "delete", "workloaddeployment", deploymentName,
+			"-n", namespace, "--ignore-not-found=true").Run()
+	})
+
+	It("places every replica of a herd on one host and converges", func() {
+		// Earlier specs upgrade the release, which rolls this Deployment. Until
+		// that settles there are two generations of host pod about — one
+		// draining, one starting — and neither is Ready, which is a rolling
+		// update rather than anything the herd did.
+		By("waiting for the host group to finish rolling out")
+		_, err := utils.Run(exec.Command("kubectl", "rollout", "status",
+			fmt.Sprintf("deployment/hostgroup-%s", herdHostGroup),
+			"-n", namespace, "--timeout=3m"))
+		Expect(err).NotTo(HaveOccurred(), "the host group never finished rolling out")
+
+		// The baseline the watch below is against. Without it a host that has
+		// not finished registering reads the same as one that has gone quiet:
+		// both have no Ready condition to report.
+		By("waiting for the host to be Ready before the herd arrives")
+		var hostName string
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get",
+				"hosts.runtime.wasmcloud.dev", "-n", namespace,
+				"-l", "hostgroup=default",
+				"-o", `jsonpath={range .items[*]}{.metadata.name}={.status.conditions[?(@.type=="Ready")].status} {end}`))
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, entry := range strings.Fields(out) {
+				if name, ok := strings.CutSuffix(entry, "=True"); ok {
+					hostName = name
+					return
+				}
+			}
+			g.Expect(out).To(BeEmpty(), "no host in the default hostgroup is Ready yet")
+		}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+		// The baseline for the restart check after convergence.
+		restartsBefore := hostPodRestarts()
+		Expect(restartsBefore).NotTo(BeEmpty(), "no hostgroup pod to watch")
+
+		By(fmt.Sprintf("applying a %d-replica WorkloadDeployment", replicas))
+		manifest := fmt.Sprintf(`apiVersion: runtime.wasmcloud.dev/v1alpha1
+kind: WorkloadDeployment
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  replicas: %d
+  template:
+    spec:
+      hostSelector:
+        hostgroup: default
+      hostInterfaces:
+        - namespace: wasi
+          package: http
+          interfaces:
+            - incoming-handler
+          config:
+            host: %s
+      components:
+        - name: hello-world
+          image: %s
+`, deploymentName, namespace, replicas, workloadHost, image)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(manifest)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply the herd WorkloadDeployment")
+
+		// Watched for the whole convergence rather than sampled after it: both
+		// failures this guards against are transient by nature. A host that
+		// goes quiet long enough to be reaped and then comes back looks healthy
+		// afterwards, and every workload it was carrying is gone; a pod whose
+		// `/readyz` refused during the herd is back in the Service by the time
+		// anything reads it, having dropped whatever arrived meanwhile.
+		var (
+			mu       sync.Mutex
+			notReady []string
+			done     = make(chan struct{})
+			watching sync.WaitGroup
+		)
+		watching.Add(1)
+		// Deferred rather than closed after the wait below: a convergence that
+		// times out unwinds the spec through a panic, and a watcher whose only
+		// exit is this channel would then keep shelling out to kubectl for the
+		// rest of the suite — on the failure path, which is the one that matters.
+		defer func() {
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+			watching.Wait()
+		}()
+		go func() {
+			defer watching.Done()
+			defer GinkgoRecover()
+			for {
+				select {
+				case <-done:
+					return
+				case <-time.After(2 * time.Second):
+				}
+				// The host the herd is landing on, by name. `--ignore-not-found`
+				// so a reaped Host CR comes back as empty output rather than a
+				// non-zero exit: being gone is the failure this watches for, and
+				// skipping errors would skip exactly that.
+				out, err := utils.Run(exec.Command("kubectl", "get",
+					"hosts.runtime.wasmcloud.dev", hostName, "-n", namespace,
+					"--ignore-not-found",
+					"-o", `jsonpath={.status.conditions[?(@.type=="Ready")].status}`))
+				if err != nil {
+					continue
+				}
+				if out != "True" {
+					mu.Lock()
+					notReady = append(notReady, fmt.Sprintf("host CR Ready=%q at %s", out, time.Now().Format(time.RFC3339)))
+					mu.Unlock()
+				}
+
+				// The pod's own readiness, which is what Kubernetes acts on:
+				// `/readyz` drives it, and it goes red when the host is draining
+				// or its ingress is at its ceiling. A herd that pushes the host
+				// past that ceiling takes its endpoint out of the Service, so
+				// the workloads it just started are unreachable through the
+				// gateway — while every workload still reports Ready.
+				pods, err := utils.Run(exec.Command("kubectl", "get", "pods", "-n", namespace,
+					"-l", herdHostPods,
+					"--field-selector=status.phase=Running",
+					"-o", `jsonpath={range .items[*]}{.metadata.name}={.status.conditions[?(@.type=="Ready")].status} {end}`))
+				if err != nil {
+					continue
+				}
+				for _, entry := range strings.Fields(pods) {
+					name, ready, _ := strings.Cut(entry, "=")
+					// Only the pods the herd is actually running on. A pod that
+					// appears mid-herd belongs to a rollout somebody else
+					// started, and its two generations are both legitimately
+					// unready; the restart check is what catches a replacement
+					// this herd caused.
+					if _, ours := restartsBefore[name]; !ours || ready == "True" {
+						continue
+					}
+					mu.Lock()
+					notReady = append(notReady, fmt.Sprintf("pod %s=%s at %s", name, ready, time.Now().Format(time.RFC3339)))
+					mu.Unlock()
+				}
+			}
+		}()
+
+		By("waiting for the WorkloadDeployment to become Ready")
+		started := time.Now()
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get", "workloaddeployment",
+				deploymentName, "-n", namespace,
+				"-o", `jsonpath={.status.conditions[?(@.type=="Ready")].status}`))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("True"))
+		}).WithTimeout(converge).WithPolling(2 * time.Second).Should(Succeed())
+		converged := time.Since(started)
+		close(done)
+		watching.Wait()
+
+		// How wide the herd actually ran, read off the host rather than
+		// inferred: the washlet logs the permit it resolved from the pod's CPU
+		// quota in its "Host started" line.
+		width := "unknown"
+		if out, err := utils.Run(exec.Command("kubectl", "logs", "-n", namespace,
+			"-l", "wasmcloud.com/name=hostgroup", "--tail=-1")); err == nil {
+			for _, line := range strings.Split(out, "\n") {
+				if !strings.Contains(line, "Host started") {
+					continue
+				}
+				if _, rest, ok := strings.Cut(line, "max_concurrent_starts="); ok {
+					width, _, _ = strings.Cut(rest, " ")
+				}
+			}
+		}
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"herd of %d converged in %s (host admitted %s start(s) at a time)\n",
+			replicas, converged.Round(time.Second), width)
+
+		mu.Lock()
+		observed := append([]string(nil), notReady...)
+		mu.Unlock()
+		Expect(observed).To(BeEmpty(),
+			"host %s stopped reporting Ready while the herd was starting. The Host CR going quiet means the operator deletes it and every workload on it; the pod going unready means `/readyz` refused and the endpoint left the Service, so the workloads it just started are unreachable",
+			hostName)
+
+		// Compilation is the memory peak of a start, and the pod is capped at
+		// 512Mi. A herd that walks the pod into an OOMKill restarts the host,
+		// which takes every workload on it — and the deployment then converges
+		// anyway on the way back up, so readiness alone would not notice.
+		By("verifying the herd did not restart the host pod")
+		restartsAfter := hostPodRestarts()
+		// Every pod that was there before must still be there. Ranging over the
+		// second reading alone would report success from an empty map — a
+		// kubectl blip, or a herd that took the whole host group down, both
+		// read as "nothing restarted".
+		for pod, before := range restartsBefore {
+			after, still := restartsAfter[pod]
+			Expect(still).To(BeTrue(), "host pod %s is gone after the herd; it was at %s before", pod, before)
+			Expect(after).To(Equal(before), "host pod %s restarted during the herd: %s, was %s", pod, after, before)
+		}
+		for pod := range restartsAfter {
+			Expect(restartsBefore).To(HaveKey(pod),
+				"host pod %s appeared during the herd, replacing the one it started on", pod)
+		}
+
+		By("verifying every replica reached Ready, on one host")
+		// The Workload CRs carry no label naming their deployment, so they are
+		// matched on the generated `<replicaset>-<hash>` name, which is
+		// prefixed with it.
+		rows := herdWorkloads(deploymentName)
+		Expect(rows).To(HaveLen(replicas), "expected %d Workload CRs, got %d", replicas, len(rows))
+
+		hosts := map[string]int{}
+		for _, row := range rows {
+			Expect(row.ready).To(Equal("True"), "%s is not Ready", row.name)
+			hosts[row.hostID]++
+		}
+		Expect(hosts).To(HaveLen(1),
+			"the herd was spread over %d hosts, so this run did not test a herd on one host: %v", len(hosts), hosts)
+		for id, count := range hosts {
+			Expect(count).To(Equal(replicas), "host %s carries %d of %d replicas", id, count, replicas)
+		}
+	})
+
+	It("still serves HTTP through the gateway after the herd", func() {
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("curl", "-s", "-o", "/dev/null",
+				"-w", "%{http_code}",
+				"-H", fmt.Sprintf("Host: %s", workloadHost),
+				gatewayURL("")))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("200"))
+		}).WithTimeout(2 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+	})
+
+	It("tears the whole herd down on delete", func() {
+		By("deleting the WorkloadDeployment")
+		_, err := utils.Run(exec.Command("kubectl", "delete", "workloaddeployment",
+			deploymentName, "-n", namespace))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for every Workload CR to go")
+		Eventually(func(g Gomega) {
+			g.Expect(herdWorkloads(deploymentName)).To(BeEmpty())
+		}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+
+		By("verifying the host survived the herd")
+		out, err := utils.Run(exec.Command("kubectl", "get", "hosts.runtime.wasmcloud.dev",
+			"-n", namespace, "-l", "hostgroup=default",
+			"-o", `jsonpath={range .items[*]}{.status.conditions[?(@.type=="Ready")].status} {end}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Fields(out)).To(ContainElement("True"),
+			"no host in the default hostgroup is Ready after the herd")
+	})
+})

--- a/runtime-operator/test/e2e/thundering_herd_test.go
+++ b/runtime-operator/test/e2e/thundering_herd_test.go
@@ -68,19 +68,31 @@ var herdHostPods = "wasmcloud.com/name=hostgroup,wasmcloud.com/hostgroup=" + her
 // release routinely carries a restart or two that has nothing to do with any
 // workload.
 func hostPodRestarts() map[string]string {
+	// `deletionTimestamp` is read so pods on their way out can be left alone.
+	// A re-run against a live cluster upgrades the release, which rolls this
+	// Deployment, and the outgoing pod serves its drain delay and grace period
+	// after `rollout status` already reports the new one complete. Counted in
+	// the baseline, it disappears mid-herd and reads as the herd having taken
+	// a host pod down.
+	const columns = `jsonpath={range .items[*]}` +
+		`{.metadata.name}{"\t"}` +
+		`{.metadata.deletionTimestamp}{"\t"}` +
+		`{.status.containerStatuses[*].restartCount}{"\t"}` +
+		`{.status.containerStatuses[*].lastState.terminated.reason}` +
+		`{"\n"}{end}`
+
 	out, err := utils.Run(exec.Command("kubectl", "get", "pods", "-n", namespace,
-		"-l", herdHostPods,
-		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].restartCount}{"\t"}{.status.containerStatuses[*].lastState.terminated.reason}{"\n"}{end}`))
+		"-l", herdHostPods, "--field-selector=status.phase=Running", "-o", columns))
 	if err != nil {
 		return nil
 	}
 	restarts := map[string]string{}
 	for _, line := range strings.Split(out, "\n") {
-		fields := strings.SplitN(line, "\t", 3)
-		if len(fields) < 3 {
+		fields := strings.SplitN(line, "\t", 4)
+		if len(fields) < 4 || fields[1] != "" {
 			continue
 		}
-		restarts[fields[0]] = fields[1] + " (last termination: " + fields[2] + ")"
+		restarts[fields[0]] = fields[2] + " (last termination: " + fields[3] + ")"
 	}
 	return restarts
 }
@@ -90,9 +102,14 @@ func hostPodRestarts() map[string]string {
 // generate. Nothing labels a Workload with the deployment it came from, and
 // listing the namespace unfiltered would pick up whatever another spec left.
 func herdWorkloads(deployment string) []herdWorkload {
+	const columns = `jsonpath={range .items[*]}` +
+		`{.metadata.name}{"\t"}` +
+		`{.status.conditions[?(@.type=="Ready")].status}{"\t"}` +
+		`{.status.hostID}` +
+		`{"\n"}{end}`
+
 	out, err := utils.Run(exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
-		"-n", namespace,
-		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.status.hostID}{"\n"}{end}`))
+		"-n", namespace, "-o", columns))
 	if err != nil {
 		return nil
 	}
@@ -354,7 +371,10 @@ spec:
 		observed := append([]string(nil), notReady...)
 		mu.Unlock()
 		Expect(observed).To(BeEmpty(),
-			"host %s stopped reporting Ready while the herd was starting. The Host CR going quiet means the operator deletes it and every workload on it; the pod going unready means `/readyz` refused and the endpoint left the Service, so the workloads it just started are unreachable",
+			"host %s stopped reporting Ready while the herd was starting.\n"+
+				"A Host CR going quiet means the operator deletes it and every workload on it.\n"+
+				"A pod going unready means `/readyz` refused and the endpoint left the Service, "+
+				"so the workloads it just started are unreachable.",
 			hostName)
 
 		// Compilation is the memory peak of a start, and the pod is capped at

--- a/runtime-operator/test/e2e/thundering_herd_test.go
+++ b/runtime-operator/test/e2e/thundering_herd_test.go
@@ -106,7 +106,7 @@ func herdWorkloads(deployment string) []herdWorkload {
 	const columns = `jsonpath={range .items[*]}` +
 		`{.metadata.name}{"\t"}` +
 		`{.status.conditions[?(@.type=="Ready")].status}{"\t"}` +
-		`{.status.hostID}` +
+		`{.status.hostId}` +
 		`{"\n"}{end}`
 
 	out, err := utils.Run(exec.Command("kubectl", "get", "workloads.runtime.wasmcloud.dev",
@@ -383,7 +383,15 @@ spec:
 		// which takes every workload on it — and the deployment then converges
 		// anyway on the way back up, so readiness alone would not notice.
 		By("verifying the herd did not restart the host pod")
-		restartsAfter := hostPodRestarts()
+		// Retried, so a kubectl that fails once does not read as the whole host
+		// group having gone: `hostPodRestarts` answers `nil` either way, and the
+		// comparison below cannot tell the two apart.
+		var restartsAfter map[string]string
+		Eventually(func() int {
+			restartsAfter = hostPodRestarts()
+			return len(restartsAfter)
+		}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(BeNumerically(">", 0),
+			"no host pods could be read after the herd")
 		// Every pod that was there before must still be there. Ranging over the
 		// second reading alone would report success from an empty map — a
 		// kubectl blip, or a herd that took the whole host group down, both
@@ -408,6 +416,11 @@ spec:
 		hosts := map[string]int{}
 		for _, row := range rows {
 			Expect(row.ready).To(Equal("True"), "%s is not Ready", row.name)
+			// Asserted before counting. An unset field reads as empty rather
+			// than erroring, and an empty key would collapse every replica into
+			// one bucket — making the "all on one host" check below pass
+			// whatever the placement actually was.
+			Expect(row.hostID).NotTo(BeEmpty(), "%s reports no host", row.name)
 			hosts[row.hostID]++
 		}
 		Expect(hosts).To(HaveLen(1),

--- a/runtime-operator/test/e2e/thundering_herd_test.go
+++ b/runtime-operator/test/e2e/thundering_herd_test.go
@@ -194,8 +194,15 @@ var _ = Describe("Thundering Herd", Ordered, func() {
 					return
 				}
 			}
-			g.Expect(out).To(BeEmpty(), "no host in the default hostgroup is Ready yet")
+			// Asserted on the name, not on the output: no Host CRs at all
+			// prints nothing and exits 0, so an emptiness check on `out` would
+			// pass on the way in and leave every reading below aimed at a host
+			// that does not exist — with the herd's central assertion satisfied
+			// by having looked at nothing.
+			g.Expect(hostName).NotTo(BeEmpty(),
+				"no host in the default hostgroup is Ready yet, got %q", out)
 		}).WithTimeout(3 * time.Minute).WithPolling(2 * time.Second).Should(Succeed())
+		Expect(hostName).NotTo(BeEmpty())
 
 		// The baseline for the restart check after convergence.
 		restartsBefore := hostPodRestarts()

--- a/runtime-operator/test/e2e/workload_limits_test.go
+++ b/runtime-operator/test/e2e/workload_limits_test.go
@@ -517,7 +517,7 @@ func probeOnce(host string) (sleeperReply, error) {
 
 func probeWith(client *http.Client, host string) (sleeperReply, error) {
 	var reply sleeperReply
-	req, err := http.NewRequest(http.MethodGet, "http://localhost:80/", nil)
+	req, err := http.NewRequest(http.MethodGet, gatewayURL("/"), nil)
 	if err != nil {
 		return reply, err
 	}


### PR DESCRIPTION
Comprehensive test suite for handling a thundering herd and a handful of fixes needed to be able to run the suite. It creates a stampede in the runtime-operator e2e tests via `reconcileScaleUp` which creates every missing Workload in one pass.  `findFreeHost` shuffles the schedulable hosts and takes the first available one with no capacity accounting. In wash-runtime we have a similar herd test that validates 15 workloads are able to start at once on one host and that compilation never stops the HTTP server from answering.

Fixes are mostly around timeouts, adding error cases, and logging:
- Wait out a NATS that isn't up yet instead of exiting and burning a pod restart on a startup race
- Same fix for the operator, infinite reconnects but no retry on the first connect.
- Hardening for the accept loop pacing added last week when a listener breaks in a way the errno list never anticipated, instead of spinning a core silently.
- Fail /livez when the ingress has stopped
- Make not-ready mean the host has no room rather than that it's busy, so a healthy host at 90% isn't pulled from the Service.
- Chart hardening where we fail the render when a host group claims a port the chart already renders.

Follow-ups after this merges:
- Update the canary compatibility list in e2e_suite_test.go:496. These only exist because the canary host image predates the flags. Once this PR merges and a new canary publishes, all three should be deleted 
-  Nothing routes host traffic through a k8s Service.  The gateway proxies to pod IPs from the Host CR, and the only EndpointSlice writer hardcodes ready := true. So /readyz sheds no traffic today