### PR TITLE
fix(wash-dev): enable host loopback so allowedHostLoopbackPorts works

### DIFF
--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -87,6 +87,14 @@ impl CliCommand for DevCommand {
                 .with_context(|| format!("invalid dev.wasm_proposals entry {name:?}"))?;
             engine_builder = engine_builder.with_wasm_proposal(proposal);
         }
+        // Host loopback is still gated per-workload by `allowedHostLoopbackPorts`
+        // below; this just enables the master switch `wash host` exposes via
+        // `--allow-host-loopback`, since a dev session has no equivalent flag.
+        let socket_policy = Arc::new(wash_runtime::sockets::policy::SocketPolicy {
+            host_loopback_enabled: true,
+            ..Default::default()
+        });
+        engine_builder = engine_builder.with_socket_policy(socket_policy);
         let engine = engine_builder.build()?;
 
         let mut host_builder = Host::builder()

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -87,9 +87,10 @@ impl CliCommand for DevCommand {
                 .with_context(|| format!("invalid dev.wasm_proposals entry {name:?}"))?;
             engine_builder = engine_builder.with_wasm_proposal(proposal);
         }
-        // Host loopback is still gated per-workload by `allowedHostLoopbackPorts`
-        // below; this just enables the master switch `wash host` exposes via
-        // `--allow-host-loopback`, since a dev session has no equivalent flag.
+        // `wash host` needs both an operator flag and the workload's
+        // `allowedHostLoopbackPorts`. In a dev session the developer is
+        // both parties, so the flag is redundant: the port list alone gates
+        // it, and an empty list still denies.
         let socket_policy = Arc::new(wash_runtime::sockets::policy::SocketPolicy {
             host_loopback_enabled: true,
             ..Default::default()


### PR DESCRIPTION
Fixes #5531

## Summary
`wash dev` never built a `SocketPolicy`, so it used the default one, which
hardcodes `host_loopback_enabled: false`, so listing a port in
`allowedHostLoopbackPorts` never actually worked — it was denied before that
list was even checked.

`wash host` already has a flag to turn this on. `wash dev` doesn't, so this
just turns it on by default. The port list is still what decides which ports
a component can actually reach.



