### PR TITLE
fix(wash-runtime): build and test with --no-default-features

### DIFF
--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -192,6 +192,140 @@ criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 # run time.
 gungraun = "0.19.1"
 
+# Integration tests that build a host through `tests/common`'s standard
+# plugin set (in-memory blobstore + keyvalue, tracing logger, dynamic
+# config) or import one of those plugins directly. `required-features`
+# lets `--no-default-features` skip these cleanly instead of failing to
+# compile `tests/common/mod.rs`; every name below is already on by default,
+# so this changes nothing for a default or CI (`OPTIONAL_FEATURES`) build.
+[[test]]
+name = "integration_abandoned_calls"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_abandonment_grace_ratio"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_cross_store_bridge"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_http_call_timeout"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_http_counter"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_http_ip_name_lookup"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_http_tls"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_instance_concurrency"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_messaging_async"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_messaging_concurrency"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_p2_p3_matrix"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_p3_ephemeral"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_p3_loopback_service"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_p3_resources"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_p3_streams"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_router_dev"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_router_dynamic"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_secrets_plugin"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_service_http"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_service_no_cli_run"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_trigger_service_messaging"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_warm_instances"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_wasip3"
+required-features = ["wasi-blobstore", "wasi-config", "wasi-keyvalue", "wasi-logging"]
+
+[[test]]
+name = "integration_blobstore_span_names"
+required-features = ["wasi-blobstore"]
+
+[[test]]
+name = "integration_http_blobstore"
+required-features = ["wasi-blobstore"]
+
+[[test]]
+name = "integration_nats_blobstore"
+required-features = ["wasi-blobstore"]
+
+[[test]]
+name = "integration_guest_memory_budget"
+required-features = ["wasi-config", "wasi-logging"]
+
+[[test]]
+name = "integration_http_allowed_hosts"
+required-features = ["wasi-config", "wasi-logging"]
+
+[[test]]
+name = "integration_http_egress_pooling"
+required-features = ["wasi-config", "wasi-logging"]
+
+[[test]]
+name = "integration_multi_component_config"
+required-features = ["wasi-config"]
+
+[[test]]
+name = "integration_inter_component_call"
+required-features = ["wasi-config", "wasi-keyvalue"]
+
+[[test]]
+name = "integration_nats_plugin"
+required-features = ["wasmcloud-nats"]
+
 [[bench]]
 name = "http_invoke"
 harness = false

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -158,6 +158,7 @@ impl InvocationSample {
 
     /// Mark what went wrong, for a call site that knows. The value is a short
     /// bounded name — `trap`, `timeout` — never anything a caller supplies.
+    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     pub(crate) fn failed(&mut self, error: &'static str) {
         self.error = Some(error);
     }

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -16,22 +16,73 @@ pub mod postgres;
 pub mod streaming;
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use std::{path::Path, sync::Arc};
 use tokio::time::timeout;
 
-#[cfg(feature = "host-component-plugins")]
+#[cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 use wash_runtime::plugin::component_host::ComponentHostPlugin;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use wash_runtime::plugin::wasi_blobstore::InMemoryBlobstore;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use wash_runtime::plugin::wasi_config::DynamicConfig;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use wash_runtime::plugin::wasi_keyvalue::InMemoryKeyValue;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use wash_runtime::plugin::wasi_logging::TracingLogger;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
+use wash_runtime::plugin::wasmcloud_secrets::WasmcloudSecrets;
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 use wash_runtime::{
     engine::Engine,
     host::{
         HostApi, HostBuilder,
         http::{DevRouter, DynamicRouter, Ingress, TlsConfig},
     },
-    plugin::{
-        wasi_blobstore::InMemoryBlobstore, wasi_config::DynamicConfig,
-        wasi_keyvalue::InMemoryKeyValue, wasi_logging::TracingLogger,
-        wasmcloud_secrets::WasmcloudSecrets,
-    },
+};
+use wash_runtime::{
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
     wit::WitInterface,
 };
@@ -255,6 +306,12 @@ pub fn default_counter_resources() -> LocalResources {
 
 /// Attach the standard suite of plugins used by http-counter tests:
 /// in-memory blobstore + keyvalue, tracing logger, dynamic config.
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 fn with_standard_plugins(
     builder: wash_runtime::host::HostBuilder,
 ) -> Result<wash_runtime::host::HostBuilder> {
@@ -268,6 +325,12 @@ fn with_standard_plugins(
 
 /// Start a host with a "DevRouter" backed HTTP server and the standard plugin
 /// set. Returns the bound address and a started `HostApi` ref.
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_dev_router(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
@@ -286,6 +349,12 @@ pub async fn start_host_with_dev_router(
 
 /// Start a host with a "DynamicRouter" backed HTTP server and the standard
 /// plugin set.
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_dynamic_router(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
@@ -305,6 +374,12 @@ pub async fn start_host_with_dynamic_router(
 /// Start a host with a TLS-enabled `DevRouter`-backed HTTP server and the
 /// standard plugin set. Certificate and key are read from disk at the given
 /// paths.
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_tls(
     cert_path: &Path,
     key_path: &Path,
@@ -329,6 +404,12 @@ pub async fn start_host_with_tls(
 
 /// Start a host with `wasip3` enabled on the engine, a `DevRouter` backed
 /// HTTP server, and the standard plugin set.
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_p3_http_handler(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi)> {
@@ -349,7 +430,13 @@ pub async fn start_host_with_p3_http_handler(
 /// built from `plugin_wasm`, routed by `router`, with `max_restarts` overriding
 /// the plugin's supervision budget when given. The named wrappers below cover
 /// the common shapes.
-#[cfg(feature = "host-component-plugins")]
+#[cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 async fn start_host_with_component_plugin_router(
     addr: &str,
     router: impl wash_runtime::host::http::Router,
@@ -387,7 +474,13 @@ async fn start_host_with_component_plugin_router(
 /// Start a p3 host with the standard plugin set plus a [`ComponentHostPlugin`]
 /// built from `plugin_wasm` (a host component plugin exporting a capability).
 /// Used to test workloads that import a component-provided host capability.
-#[cfg(feature = "host-component-plugins")]
+#[cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_component_plugin(
     addr: &str,
     plugin_id: &'static str,
@@ -407,7 +500,13 @@ pub async fn start_host_with_component_plugin(
 /// routes by `Host` header — so distinct workloads are reachable individually
 /// (the `DevRouter` sends every request to the last-resolved workload). Needed
 /// to test per-caller behavior across genuinely separate workloads.
-#[cfg(feature = "host-component-plugins")]
+#[cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_component_plugin_by_host(
     addr: &str,
     plugin_id: &'static str,
@@ -425,7 +524,13 @@ pub async fn start_host_with_component_plugin_by_host(
 
 /// Like [`start_host_with_component_plugin`] but overriding the plugin's
 /// supervision restart budget — for tests that exhaust it.
-#[cfg(feature = "host-component-plugins")]
+#[cfg(all(
+    feature = "host-component-plugins",
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_component_plugin_max_restarts(
     addr: &str,
     plugin_id: &'static str,
@@ -445,6 +550,12 @@ pub async fn start_host_with_component_plugin_max_restarts(
 /// Like [`start_host_with_p3_http_handler`] but also returns the [`Ingress`], so a test can
 /// drive host-side ingress hooks directly (e.g. deliver a message to a trigger service's
 /// messaging handler via `deliver_trigger_service_message`).
+#[cfg(all(
+    feature = "wasi-blobstore",
+    feature = "wasi-config",
+    feature = "wasi-keyvalue",
+    feature = "wasi-logging"
+))]
 pub async fn start_host_with_p3_handler(
     addr: &str,
 ) -> Result<(std::net::SocketAddr, impl HostApi, Arc<Ingress<DevRouter>>)> {


### PR DESCRIPTION
`cargo build --no-default-features` failed on `wash-runtime` once `wasmcloud-nats` is off, and the workspace denies warnings. Gated it the same way this file already gates other feature-only call sites.

Additionally added gates for `tests/common/mod.rs` where the shared host-builder helpers assumed the "standard" plugin bundle (blobstore, keyvalue, logging, config) was always on. I'm not opting to run default-features in CI right now until we improve CI build times. 