### PR TITLE
fix(wash-runtime): act on a stopped ingress and a lost control plane

### DIFF
--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -429,6 +429,18 @@ runtime:
   # in the first place. So liveness waits a good deal longer before calling a
   # host dead.
   #
+  # The body of a failed probe names the condition, so `kubectl describe pod`
+  # says which one without reaching for the host's logs. Readiness reports
+  # `starting`, `draining`, and `http_ingress_saturated` for a host at its
+  # connection ceiling. Liveness reports `stalled` for a host whose command loop
+  # has stopped turning.
+  #
+  # There is a second liveness condition, `http_ingress_stopped`, that a host
+  # pod will rarely show: an accept loop that returned is not coming back, so
+  # `wash host` notices and stops itself, and the pod is usually replaced by the
+  # process exiting before a probe is next polled. It is the backstop for a
+  # runtime embedded in something that does not watch its own ingress.
+  #
   # `liveness.enabled: false` leaves nothing to recycle a wedged host: the
   # operator deletes the *Host* of a host it stops hearing from, and its
   # workloads move, but the pod is not the operator's to delete and keeps

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -85,7 +85,12 @@ semver = { workspace = true }
 sysinfo = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v7"] }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["sync", "net", "macros"] }
+# Every tokio feature this library relies on is named here, for the reason the
+# `wasmtime` list below gives: `time`, `rt`, `fs` and `io-util` all reach this
+# crate today through `tokio-util`, `async-nats` and `hyper-util`, and would
+# leave with any of them. `[dev-dependencies]` takes `full`, so a test build
+# cannot show the gap either.
+tokio = { workspace = true, features = ["sync", "net", "macros", "time", "rt", "fs", "io-util"] }
 tracing = { workspace = true }
 zeroize = { workspace = true }
 # Every wasmtime feature this host relies on is named here rather than left to

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -18,6 +18,7 @@
 //! 4. Managing the request/response lifecycle through WASI-HTTP
 //! ```
 
+use std::sync::atomic::AtomicBool;
 use std::{
     collections::{BTreeSet, HashMap},
     net::SocketAddr,
@@ -27,7 +28,6 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-use std::sync::atomic::AtomicBool;
 
 use crate::engine::abandon::{AbandonFlag, AbandonOnDrop, DispatchedCall};
 use crate::host::allowed_hosts::AllowedHost;
@@ -756,6 +756,22 @@ pub trait HostHandler: Send + Sync + 'static {
     async fn start(&self) -> anyhow::Result<()>;
     /// Stop the HTTP server
     async fn stop(&self) -> anyhow::Result<()>;
+
+    /// Resolves once this handler's accept loop has stopped and will not run
+    /// again — whether it returned an error, returned cleanly, or panicked.
+    ///
+    /// The loop is spawned detached, so without this its exit is one log line:
+    /// the host keeps every workload it was given, keeps answering its control
+    /// plane, and serves no HTTP for as long as it runs. Whoever owns the host
+    /// watches this so the failure is acted on rather than only recorded; see
+    /// [`crate::washlet::ClusterHost`], which ends the host on it.
+    ///
+    /// Default: pending forever, which is right for a handler with no accept
+    /// loop to lose ([`NullServer`]).
+    async fn stopped(&self) {
+        std::future::pending().await
+    }
+
     /// Get the port on which the HTTP server is listening
     fn port(&self) -> u16;
 
@@ -1407,6 +1423,10 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         Ok(())
     }
 
+    async fn stopped(&self) {
+        self.connections.stopped().await;
+    }
+
     fn port(&self) -> u16 {
         self.addr.port()
     }
@@ -1682,10 +1702,14 @@ const READY_RECOVER_PERCENT: usize = 10;
 pub struct ConnectionLimit {
     max: usize,
     permits: Arc<Semaphore>,
-    /// Cleared when the accept loop returns. A ceiling with every permit free is
+    /// Set when the accept loop returns. A ceiling with every permit free is
     /// indistinguishable from a listener that stopped accepting, and the second
     /// is the more urgent of the two.
-    accepting: Arc<AtomicBool>,
+    ///
+    /// A watch rather than a flag because both questions get asked: `/readyz`
+    /// polls it per probe, and [`Self::stopped`] waits on it so the host can
+    /// act on an accept loop that ended without being asked to.
+    stopped: Arc<tokio::sync::watch::Sender<bool>>,
     /// Which side of the hysteresis below readiness is currently on. Shared,
     /// because the probe handler and the accept loop hold separate clones of
     /// the same limit.
@@ -1701,7 +1725,7 @@ impl ConnectionLimit {
         Self {
             max,
             permits: Arc::new(Semaphore::new(max)),
-            accepting: Arc::new(AtomicBool::new(true)),
+            stopped: Arc::new(tokio::sync::watch::Sender::new(false)),
             has_headroom: Arc::new(AtomicBool::new(true)),
             offered: opentelemetry::global::meter("wash-runtime")
                 .u64_counter("http.ingress.connections")
@@ -1715,8 +1739,29 @@ impl ConnectionLimit {
 
     /// Record that the accept loop is no longer running.
     fn stopped_accepting(&self) {
-        self.accepting
-            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.stopped.send_replace(true);
+    }
+
+    /// Whether the accept loop is still running.
+    ///
+    /// An embedder that runs no probe listener reads this — or waits on
+    /// [`Self::stopped`] — to learn what the host otherwise only logs.
+    pub fn accepting(&self) -> bool {
+        !*self.stopped.borrow()
+    }
+
+    /// Resolves once the accept loop has stopped, immediately if it already
+    /// has.
+    ///
+    /// The loop is spawned detached and nothing restarts it, so this resolving
+    /// means the host will serve no more HTTP for as long as it runs. See
+    /// [`crate::host::http::HostHandler::stopped`], which is how that reaches
+    /// the host.
+    pub async fn stopped(&self) {
+        let mut stopped = self.stopped.subscribe();
+        // `Err` is the sender dropped, which cannot happen through a `&self`
+        // holding it — and would mean the same thing if it could.
+        let _ = stopped.wait_for(|stopped| *stopped).await;
     }
 
     /// Take a slot for an accepted connection, or `None` at the ceiling.
@@ -1755,7 +1800,7 @@ impl std::fmt::Debug for ConnectionLimit {
 /// with capacity.
 impl crate::host::probes::ReadinessCheck for ConnectionLimit {
     fn name(&self) -> &'static str {
-        if self.accepting.load(std::sync::atomic::Ordering::Relaxed) {
+        if self.accepting() {
             "http_ingress_saturated"
         } else {
             "http_ingress_stopped"
@@ -1775,7 +1820,7 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
     /// waits for [`READY_RECOVER_PERCENT`] of its ceiling to come back.
     fn ready(&self) -> bool {
         use std::sync::atomic::Ordering::Relaxed;
-        if !self.accepting.load(Relaxed) {
+        if !self.accepting() {
             return false;
         }
         // Never above the ceiling, so a host too small for the percentage still
@@ -1801,11 +1846,11 @@ impl crate::host::probes::ReadinessCheck for ConnectionLimit {
     /// listener goes on satisfying. Left to readiness, it keeps being given
     /// workloads that report Ready and are unreachable.
     fn unrecoverable(&self) -> bool {
-        !self.accepting.load(std::sync::atomic::Ordering::Relaxed)
+        !self.accepting()
     }
 }
 
-/// Clears [`ConnectionLimit`]'s accepting flag however the accept loop ends.
+/// Marks [`ConnectionLimit`] stopped however the accept loop ends.
 ///
 /// A guard rather than a statement after the await: a panicking task unwinds
 /// past the statement, leaving readiness reporting a healthy idle host.
@@ -3187,6 +3232,45 @@ mod tests {
             server.nodelay().unwrap(),
             "run_http_server must set TCP_NODELAY on accepted connections"
         );
+    }
+
+    /// However the accept loop ends, it has to be findable. It is spawned
+    /// detached and nothing restarts it, so a host that only logged the exit
+    /// holds every workload it was given, keeps answering its control plane,
+    /// and serves no HTTP for the rest of its life.
+    #[tokio::test]
+    async fn a_stopped_accept_loop_is_observable_and_unrecoverable() {
+        use crate::host::probes::ReadinessCheck as _;
+
+        let ingress = Ingress::builder(DevRouter::default(), "127.0.0.1:0".parse().unwrap())
+            .build()
+            .await
+            .unwrap();
+        let limit = ingress.connection_limit();
+
+        assert!(limit.accepting());
+        assert!(limit.ready(), "a fresh ingress has room");
+        assert!(!limit.unrecoverable());
+
+        ingress.start().await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), ingress.stopped())
+                .await
+                .is_err(),
+            "a running accept loop must not report itself stopped"
+        );
+
+        ingress.stop().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), ingress.stopped())
+            .await
+            .expect("the accept loop's exit has to reach whoever is watching for it");
+
+        assert!(!limit.accepting());
+        assert!(!limit.ready());
+        assert_eq!(limit.name(), "http_ingress_stopped");
+        // The distinction from saturation: a full ingress empties, this does
+        // not — so it is a reason to be replaced, not only to leave the Service.
+        assert!(limit.unrecoverable());
     }
 
     /// A host at its ingress ceiling has to keep accepting and close what it

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -139,23 +139,41 @@ pub struct ProbeState {
     liveness: Option<Arc<Liveness>>,
     started: Arc<AtomicBool>,
     draining: Arc<AtomicBool>,
-    checks: Vec<Arc<dyn ReadinessCheck>>,
+    /// Shared with every clone, and appendable after cloning: a host hands one
+    /// clone to [`serve`] and keeps another, so a check registered on either
+    /// afterwards has to be one the listener answers from.
+    checks: Arc<arc_swap::ArcSwap<Vec<Arc<dyn ReadinessCheck>>>>,
 }
 
 impl ProbeState {
     /// Watch `liveness` for `/livez`. Without one, `/livez` reports alive
     /// whenever the listener can answer at all — still stronger than a TCP
     /// probe, which the kernel answers whether or not the runtime is running.
+    ///
+    /// Per-instance, unlike [`Self::register`]: this writes a field rather than
+    /// the shared check list, so set it before handing a clone to [`serve`].
+    /// Calling it on a clone afterwards leaves that listener answering `/livez`
+    /// from nothing at all.
     #[must_use]
     pub fn with_liveness(mut self, liveness: Arc<Liveness>) -> Self {
         self.liveness = Some(liveness);
         self
     }
 
-    /// Add a reason the host may be not-ready.
+    /// Add a reason the host may be not-ready, on this state and every clone
+    /// of it.
+    pub fn register(&self, check: Arc<dyn ReadinessCheck>) {
+        self.checks.rcu(|current| {
+            let mut checks = (**current).clone();
+            checks.push(Arc::clone(&check));
+            checks
+        });
+    }
+
+    /// [`Self::register`], for a caller still building the state up.
     #[must_use]
-    pub fn with_readiness(mut self, check: Arc<dyn ReadinessCheck>) -> Self {
-        self.checks.push(check);
+    pub fn with_readiness(self, check: Arc<dyn ReadinessCheck>) -> Self {
+        self.register(check);
         self
     }
 
@@ -190,6 +208,7 @@ impl ProbeState {
         }
         !self
             .checks
+            .load()
             .iter()
             .any(|check| check.unrecoverable() && !check.ready())
     }
@@ -203,6 +222,7 @@ impl ProbeState {
             return vec!["starting"];
         }
         self.checks
+            .load()
             .iter()
             .filter(|check| !check.ready())
             .map(|check| check.name())
@@ -407,6 +427,19 @@ mod tests {
 
         assert!(state.live(), "a draining host must not be restarted");
         assert_eq!(state.not_ready(), vec!["draining"]);
+    }
+
+    /// A host hands one clone to [`serve`] and keeps another to register on.
+    /// A check the listener cannot see is one that never fails a probe, which
+    /// is the silent half of getting this wrong.
+    #[test]
+    fn a_check_registered_after_a_clone_is_visible_to_it() {
+        let serving = ProbeState::default();
+        let held = serving.clone();
+        held.started();
+
+        held.register(gate("late", false));
+        assert_eq!(serving.not_ready(), vec!["late"]);
     }
 
     /// Draining is the same shape and the more common one: leave the Service,

--- a/crates/wash-runtime/src/host/probes.rs
+++ b/crates/wash-runtime/src/host/probes.rs
@@ -4,10 +4,15 @@
 //! the listen backlog, which the kernel answers whether or not the process is
 //! running. This listener answers from what the host knows about itself.
 //!
-//! `/livez` is "restart me" and fails only when the command loop has stopped —
-//! the cure costs every workload on the host. `/readyz` is "stop sending me
-//! work" and fails while starting, while draining, and while the ingress is at
-//! its ceiling, which a TCP probe cannot express at all.
+//! `/livez` is "restart me" and the cure costs every workload on the host, so
+//! it fails for two things only: the command loop has stopped, or a readiness
+//! check calls itself [unrecoverable](ReadinessCheck::unrecoverable) — one that
+//! leaves the host out of rotation with nothing to put it back, where holding
+//! the workloads costs them the same and buys nothing.
+//!
+//! `/readyz` is "stop sending me work" and fails while starting, while
+//! draining, and for every registered check — the ingress at its ceiling —
+//! which a TCP probe cannot express at all.
 
 use core::time::Duration;
 use std::net::SocketAddr;
@@ -196,21 +201,28 @@ impl ProbeState {
         self.draining.store(true, Ordering::Relaxed);
     }
 
-    fn live(&self) -> bool {
-        if !self.liveness.as_ref().is_none_or(|l| l.alive()) {
-            return false;
-        }
-        // A draining host stops accepting because it was told to. Reading that
-        // as "restart me" would kill it mid-drain, which is the one thing
-        // `drain` exists to avoid.
+    /// Why this host should be restarted, or `None` while it should not.
+    ///
+    /// Named for the same reason [`Self::not_ready`] names its refusals: a
+    /// restart is the expensive answer, and an operator reading one should not
+    /// have to correlate it with the logs to learn which condition asked for it.
+    fn not_live(&self) -> Option<&'static str> {
+        // First, so it covers every condition below rather than only the ones
+        // that happen to follow it. A draining host stops accepting because it
+        // was told to, and its command loop stops beating the moment it starts
+        // unbinding plugins — reading either as "restart me" would kill it
+        // mid-drain, which is the one thing `drain` exists to avoid.
         if self.draining.load(Ordering::Relaxed) {
-            return true;
+            return None;
         }
-        !self
-            .checks
+        if self.liveness.as_ref().is_some_and(|l| !l.alive()) {
+            return Some("stalled");
+        }
+        self.checks
             .load()
             .iter()
-            .any(|check| check.unrecoverable() && !check.ready())
+            .find(|check| !check.ready() && check.unrecoverable())
+            .map(|check| check.name())
     }
 
     /// The checks currently refusing, empty when the host is ready.
@@ -238,8 +250,10 @@ fn text(status: StatusCode, body: impl Into<Bytes>) -> Response<Full<Bytes>> {
 
 fn answer(state: &ProbeState, req: &Request<hyper::body::Incoming>) -> Response<Full<Bytes>> {
     match req.uri().path() {
-        LIVEZ if state.live() => text(StatusCode::OK, "ok\n"),
-        LIVEZ => text(StatusCode::SERVICE_UNAVAILABLE, "stalled\n"),
+        LIVEZ => match state.not_live() {
+            None => text(StatusCode::OK, "ok\n"),
+            Some(reason) => text(StatusCode::SERVICE_UNAVAILABLE, format!("{reason}\n")),
+        },
         READYZ => match state.not_ready() {
             reasons if reasons.is_empty() => text(StatusCode::OK, "ok\n"),
             reasons => text(
@@ -387,7 +401,10 @@ mod tests {
         let state = ProbeState::default().with_readiness(saturated);
         state.started();
 
-        assert!(state.live(), "saturation is not a reason to restart");
+        assert!(
+            state.not_live().is_none(),
+            "saturation is not a reason to restart"
+        );
         assert_eq!(state.not_ready(), vec!["http_ingress_saturated"]);
     }
 
@@ -402,7 +419,11 @@ mod tests {
         let state = ProbeState::default().with_readiness(stopped);
         state.started();
 
-        assert!(!state.live(), "an ingress that cannot recover must restart");
+        assert_eq!(
+            state.not_live(),
+            Some("http_ingress_stopped"),
+            "an ingress that cannot recover must restart, and name why"
+        );
         assert_eq!(state.not_ready(), vec!["http_ingress_stopped"]);
     }
 
@@ -411,7 +432,7 @@ mod tests {
     fn an_unrecoverable_check_that_is_satisfied_leaves_the_host_live() {
         let state = ProbeState::default().with_readiness(unrecoverable_gate("ingress", true));
         state.started();
-        assert!(state.live());
+        assert!(state.not_live().is_none());
         assert!(state.not_ready().is_empty());
     }
 
@@ -425,8 +446,35 @@ mod tests {
         state.started();
         state.drain();
 
-        assert!(state.live(), "a draining host must not be restarted");
+        assert!(
+            state.not_live().is_none(),
+            "a draining host must not be restarted"
+        );
         assert_eq!(state.not_ready(), vec!["draining"]);
+    }
+
+    /// The other condition a drain has to survive, and the one that arrives on
+    /// its own: the command loop stops beating the moment it breaks out to
+    /// unbind plugins, so a host still inside its own shutdown goes stale by
+    /// definition. Restarting it there is the mid-drain kill `drain` exists to
+    /// prevent, so the drain has to be checked before the beat and not after.
+    #[test]
+    fn a_stale_beat_while_draining_is_the_shutdown_working() {
+        let liveness = Liveness::new(Duration::from_millis(50));
+        let state = ProbeState::default().with_liveness(Arc::clone(&liveness));
+        liveness.beat();
+        std::thread::sleep(Duration::from_millis(120));
+        assert_eq!(
+            state.not_live(),
+            Some("stalled"),
+            "precondition: the beat has gone stale"
+        );
+
+        state.drain();
+        assert!(
+            state.not_live().is_none(),
+            "a host inside its own shutdown must not be restarted for going quiet"
+        );
     }
 
     /// A host hands one clone to [`serve`] and keeps another to register on.
@@ -452,7 +500,10 @@ mod tests {
 
         state.drain();
         assert_eq!(state.not_ready(), vec!["draining"]);
-        assert!(state.live(), "a draining host must not be restarted");
+        assert!(
+            state.not_live().is_none(),
+            "a draining host must not be restarted"
+        );
     }
 
     /// Every refusing check is named, so a probe failure says which without
@@ -479,7 +530,10 @@ mod tests {
     fn a_host_that_has_not_started_is_not_ready() {
         let state = ProbeState::default().with_readiness(gate("ingress", true));
         assert_eq!(state.not_ready(), vec!["starting"]);
-        assert!(state.live(), "starting is not a reason to restart");
+        assert!(
+            state.not_live().is_none(),
+            "starting is not a reason to restart"
+        );
 
         state.started();
         assert!(state.not_ready().is_empty());
@@ -537,6 +591,16 @@ mod tests {
         assert!(ready.starts_with("HTTP/1.1 503"), "{ready}");
         assert!(ready.contains("http_ingress_saturated"), "{ready}");
 
+        // An unrecoverable refusal is the one that reaches `/livez`, and it
+        // names itself there the same way `/readyz` does. Registered on the
+        // state the test kept rather than the one `serve` was handed, which is
+        // how the cluster host registers its own — the listener has to answer
+        // from it.
+        state.register(unrecoverable_gate("http_ingress_stopped", false));
+        let live = get(addr, LIVEZ).await;
+        assert!(live.starts_with("HTTP/1.1 503"), "{live}");
+        assert!(live.contains("http_ingress_stopped"), "{live}");
+
         // A mistyped probe path must fail rather than pass against nothing.
         assert!(get(addr, "/healthz").await.starts_with("HTTP/1.1 404"));
 
@@ -550,26 +614,29 @@ mod tests {
     fn liveness_goes_stale_without_a_beat() {
         let liveness = Liveness::new(Duration::from_millis(50));
         let state = ProbeState::default().with_liveness(Arc::clone(&liveness));
-        assert!(state.live(), "a fresh signal starts alive");
+        assert!(state.not_live().is_none(), "a fresh signal starts alive");
 
         // Still starting, not yet stalled: a host slow to bind plugins and pull
         // images has not failed, and restarting it for that is how a slow start
         // becomes a crash loop.
         std::thread::sleep(Duration::from_millis(120));
         assert!(
-            state.live(),
+            state.not_live().is_none(),
             "a loop that has not started yet is not stalled"
         );
 
         liveness.beat();
         std::thread::sleep(Duration::from_millis(120));
-        assert!(!state.live(), "silence past the bound is a stalled host");
+        assert!(
+            state.not_live().is_some(),
+            "silence past the bound is a stalled host"
+        );
 
         liveness.beat();
-        assert!(state.live(), "a beat brings it back");
+        assert!(state.not_live().is_none(), "a beat brings it back");
 
         assert!(
-            ProbeState::default().live(),
+            ProbeState::default().not_live().is_none(),
             "with nothing to watch, answering at all is the signal"
         );
     }

--- a/crates/wash-runtime/src/observability.rs
+++ b/crates/wash-runtime/src/observability.rs
@@ -17,8 +17,8 @@ use tracing_subscriber::{
 /// Flushes the OTel exporters, if [`initialize_observability`] installed any.
 ///
 /// **Blocks** for up to five seconds per provider — the SDK's own timeout — so
-/// a signal path has to bound it and keep it off the runtime the exporter
-/// drains over. Runs at most once; a no-op when no exporter was installed.
+/// an async exit path calls [`flush_within`] instead of this. Runs at most
+/// once; a no-op when no exporter was installed.
 pub fn flush() {
     static FLUSHED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
@@ -30,6 +30,26 @@ pub fn flush() {
     if let Some(shutdown) = SHUTDOWN.get() {
         shutdown();
     }
+}
+
+/// What a process leaving on a signal gives the exporters before it goes
+/// without them. Only ever spent when one was configured.
+///
+/// Not the SDK's own five seconds per provider: three providers would be the
+/// whole 15s grace period a terminating host pod gets, and
+/// [`crate::host::Host::stop`] still has to unbind its workloads inside it.
+pub const FLUSH_BUDGET: Duration = Duration::from_secs(2);
+
+/// [`flush`], bounded: hands the exporters at most `budget` to deliver what
+/// they were still batching, and answers whether they finished.
+///
+/// A blocking thread, because `flush` blocks: the OTLP exporter drains over the
+/// connection this runtime has to keep polling. `false` covers both a budget
+/// that ran out and an exporter that panicked on its way out — either way the
+/// caller is leaving without the telemetry.
+pub async fn flush_within(budget: Duration) -> bool {
+    let flushed = tokio::task::spawn_blocking(flush);
+    matches!(tokio::time::timeout(budget, flushed).await, Ok(Ok(())))
 }
 
 /// Set once by [`initialize_observability`], so [`flush`] can reach the
@@ -574,6 +594,16 @@ mod tests {
             .iter()
             .map(|kv| (kv.key.to_string(), kv.value.to_string()))
             .collect()
+    }
+
+    /// The budget bounds the flush; it is not spent waiting on one. A process
+    /// that configured no exporter — every `wash` invocation without `OTEL_*`
+    /// set — has nothing to hand over and leaves on a signal at once.
+    #[tokio::test]
+    async fn flushing_without_an_exporter_does_not_spend_the_budget() {
+        let started = std::time::Instant::now();
+        assert!(flush_within(FLUSH_BUDGET).await);
+        assert!(started.elapsed() < FLUSH_BUDGET);
     }
 
     /// The scheme every guest-execution measurement shares, pinned by key.

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -7,7 +7,7 @@ use crate::host::{Host, HostApi, HostConfig, WorkloadReservation};
 use crate::oci::{self, OciConfig};
 use crate::plugin::HostPlugin;
 use anyhow::{Context as _, anyhow};
-use futures::StreamExt as _;
+use futures::{FutureExt as _, StreamExt as _};
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -263,6 +263,15 @@ impl ClusterHostBuilder {
     }
 }
 
+/// Why the command loop stopped turning. Both run the same shutdown; they
+/// differ only in what the host reports afterwards.
+enum Ended {
+    /// The cleanup future was awaited.
+    Requested,
+    /// The HTTP ingress' accept loop returned.
+    IngressStopped,
+}
+
 pub struct ClusterHost {
     prepared_host: Host,
     nats_client: Arc<async_nats::Client>,
@@ -363,7 +372,14 @@ impl ClusterHost {
                 let heartbeat_slot = Arc::new(tokio::sync::Semaphore::new(1));
                 let cleanup_slot = Arc::new(tokio::sync::Semaphore::new(1));
 
-                loop {
+                // Built once and pinned rather than rebuilt every turn, over an
+                // owned handle so the shutdown after the loop can still consume
+                // `host`.
+                let http_handler = Arc::clone(&host.http_handler);
+                let mut ingress_stopped =
+                    std::pin::pin!(async move { http_handler.stopped().await });
+
+                let ended = loop {
                     // Every turn, whichever branch woke it. The heartbeat timer
                     // alone guarantees one per interval, so silence here means
                     // the loop itself has stopped — which is what `/livez`
@@ -373,63 +389,13 @@ impl ClusterHost {
                     }
                     tokio::select! {
                         // Shutdown signal
-                        _ = &mut one_shot_rx => {
-                            if let Err(e) = api_subscription.unsubscribe().await {
-                                error!("failed to unsubscribe from API requests: {e}");
-                            }
-                            // Anything still queued gives its workload id back
-                            // and returns rather than starting something this
-                            // host is about to tear down.
-                            starts.close();
-                            let drained = tokio::time::timeout(COMMAND_DRAIN_TIMEOUT, async {
-                                while let Some(finished) = commands.join_next().await {
-                                    if let Err(e) = finished {
-                                        error!("command task failed during shutdown: {e}");
-                                    }
-                                }
-                            })
-                            .await;
-                            if drained.is_err() {
-                                warn!(
-                                    "commands still running after {COMMAND_DRAIN_TIMEOUT:?}; \
-                                     abandoning them to stop the host"
-                                );
-                                commands.abort_all();
-                                // `abort_all` only asks. Wait for the tasks to
-                                // reach their next await and unwind, or
-                                // `host.stop()` unbinds plugins underneath one
-                                // still binding them.
-                                //
-                                // Bounded: an aborted task cancels at its next
-                                // await, and a command inside a synchronous
-                                // compile has none. Waiting it out holds the
-                                // shutdown past the pod's grace period, so
-                                // `host.stop()` never runs at all.
-                                let unwound = tokio::time::timeout(
-                                    COMMAND_ABORT_TIMEOUT,
-                                    async {
-                                        while let Some(finished) = commands.join_next().await {
-                                            // A panic while unwinding still
-                                            // matters: the task may hold a
-                                            // workload id it never released.
-                                            if let Err(e) = finished
-                                                && !e.is_cancelled()
-                                            {
-                                                error!("aborted command task failed: {e}");
-                                            }
-                                        }
-                                    },
-                                )
-                                .await;
-                                if unwound.is_err() {
-                                    warn!(
-                                        "commands still unwinding {COMMAND_ABORT_TIMEOUT:?} after \
-                                         abort; stopping the host without them"
-                                    );
-                                }
-                            }
-                            return host.stop().await.context("failed to stop host");
-                        }
+                        _ = &mut one_shot_rx => break Ended::Requested,
+                        // The accept loop returned and nothing restarts it, so
+                        // this host would hold every workload it was given,
+                        // keep heartbeating, and serve no HTTP for as long as
+                        // it runs. Stopping is what puts those workloads on a
+                        // host that can serve them; they are lost either way.
+                        () = &mut ingress_stopped => break Ended::IngressStopped,
                         // Reaps finished commands. A panicked one is fatal: it
                         // may have died holding a workload id it claimed and
                         // never committed or released, and no later stop can
@@ -526,6 +492,82 @@ impl ClusterHost {
                                 }
                             });
                         }
+                    }
+                };
+
+                // `wash host` watches the same accept loop and asks for a
+                // shutdown the moment it ends, so both branches above can be
+                // ready at once and `select!` picks between them at random.
+                // Which one fired is therefore not evidence of anything; the
+                // ingress itself is. Only checked on the `Requested` path, so
+                // the future is never polled after it has already completed.
+                let ended = match ended {
+                    Ended::Requested if ingress_stopped.as_mut().now_or_never().is_some() => {
+                        Ended::IngressStopped
+                    }
+                    ended => ended,
+                };
+
+                if let Err(e) = api_subscription.unsubscribe().await {
+                    error!("failed to unsubscribe from API requests: {e}");
+                }
+                // Anything still queued gives its workload id back and returns
+                // rather than starting something this host is about to tear
+                // down.
+                starts.close();
+                let drained = tokio::time::timeout(COMMAND_DRAIN_TIMEOUT, async {
+                    while let Some(finished) = commands.join_next().await {
+                        if let Err(e) = finished {
+                            error!("command task failed during shutdown: {e}");
+                        }
+                    }
+                })
+                .await;
+                if drained.is_err() {
+                    warn!(
+                        "commands still running after {COMMAND_DRAIN_TIMEOUT:?}; \
+                         abandoning them to stop the host"
+                    );
+                    commands.abort_all();
+                    // `abort_all` only asks. Wait for the tasks to reach their
+                    // next await and unwind, or `host.stop()` unbinds plugins
+                    // underneath one still binding them.
+                    //
+                    // Bounded: an aborted task cancels at its next await, and a
+                    // command inside a synchronous compile has none. Waiting it
+                    // out holds the shutdown past the pod's grace period, so
+                    // `host.stop()` never runs at all.
+                    let unwound = tokio::time::timeout(COMMAND_ABORT_TIMEOUT, async {
+                        while let Some(finished) = commands.join_next().await {
+                            // A panic while unwinding still matters: the task
+                            // may hold a workload id it never released.
+                            if let Err(e) = finished
+                                && !e.is_cancelled()
+                            {
+                                error!("aborted command task failed: {e}");
+                            }
+                        }
+                    })
+                    .await;
+                    if unwound.is_err() {
+                        warn!(
+                            "commands still unwinding {COMMAND_ABORT_TIMEOUT:?} after \
+                             abort; stopping the host without them"
+                        );
+                    }
+                }
+                let stopped = host.stop().await.context("failed to stop host");
+                match ended {
+                    Ended::Requested => stopped,
+                    Ended::IngressStopped => {
+                        // Stopped first either way, so the workloads unbind
+                        // cleanly; the error is what tells whoever owns this
+                        // host that it did not stop because it was asked to.
+                        stopped?;
+                        Err(anyhow!(
+                            "HTTP ingress stopped accepting connections; \
+                             the host can no longer serve traffic"
+                        ))
                     }
                 }
             }

--- a/crates/wash-runtime/tests/integration_washlet_api.rs
+++ b/crates/wash-runtime/tests/integration_washlet_api.rs
@@ -37,6 +37,7 @@ use testcontainers::{
     core::{IntoContainerPort, WaitFor},
     runners::AsyncRunner,
 };
+use wash_runtime::host::http::{DevRouter, HostHandler, Ingress};
 use wash_runtime::washlet::{
     COMMAND_DRAIN_TIMEOUT, ClusterHostBuilder, heartbeat_subject, rpc_subject, types::v2,
 };
@@ -54,6 +55,8 @@ struct TestHarness {
     /// washlet publishes on its immediate first tick.
     heartbeat_sub: async_nats::Subscriber,
     shutdown: Pin<Box<dyn Future<Output = Result<()>> + Send>>,
+    /// Present only under [`TestHarnessBuilder::with_ingress`].
+    ingress: Option<Arc<dyn HostHandler>>,
     _container: ContainerAsync<GenericImage>,
 }
 
@@ -64,6 +67,7 @@ struct TestHarness {
 struct TestHarnessBuilder {
     heartbeat_interval: Option<Duration>,
     max_concurrent_starts: Option<usize>,
+    ingress: bool,
 }
 
 impl TestHarnessBuilder {
@@ -74,6 +78,13 @@ impl TestHarnessBuilder {
 
     fn with_max_concurrent_starts(mut self, starts: usize) -> Self {
         self.max_concurrent_starts = Some(starts);
+        self
+    }
+
+    /// Give the host an HTTP ingress on an ephemeral port, kept on
+    /// [`TestHarness::ingress`] so a test can stop it out from under the host.
+    fn with_ingress(mut self) -> Self {
+        self.ingress = true;
         self
     }
 
@@ -116,6 +127,17 @@ impl TestHarnessBuilder {
         if let Some(starts) = self.max_concurrent_starts {
             builder = builder.with_max_concurrent_starts(starts);
         }
+        let mut ingress = None;
+        if self.ingress {
+            let handler = Arc::new(
+                Ingress::builder(DevRouter::default(), "127.0.0.1:0".parse()?)
+                    .build()
+                    .await
+                    .context("failed to bind the test ingress")?,
+            );
+            builder = builder.with_http_handler(Arc::clone(&handler) as Arc<dyn HostHandler>);
+            ingress = Some(handler as Arc<dyn HostHandler>);
+        }
         let cluster_host = builder.build().context("failed to build cluster host")?;
         let host_id = cluster_host.host().id().to_string();
 
@@ -140,6 +162,7 @@ impl TestHarnessBuilder {
             host_id,
             heartbeat_sub,
             shutdown: Box::pin(shutdown),
+            ingress,
             _container: container,
         };
         harness.wait_for_api().await?;
@@ -790,6 +813,110 @@ async fn heartbeat_reports_identity_and_workload_count() -> Result<()> {
     assert_eq!(refreshed.workload_count, 1);
 
     harness.shutdown().await
+}
+
+/// An ingress accept loop that ends has to end the host with it.
+///
+/// The loop is spawned detached and nothing restarts it, so a host that only
+/// logged the exit would hold every workload it was given and keep
+/// heartbeating — the operator sees a healthy host — while serving no HTTP for
+/// the rest of its life. Stopping is what gets those workloads onto a host that
+/// can serve them; they are lost either way.
+///
+/// Stopping the ingress directly is the same exit an error or a panic takes:
+/// `AcceptingGuard` drops however the loop ends.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_stopped_ingress_stops_the_host() -> Result<()> {
+    let mut harness = TestHarness::builder().with_ingress().start().await?;
+    let ingress = harness
+        .ingress
+        .clone()
+        .context("the harness was built with an ingress")?;
+
+    // Serving normally first, so what follows is the ingress dying and not a
+    // host that never came up.
+    harness.heartbeat().await?;
+    ingress.stop().await.context("failed to stop the ingress")?;
+
+    // Nothing here asks the host to shut down — awaiting the cleanup future
+    // would. It has to end on its own, and it unsubscribes from its API subject
+    // on the way out, so an unanswered request is the host gone rather than the
+    // host busy.
+    tokio::time::timeout(COMMAND_DRAIN_TIMEOUT + ABANDON_MARGIN, async {
+        loop {
+            let probe = v2::WorkloadStatusRequest {
+                workload_id: "washlet-api-e2e-ingress-probe".to_string(),
+            };
+            let answered: Result<v2::WorkloadStatusResponse> = rpc(
+                &harness.api_client,
+                harness.subject("workload.status"),
+                &probe,
+            )
+            .await;
+            if answered.is_err() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .context("the host kept serving its API after its ingress stopped accepting")?;
+
+    // Only now, so this joins the finished loop rather than racing a shutdown
+    // request against it.
+    let stopped = tokio::time::timeout(
+        COMMAND_DRAIN_TIMEOUT + ABANDON_MARGIN,
+        &mut harness.shutdown,
+    )
+    .await
+    .context("the host did not finish stopping after its ingress stopped accepting")?;
+
+    let err = stopped.expect_err("a host that lost its ingress must not report a clean stop");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("ingress"),
+        "the error has to name what ended the host, got: {message}"
+    );
+    Ok(())
+}
+
+/// A shutdown asked for at the same moment must not mask a dead ingress.
+///
+/// `wash host` watches the same accept loop, so it requests a shutdown as soon
+/// as the loop ends — both `select!` branches in the command loop go ready at
+/// once, and it picks between them at random. Reporting a clean stop for a host
+/// that lost its ingress is the one thing this must not do, and it would do it
+/// about half the time if the branch that fired were the evidence.
+#[tokio::test]
+#[ignore = "requires Docker (NATS); run with `cargo test --include-ignored`"]
+async fn a_shutdown_racing_a_dead_ingress_still_reports_the_ingress() -> Result<()> {
+    let mut harness = TestHarness::builder().with_ingress().start().await?;
+    let ingress = harness
+        .ingress
+        .clone()
+        .context("the harness was built with an ingress")?;
+
+    harness.heartbeat().await?;
+    ingress.stop().await.context("failed to stop the ingress")?;
+
+    // Deliberately no wait: awaiting the cleanup future is what asks for the
+    // shutdown, so this is the race itself rather than a test around it.
+    let stopped = tokio::time::timeout(
+        COMMAND_DRAIN_TIMEOUT + ABANDON_MARGIN,
+        &mut harness.shutdown,
+    )
+    .await
+    .context("the host did not stop after its ingress stopped accepting")?;
+
+    let err = stopped
+        .expect_err("a shutdown racing a dead ingress must still report the ingress, not success");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("ingress"),
+        "the error has to name what ended the host, got: {message}"
+    );
+    Ok(())
 }
 
 /// Shutdown waits for the commands already running — but a start stalled on an

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -1011,7 +1011,9 @@ impl CliCommand for HostCommand {
         let probe = self.probe_addr.map(|addr| {
             let mut state =
                 wash_runtime::host::probes::ProbeState::default().with_liveness(liveness);
-            if let Some(connections) = ingress_connections {
+            // Cloned, not moved: the ingress is also what this command watches
+            // for an accept loop that ends on its own, below.
+            if let Some(connections) = ingress_connections.clone() {
                 state = state.with_readiness(Arc::new(connections));
             }
             (addr, state)
@@ -1043,7 +1045,24 @@ impl CliCommand for HostCommand {
             state.started();
         }
 
-        shutdown.await;
+        // A signal is not the only way this ends. An ingress accept loop that
+        // returns stops the host from under this — every workload unbound —
+        // and waiting for a signal that is never coming would leave a live
+        // process holding nothing and serving nothing. `host_cleanup` cannot be
+        // raced here instead: awaiting it is what *asks* for the shutdown.
+        let ingress_stopped = async {
+            match &ingress_connections {
+                Some(connections) => connections.stopped().await,
+                None => std::future::pending().await,
+            }
+        };
+        let stopped_itself = tokio::select! {
+            () = shutdown => false,
+            () = ingress_stopped => {
+                tracing::error!("HTTP ingress stopped accepting connections; stopping the host");
+                true
+            }
+        };
 
         // Reported before the wait, not after: the point of the wait is that
         // the host is still serving while everything upstream learns it is
@@ -1051,7 +1070,10 @@ impl CliCommand for HostCommand {
         if let Some(state) = &probe_state {
             state.drain();
         }
-        if !self.drain_delay.is_zero() {
+        // Nothing to keep serving while the endpoint is withdrawn: the ingress
+        // that would have served it is the thing that died, and the host has
+        // already stopped itself.
+        if !stopped_itself && !self.drain_delay.is_zero() {
             info!(delay = ?self.drain_delay, "Draining...");
             tokio::time::sleep(self.drain_delay).await;
         }

--- a/crates/wash/src/cli/signal.rs
+++ b/crates/wash/src/cli/signal.rs
@@ -1,10 +1,10 @@
 //! Shutdown signals for the commands that run until they are told to stop.
 
 use std::future::Future;
-use std::time::Duration;
 
 use anyhow::Context as _;
 use tokio::sync::oneshot;
+use wash_runtime::observability::{FLUSH_BUDGET, flush_within};
 
 /// What a process leaving on the signal it was given exits with.
 const INTERRUPTED: i32 = 130;
@@ -16,22 +16,14 @@ pub struct Shutdown {
     ready: oneshot::Sender<()>,
 }
 
-/// What a signal will wait for the OTel exporters before leaving without them.
-///
-/// Only ever spent when an exporter was configured. The host's termination
-/// grace period is 15s and `Host::stop` needs most of it, so this cannot be the
-/// SDK's own 5s-per-provider budget.
-const FLUSH_BUDGET: Duration = Duration::from_secs(2);
-
 /// Ends this process, giving the OTel exporters a bounded chance to hand over
 /// what they were still batching — the spans and logs that say what the signal
 /// interrupted.
 ///
-/// `flush` blocks, so it goes to a blocking thread: the OTLP exporter drains
-/// over a connection this runtime has to keep polling.
+/// Ending the process is this binary's own decision, so it stays here; how long
+/// the exporters get, and why, belongs to the runtime that configured them.
 async fn exit(code: i32) -> ! {
-    let flushed = tokio::task::spawn_blocking(wash_runtime::observability::flush);
-    if tokio::time::timeout(FLUSH_BUDGET, flushed).await.is_err() {
+    if !flush_within(FLUSH_BUDGET).await {
         eprintln!("observability did not flush within {FLUSH_BUDGET:?}; exiting without it");
     }
     std::process::exit(code)


### PR DESCRIPTION
Stacks on #5536 

Follow-ups from embedding `wash-runtime` in a downstream host.

- Fixes an ingress race. When a shutdown arrived at the same instant as a select on ingress, we didn't handle it. Now it no longer reports a dead ingress as a clean exit. http_ingress_stopped is now described as the backstop for an embedded runtime, since wash host drains and exits before a /livez poll could surface it.
- flush_within the bounded OTel flush moved out of the wash binary into wash-runtime as FLUSH_BUDGET plus an async flush_within, so an embedder gets the two-second budget and the spawn_blocking reasoning instead of copying both.
- tokio features wash-runtime uses time, rt, fs and io-util throughout but did not declare them. This is similar to an earlier change made for wasmtime.  We were getting these transitively from tokio-util, async-nats and hyper-util.