### PR TITLE
feat: plugin dispatch target

### DIFF
--- a/crates/wash-runtime/src/engine/dispatch.rs
+++ b/crates/wash-runtime/src/engine/dispatch.rs
@@ -16,9 +16,10 @@
 //!    — in which case the call runs on one of them, alongside whatever that
 //!    instance already has in flight, exactly as an inbound HTTP request or a
 //!    call from another component does (see the `instance_pool` module).
-//!    That is what makes `poolSize`/`maxConcurrency` mean something here: a
-//!    burst of dispatches fans out across the warm set rather than paying for a
-//!    store apiece.
+//!    That is what makes `poolSize`, `maxInvocations` and `maxConcurrency` mean
+//!    something here: a burst of dispatches fans out across the warm set rather
+//!    than paying for a store apiece, and an instance that has served its
+//!    budget is replaced under the plugin without it noticing.
 //!  * a **service** is the workload's one long-lived instance and is never
 //!    instantiated again. Its calls are delivered to the instance that is
 //!    already running, over the ingress its trigger-service driver serves (see
@@ -30,6 +31,14 @@
 //! being driven under. A plugin therefore keeps using its generated bindings
 //! for the call itself — the host decides *where* the call runs, not *what* it
 //! is — and carries results back over a channel of its own.
+//!
+//! Everything a shared instance owes a call it did not build is the host's, and
+//! is why a plugin dispatching here behaves better than one keeping a warm set
+//! of its own: the epoch deadline is re-armed so it measures the call rather
+//! than the instance's whole life, the call is registered with its store's
+//! abandonment set for as long as it runs, it is bounded by
+//! [`GuestCall::deadline`], an instance it leaves in an indeterminate state is
+//! retired, and its guest execution is recorded under the plugin that drove it.
 //!
 //! [`HostPlugin::on_workload_resolved`]: crate::plugin::HostPlugin::on_workload_resolved
 
@@ -43,7 +52,7 @@ use tokio_util::task::AbortOnDropHandle;
 use wasmtime::component::{Accessor, AccessorTask, Instance, InstancePre};
 
 use crate::engine::ctx::SharedCtx;
-use crate::engine::instance_driver::{InstanceJob, PoolSlot};
+use crate::engine::instance_driver::{InstanceJob, InvocationSample, PoolSlot};
 use crate::engine::instance_pool::{self, ComponentInstance, Declined, InstancePool};
 use crate::engine::workload::ResolvedWorkload;
 
@@ -54,16 +63,32 @@ use crate::engine::workload::ResolvedWorkload;
 pub(crate) const INGRESS_BACKLOG: usize = 256;
 
 /// A future borrowing the accessor a [`GuestCall`] was handed.
-pub type GuestCallFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+pub type GuestCallFuture<'a> = Pin<Box<dyn Future<Output = GuestCallOutcome> + Send + 'a>>;
+
+/// What a [`GuestCall`] reports back to the host.
+///
+///  * `Ok(None)` — the guest ran and answered. Whatever it answered is the
+///    plugin's to interpret and to report on its own channel.
+///  * `Ok(Some(label))` — the guest ran and answered with a failure the plugin
+///    counts as one: a handler returning its interface's own error. `label` is
+///    what the call is recorded under, and must be a short bounded name (the
+///    host uses `trap` and `timeout`), never anything a caller supplies.
+///  * `Err` — the call did not complete, so a pooled instance that was serving
+///    it is retired rather than left holding guest state no one can account
+///    for.
+pub type GuestCallOutcome = anyhow::Result<Option<&'static str>>;
 
 /// Work a host plugin runs on a live instance of a workload item.
 ///
 /// The host resolves the instance — a warm one, one built for this call, or the
-/// running service — and drives its store; the call itself is the plugin's,
-/// made through whatever bindings it generated for the interface:
+/// running service — drives its store, and owns everything a shared instance
+/// needs around the call: the epoch deadline is re-armed so it measures this
+/// call rather than the instance's whole life, the call is registered with the
+/// store's abandonment set for as long as it runs, it is bounded by
+/// [`Self::deadline`], and its guest execution is recorded. The call itself is
+/// the plugin's, made through whatever bindings it generated for the interface:
 ///
 /// ```no_run
-/// # use std::sync::Arc;
 /// # use wasmtime::component::{Accessor, Instance};
 /// # use wash_runtime::engine::ctx::SharedCtx;
 /// # use wash_runtime::engine::dispatch::{GuestCall, GuestCallFuture};
@@ -71,14 +96,18 @@ pub type GuestCallFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> +
 /// # struct Handler;
 /// # impl Handler {
 /// #     fn new(_: &mut impl wasmtime::AsContextMut, _: &Instance) -> anyhow::Result<Self> { todo!() }
-/// #     async fn call_handle(&self, _: &Accessor<SharedCtx>, _: Records) -> anyhow::Result<()> { todo!() }
+/// #     async fn call_handle(&self, _: &Accessor<SharedCtx>, _: Records) -> anyhow::Result<Result<(), String>> { todo!() }
 /// # }
 /// struct Deliver {
 ///     records: Records,
-///     reply: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+///     reply: tokio::sync::oneshot::Sender<anyhow::Result<Result<(), String>>>,
 /// }
 ///
 /// impl GuestCall for Deliver {
+///     fn describe(&self) -> &str {
+///         "acme:events/handler#handle"
+///     }
+///
 ///     fn call<'a>(
 ///         self: Box<Self>,
 ///         accessor: &'a Accessor<SharedCtx>,
@@ -86,22 +115,36 @@ pub type GuestCallFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> +
 ///     ) -> GuestCallFuture<'a> {
 ///         Box::pin(async move {
 ///             let handler = accessor.with(|mut access| Handler::new(&mut access, &instance))?;
-///             let outcome = handler.call_handle(accessor, self.records).await;
-///             let _ = self.reply.send(outcome);
-///             Ok(())
+///             let answered = handler.call_handle(accessor, self.records).await?;
+///             let refused = answered.is_err().then_some("handler");
+///             let _ = self.reply.send(Ok(answered));
+///             Ok(refused)
 ///         })
 ///     }
 /// }
 /// ```
-///
-/// # Errors
-///
-/// The `Err` a call returns is reported to whoever dispatched it, and means the
-/// call did not complete: a pooled instance that was serving it is retired
-/// rather than left holding guest state no one can account for. A guest that
-/// answers with its interface's own error type has *completed* — report that
-/// through the plugin's own channel, as above, and return `Ok`.
 pub trait GuestCall: Send + 'static {
+    /// Names this call in the host's log lines, and is the `operation` its
+    /// guest execution is recorded under.
+    ///
+    /// The WIT export being invoked, so it is bounded by the interface set a
+    /// component declares — one metric series per export, never one per
+    /// message.
+    fn describe(&self) -> &str;
+
+    /// How long the host waits for the guest before it stops wanting the
+    /// result and retires the instance serving it.
+    ///
+    /// The default is the host's own ephemeral-call timeout, which is generous
+    /// enough for a batch handler. It exists at all because a guest subtask
+    /// cannot be cancelled from the host: on a *shared* instance — a warm one,
+    /// or the service — a call that never returns would otherwise hold its
+    /// in-flight slot for the life of the workload, and retiring the instance
+    /// is what ends it.
+    fn deadline(&self) -> std::time::Duration {
+        crate::timeouts::ephemeral_call()
+    }
+
     /// Run this call on `instance`, under the store `accessor` is driving.
     fn call<'a>(
         self: Box<Self>,
@@ -110,14 +153,72 @@ pub trait GuestCall: Send + 'static {
     ) -> GuestCallFuture<'a>;
 }
 
-/// A [`GuestCall`] with the channel its outcome goes back on, as it travels to
-/// the instance that will serve it.
+/// A [`GuestCall`] as it travels to the instance that will serve it: the
+/// channel its outcome goes back on, the flag its dispatcher arms when it stops
+/// wanting the result, and what its guest execution is recorded under.
 ///
 /// Opaque: a job is minted by [`DispatchTarget::dispatch`] and is only ever
 /// handed to the instance that runs it.
 pub struct GuestJob {
     call: Box<dyn GuestCall>,
     reply: oneshot::Sender<anyhow::Result<()>>,
+    /// The abandonment flag of the dispatched call enforcing this job's
+    /// deadline (see [`crate::engine::abandon`]).
+    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+    /// Built where the target was resolved: the identity a dispatched call is
+    /// measured under cannot change under a resolved workload, and resolving it
+    /// costs a read lock.
+    attributes: Arc<[opentelemetry::KeyValue]>,
+}
+
+impl GuestJob {
+    /// Mint a job for a dispatcher that runs the pool dance itself rather than
+    /// through a [`DispatchTarget`] — the `wasmcloud:nats` subscriber, whose
+    /// deliveries carry a cancellation of their own.
+    ///
+    /// `abandoned` comes from the [`DispatchedCall`] enforcing this job's
+    /// deadline, which is what makes the field proof that some dispatcher does.
+    ///
+    /// [`DispatchedCall`]: crate::engine::abandon::DispatchedCall
+    pub(crate) fn new(
+        call: Box<dyn GuestCall>,
+        reply: oneshot::Sender<anyhow::Result<()>>,
+        abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+        attributes: Arc<[opentelemetry::KeyValue]>,
+    ) -> Self {
+        Self {
+            call,
+            reply,
+            abandoned,
+            attributes,
+        }
+    }
+
+    /// Run this job on an instance in a store built for it alone, and answer
+    /// what it did.
+    ///
+    /// The outcome is returned rather than sent on the job's reply channel: the
+    /// dispatcher is right here awaiting this future, so there is nothing to
+    /// deliver it to. The store is dropped with the call, so there is no pooled
+    /// instance to retire either — what the call leaves behind goes with it.
+    pub(crate) async fn run_on_store(
+        self,
+        store: &mut wasmtime::Store<SharedCtx>,
+        instance: Instance,
+    ) -> anyhow::Result<()> {
+        let GuestJob {
+            call,
+            reply: _,
+            abandoned,
+            attributes,
+        } = self;
+        store
+            .run_concurrent(async move |accessor| {
+                serve(accessor, instance, call, abandoned, attributes, None).await
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("dispatched call store faulted: {e:#}"))?
+    }
 }
 
 /// Serves one plugin-dispatched call on an instance: the workload's service, or
@@ -133,7 +234,8 @@ pub struct GuestJob {
 pub(crate) struct GuestTask {
     pub(crate) instance: Instance,
     pub(crate) job: GuestJob,
-    /// This call's tether to a pooled instance. `None` for a service.
+    /// This call's tether to a pooled instance. `None` for a service, and for a
+    /// store built to serve this call alone.
     pub(crate) pool_slot: Option<PoolSlot>,
 }
 
@@ -144,21 +246,102 @@ impl AccessorTask<SharedCtx> for GuestTask {
             job,
             pool_slot,
         } = self;
-        let GuestJob { call, reply } = job;
-        let outcome = call.call(accessor, instance).await;
-        if let Err(e) = &outcome
-            && let Some(slot) = &pool_slot
-        {
-            tracing::warn!(
-                err = ?e,
-                "dispatched call failed; retiring the instance that served it"
-            );
-            slot.retire_instance();
-        }
+        let GuestJob {
+            call,
+            reply,
+            abandoned,
+            attributes,
+        } = job;
+        let outcome = serve(accessor, instance, call, abandoned, attributes, pool_slot).await;
         // The dispatcher may have gone; the call still ran, because a guest
         // subtask cannot be cancelled from the host.
         let _ = reply.send(outcome);
         Ok(())
+    }
+}
+
+/// Run one dispatched call on `instance`, under everything a store owes a call
+/// it did not build itself: the epoch deadline re-armed so it measures this
+/// call rather than the instance's whole life, the call registered with the
+/// store's abandonment set for as long as it runs, its own deadline, and the
+/// record of what it cost.
+///
+/// `pool_slot` is the call's tether to a warm instance, and `None` for an
+/// instance nothing else will use — the service's, which is not the pool's to
+/// retire, and a store built for this call alone, which is dropped either way.
+async fn serve(
+    accessor: &Accessor<SharedCtx>,
+    instance: Instance,
+    call: Box<dyn GuestCall>,
+    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
+    pool_slot: Option<PoolSlot>,
+) -> anyhow::Result<()> {
+    let what = Arc::<str>::from(call.describe());
+    let deadline = call.deadline();
+
+    // Re-armed here, and registered below, rather than left to the plugin: the
+    // instance it dispatches to is one it shares with calls it cannot see.
+    let (calls, executed) = accessor.with(|mut access| {
+        crate::engine::abandon::rearm_for_call(&mut access);
+        (
+            Arc::clone(&access.get().abandoned),
+            Arc::clone(&access.get().executed),
+        )
+    });
+    let mut sample = InvocationSample::start(&executed, attributes);
+
+    // This bound ends the wait of a dispatcher that is still there; keeping a
+    // slow guest out of the epoch callback's reach is `watch_until_abandoned`'s
+    // job.
+    match tokio::time::timeout(
+        deadline,
+        crate::engine::abandon::watch_until_abandoned(
+            &calls,
+            abandoned,
+            call.call(accessor, instance),
+        ),
+    )
+    .await
+    {
+        Ok(Ok(refused)) => {
+            if let Some(label) = refused {
+                sample.failed(label);
+            }
+            Ok(())
+        }
+        // A host failure mid-call leaves guest state indeterminate.
+        Ok(Err(e)) => {
+            sample.failed("trap");
+            tracing::warn!(
+                err = ?e,
+                what = %what,
+                "dispatched call failed; retiring the instance that served it"
+            );
+            if let Some(slot) = &pool_slot {
+                slot.retire_instance();
+            }
+            Err(e)
+        }
+        // A guest subtask cannot be cancelled from the host, so the timed out
+        // work is still running on this store. Retiring the instance is what
+        // ends it: the driver stops admitting, drains, ends its run loop, and
+        // the store's teardown takes the stalled work with it.
+        Err(_) => {
+            sample.failed("timeout");
+            tracing::warn!(
+                what = %what,
+                ?deadline,
+                "dispatched call did not return within its deadline; retiring the instance \
+                 that served it"
+            );
+            if let Some(slot) = &pool_slot {
+                slot.retire_instance();
+            }
+            Err(anyhow::anyhow!(
+                "dispatched call '{what}' did not return within {deadline:?}"
+            ))
+        }
     }
 }
 
@@ -350,6 +533,40 @@ impl Drop for ServiceClaim {
 pub struct DispatchTarget {
     workload: Arc<ResolvedWorkload>,
     item: TargetItem,
+    /// What this item's guest execution is recorded under. Resolved with the
+    /// target rather than per call: the identity costs a read lock and cannot
+    /// change under a resolved workload, and the attribute set is rebuilt only
+    /// when a call names an operation this target has not carried before.
+    metrics: Arc<DispatchMetrics>,
+}
+
+/// The attribute sets a target's dispatches are recorded under, one per
+/// operation.
+///
+/// Keyed by [`GuestCall::describe`], which names a WIT export, so the map is
+/// bounded by the interface set the item declares — never by traffic. Built
+/// lazily because a target learns its operations only from the calls that
+/// arrive on it, and cached because rebuilding a set costs the vector and five
+/// strings on a delivery hot path to arrive at the same answer every time.
+struct DispatchMetrics {
+    identity: crate::observability::WorkloadIdentity,
+    plugin: &'static str,
+    by_operation: Mutex<std::collections::BTreeMap<Arc<str>, Arc<[opentelemetry::KeyValue]>>>,
+}
+
+impl DispatchMetrics {
+    fn attributes(&self, operation: &str) -> Arc<[opentelemetry::KeyValue]> {
+        let mut cached = self
+            .by_operation
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(attributes) = cached.get(operation) {
+            return Arc::clone(attributes);
+        }
+        let attributes = self.identity.attributes(self.plugin, operation);
+        cached.insert(Arc::from(operation), Arc::clone(&attributes));
+        attributes
+    }
 }
 
 #[derive(Clone)]
@@ -394,6 +611,7 @@ impl DispatchTarget {
     pub(crate) async fn resolve(
         workload: &ResolvedWorkload,
         item_id: &str,
+        plugin: &'static str,
     ) -> anyhow::Result<Self> {
         let item = if workload.is_service_item(item_id) {
             // Asked for by name, so a service that can never serve a dispatched
@@ -403,12 +621,18 @@ impl DispatchTarget {
             let (id, pre, pool) = workload.component_dispatch(item_id).await?;
             TargetItem::Component { id, pre, pool }
         };
+        let metrics = Arc::new(DispatchMetrics {
+            identity: workload.component_identity(item_id).await,
+            plugin,
+            by_operation: Mutex::default(),
+        });
         Ok(Self {
             // Copied once per target: cloning a `ResolvedWorkload` copies the
             // service's `Linker` by value, so it is worth paying here rather
             // than on every clone of the target.
             workload: Arc::new(workload.clone()),
             item,
+            metrics,
         })
     }
 
@@ -426,14 +650,14 @@ impl DispatchTarget {
     ///
     /// # How long it may take
     ///
-    /// No host timeout bounds the call: the host cannot know what the plugin
-    /// asked the guest to do, and a batch handler that takes minutes is the
-    /// point of this interface. A caller that wants a deadline imposes its own
-    /// by dropping this future, which reclaims a store built for the call alone.
-    /// It cannot end guest work already running on a *shared* instance, though —
-    /// a warm one or the service — because a guest subtask cannot be cancelled
-    /// from the host: that call runs to completion on the instance, with nowhere
-    /// left to report its outcome.
+    /// Up to the call's own [`GuestCall::deadline`], which defaults to the
+    /// host's ephemeral-call timeout — long enough for a batch handler, and
+    /// bounded because a call on a *shared* instance that never returns would
+    /// otherwise hold its in-flight slot for the life of the workload. Dropping
+    /// this future gives up on the result sooner and reclaims a store built for
+    /// the call alone; it cannot end guest work already running on a warm
+    /// instance or the service, because a guest subtask cannot be cancelled
+    /// from the host.
     ///
     /// [module docs]: self
     pub async fn dispatch(&self, call: impl GuestCall) -> anyhow::Result<()> {
@@ -447,12 +671,16 @@ impl DispatchTarget {
                 self.workload.id()
             );
         }
-        let call = Box::new(call);
+        let call: Box<dyn GuestCall> = Box::new(call);
+        let attributes = self.metrics.attributes(call.describe());
         match &self.item {
             TargetItem::Component { id, pre, pool } => {
-                dispatch_to_component(&self.workload, id, pre, pool.as_ref(), call).await
+                dispatch_to_component(&self.workload, id, pre, pool.as_ref(), call, attributes)
+                    .await
             }
-            TargetItem::Service(claim) => dispatch_to_service(claim.calls(), call).await,
+            TargetItem::Service(claim) => {
+                dispatch_to_service(claim.calls(), call, attributes).await
+            }
         }
     }
 }
@@ -461,17 +689,16 @@ impl DispatchTarget {
 pub(crate) async fn dispatch_to_service(
     calls: &ServiceCalls,
     call: Box<dyn GuestCall>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
 ) -> anyhow::Result<()> {
     let tx = calls
         .sender()
         .context("the workload's service is not accepting dispatched calls")?;
-    let (reply, reply_rx) = oneshot::channel();
-    tx.send(GuestJob { call, reply })
+    let (job, reply_rx, dispatched) = mint(call, attributes);
+    tx.send(job)
         .await
         .map_err(|_| anyhow::anyhow!("the workload's service is no longer running"))?;
-    reply_rx
-        .await
-        .map_err(|_| anyhow::anyhow!("the workload's service dropped the dispatched call"))?
+    await_outcome(dispatched, reply_rx).await
 }
 
 /// Run a call on `component_id`: on one of its warm instances when it keeps
@@ -483,23 +710,22 @@ async fn dispatch_to_component(
     pre: &InstancePre<SharedCtx>,
     pool: Option<&Arc<InstancePool>>,
     call: Box<dyn GuestCall>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
 ) -> anyhow::Result<()> {
+    let (job, reply_rx, dispatched) = mint(call, attributes);
     // An instance built for a pool that then declined the call: the store of
     // its own below is that instance, rather than a second one beside it.
     let mut reclaimed = None;
-    let call = if let Some(pool) = pool {
-        let (reply, reply_rx) = oneshot::channel();
-        let job = InstanceJob::Guest(GuestJob { call, reply });
-        let outcome =
-            instance_pool::offer_or_install(pool, pre, job, || workload.new_store(component_id))
-                .await?;
+    let job = if let Some(pool) = pool {
+        let outcome = instance_pool::offer_or_install(pool, pre, InstanceJob::Guest(job), || {
+            workload.new_store(component_id)
+        })
+        .await?;
         match outcome {
-            Ok(()) => {
-                return reply_rx
-                    .await
-                    .map_err(|_| anyhow::anyhow!("pooled instance dropped the dispatched call"))?;
-            }
-            // Every warm instance was busy; run it in a store of its own.
+            Ok(()) => return await_outcome(dispatched, reply_rx).await,
+            // Every warm instance was busy; run the very same job in a store of
+            // its own, so neither its payload nor an instantiation is paid for
+            // twice.
             Err(Declined {
                 job: InstanceJob::Guest(job),
                 instance,
@@ -509,7 +735,7 @@ async fn dispatch_to_component(
                     "warm instances saturated; dispatching to a store of its own"
                 );
                 reclaimed = instance;
-                job.call
+                job
             }
             // A job comes back as the variant it went in as, so this is
             // unreachable — but not worth a panic on a dispatch path.
@@ -519,7 +745,7 @@ async fn dispatch_to_component(
             }
         }
     } else {
-        call
+        job
     };
 
     let ComponentInstance {
@@ -534,14 +760,53 @@ async fn dispatch_to_component(
         }
     };
     // The store travels into the task, so a dispatcher cancelled mid-call drops
-    // it with the task rather than leaving it running.
-    let mut task = AbortOnDropHandle::new(tokio::spawn(async move {
-        store
-            .run_concurrent(async move |accessor| call.call(accessor, instance).await)
-            .await
-            .map_err(|e| anyhow::anyhow!("dispatched call store faulted: {e:#}"))?
+    // it with the task rather than leaving it running. The task's own result is
+    // the call's outcome, so `reply_rx` has nothing to carry here.
+    drop(reply_rx);
+    let task = AbortOnDropHandle::new(tokio::spawn(async move {
+        job.run_on_store(&mut store, instance).await
     }));
-    (&mut task).await.context("dispatched call task failed")?
+    dispatched
+        .await_reply(task)
+        .await
+        .context("dispatched call produced no outcome within its deadline")?
+        .context("dispatched call task failed")?
+}
+
+/// A job and what its dispatcher waits on: the outcome channel, and the
+/// [`DispatchedCall`] enforcing the call's own deadline.
+///
+/// The deadline is enforced out here, in the dispatcher's task, as well as
+/// inside the callee's store — a non-yielding guest can block the store-side
+/// timer but not this one (see [`crate::engine::abandon`]).
+///
+/// [`DispatchedCall`]: crate::engine::abandon::DispatchedCall
+fn mint(
+    call: Box<dyn GuestCall>,
+    attributes: Arc<[opentelemetry::KeyValue]>,
+) -> (
+    GuestJob,
+    oneshot::Receiver<anyhow::Result<()>>,
+    crate::engine::abandon::DispatchedCall,
+) {
+    let dispatched =
+        crate::engine::abandon::DispatchedCall::new("plugin dispatch", call.deadline());
+    let (reply, reply_rx) = oneshot::channel();
+    let job = GuestJob::new(call, reply, dispatched.flag(), attributes);
+    (job, reply_rx, dispatched)
+}
+
+/// Wait for a call already handed to an instance the dispatcher does not own —
+/// a warm one, or the service — and report what it did.
+async fn await_outcome(
+    dispatched: crate::engine::abandon::DispatchedCall,
+    reply_rx: oneshot::Receiver<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    dispatched
+        .await_reply(reply_rx)
+        .await
+        .context("dispatched call produced no outcome within its deadline")?
+        .map_err(|_| anyhow::anyhow!("the instance serving the dispatched call went away"))?
 }
 
 #[cfg(test)]

--- a/crates/wash-runtime/src/engine/dispatch.rs
+++ b/crates/wash-runtime/src/engine/dispatch.rs
@@ -58,8 +58,14 @@ use crate::engine::workload::ResolvedWorkload;
 
 /// Invocations one of a service's ingresses may have queued before its driver
 /// takes them — dispatched calls here, and the HTTP and messaging ingresses
-/// built beside them (see `build_trigger_ingresses`). A dispatcher that fills it
-/// waits, which is the back-pressure a plugin reading an external stream wants.
+/// built beside them (see `build_trigger_ingresses`).
+///
+/// This bounds the queue, not the work: the serve loop takes a job and spawns it
+/// straight away, so the channel only fills while the driver itself is stalled.
+/// What bounds concurrent calls on a service's one instance is
+/// [`MAX_INFLIGHT_GUEST_CALLS`].
+///
+/// [`MAX_INFLIGHT_GUEST_CALLS`]: crate::host::trigger_service::MAX_INFLIGHT_GUEST_CALLS
 pub(crate) const INGRESS_BACKLOG: usize = 256;
 
 /// A future borrowing the accessor a [`GuestCall`] was handed.
@@ -192,6 +198,15 @@ impl GuestJob {
             abandoned,
             attributes,
         }
+    }
+
+    /// Turn this job away without running it, and tell its dispatcher why.
+    ///
+    /// For an ingress at its ceiling: a dispatcher waiting on a call the host
+    /// will not admit has to be told, or it waits out the call's whole deadline
+    /// for a reply that was never coming.
+    pub(crate) fn refuse(self, err: anyhow::Error) {
+        let _ = self.reply.send(Err(err));
     }
 
     /// Run this job on an instance in a store built for it alone, and answer
@@ -496,19 +511,6 @@ impl ServiceClaim {
             .swap(true, std::sync::atomic::Ordering::SeqCst)
         {
             self.calls.release_claim();
-        }
-    }
-}
-
-impl Clone for ServiceClaim {
-    /// A copy of a claim is a claim of its own, so the ingress outlives whichever
-    /// of them is dropped first. Never refused: an existing claim is proof the
-    /// service was claimed in time, whatever it has done since.
-    fn clone(&self) -> Self {
-        self.calls.lock().claims += 1;
-        Self {
-            calls: Arc::clone(&self.calls),
-            released: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }

--- a/crates/wash-runtime/src/engine/dispatch.rs
+++ b/crates/wash-runtime/src/engine/dispatch.rs
@@ -1,0 +1,672 @@
+//! Plugin-initiated dispatch: a host plugin running work on a workload's own
+//! guest code.
+//!
+//! This is the direction a *push-mode* capability runs in. A plugin that serves
+//! an interface waits to be called; a plugin that consumes an external event
+//! stream — a broker subscription, a topic partition, a timer — has to call
+//! *into* the workload instead, on whichever of its items exports the interface
+//! the plugin drives.
+//!
+//! A plugin resolves one [`DispatchTarget`] per item it will call, once, while
+//! the workload resolves ([`HostPlugin::on_workload_resolved`]), and dispatches
+//! through it for as long as the workload is up. The target hides which shape
+//! the item is, because the two are reached in genuinely different ways:
+//!
+//!  * a **component** is instantiated per call, unless it keeps instances warm
+//!    — in which case the call runs on one of them, alongside whatever that
+//!    instance already has in flight, exactly as an inbound HTTP request or a
+//!    call from another component does (see the `instance_pool` module).
+//!    That is what makes `poolSize`/`maxConcurrency` mean something here: a
+//!    burst of dispatches fans out across the warm set rather than paying for a
+//!    store apiece.
+//!  * a **service** is the workload's one long-lived instance and is never
+//!    instantiated again. Its calls are delivered to the instance that is
+//!    already running, over the ingress its trigger-service driver serves (see
+//!    [`crate::host::trigger_service`]), so they share the state the service
+//!    has built up — which is the entire reason to write a handler as a service.
+//!
+//! The unit of dispatch is a [`GuestCall`]: the plugin's own code, run on the
+//! instance the host picked, with the [`Accessor`] that instance's store is
+//! being driven under. A plugin therefore keeps using its generated bindings
+//! for the call itself — the host decides *where* the call runs, not *what* it
+//! is — and carries results back over a channel of its own.
+//!
+//! [`HostPlugin::on_workload_resolved`]: crate::plugin::HostPlugin::on_workload_resolved
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use anyhow::{Context as _, bail};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::task::AbortOnDropHandle;
+use wasmtime::component::{Accessor, AccessorTask, Instance, InstancePre};
+
+use crate::engine::ctx::SharedCtx;
+use crate::engine::instance_driver::{InstanceJob, PoolSlot};
+use crate::engine::instance_pool::{self, ComponentInstance, Declined, InstancePool};
+use crate::engine::workload::ResolvedWorkload;
+
+/// Invocations one of a service's ingresses may have queued before its driver
+/// takes them — dispatched calls here, and the HTTP and messaging ingresses
+/// built beside them (see `build_trigger_ingresses`). A dispatcher that fills it
+/// waits, which is the back-pressure a plugin reading an external stream wants.
+pub(crate) const INGRESS_BACKLOG: usize = 256;
+
+/// A future borrowing the accessor a [`GuestCall`] was handed.
+pub type GuestCallFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+/// Work a host plugin runs on a live instance of a workload item.
+///
+/// The host resolves the instance — a warm one, one built for this call, or the
+/// running service — and drives its store; the call itself is the plugin's,
+/// made through whatever bindings it generated for the interface:
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use wasmtime::component::{Accessor, Instance};
+/// # use wash_runtime::engine::ctx::SharedCtx;
+/// # use wash_runtime::engine::dispatch::{GuestCall, GuestCallFuture};
+/// # struct Records;
+/// # struct Handler;
+/// # impl Handler {
+/// #     fn new(_: &mut impl wasmtime::AsContextMut, _: &Instance) -> anyhow::Result<Self> { todo!() }
+/// #     async fn call_handle(&self, _: &Accessor<SharedCtx>, _: Records) -> anyhow::Result<()> { todo!() }
+/// # }
+/// struct Deliver {
+///     records: Records,
+///     reply: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+/// }
+///
+/// impl GuestCall for Deliver {
+///     fn call<'a>(
+///         self: Box<Self>,
+///         accessor: &'a Accessor<SharedCtx>,
+///         instance: Instance,
+///     ) -> GuestCallFuture<'a> {
+///         Box::pin(async move {
+///             let handler = accessor.with(|mut access| Handler::new(&mut access, &instance))?;
+///             let outcome = handler.call_handle(accessor, self.records).await;
+///             let _ = self.reply.send(outcome);
+///             Ok(())
+///         })
+///     }
+/// }
+/// ```
+///
+/// # Errors
+///
+/// The `Err` a call returns is reported to whoever dispatched it, and means the
+/// call did not complete: a pooled instance that was serving it is retired
+/// rather than left holding guest state no one can account for. A guest that
+/// answers with its interface's own error type has *completed* — report that
+/// through the plugin's own channel, as above, and return `Ok`.
+pub trait GuestCall: Send + 'static {
+    /// Run this call on `instance`, under the store `accessor` is driving.
+    fn call<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: Instance,
+    ) -> GuestCallFuture<'a>;
+}
+
+/// A [`GuestCall`] with the channel its outcome goes back on, as it travels to
+/// the instance that will serve it.
+///
+/// Opaque: a job is minted by [`DispatchTarget::dispatch`] and is only ever
+/// handed to the instance that runs it.
+pub struct GuestJob {
+    call: Box<dyn GuestCall>,
+    reply: oneshot::Sender<anyhow::Result<()>>,
+}
+
+/// Serves one plugin-dispatched call on an instance: the workload's service, or
+/// one warm instance of a pooled component.
+///
+/// A call that fails retires the pooled instance it ran on. The host cannot know
+/// what the plugin's call left behind — a timed-out guest task is still running
+/// on that store, and a host-side failure mid-call leaves guest state
+/// indeterminate — so the instance drains and its store drops rather than
+/// serving anything else. A service's singleton instance is not the pool's to
+/// retire, so it keeps serving; a guest *trap* faults its store either way, and
+/// the supervisor restarts it.
+pub(crate) struct GuestTask {
+    pub(crate) instance: Instance,
+    pub(crate) job: GuestJob,
+    /// This call's tether to a pooled instance. `None` for a service.
+    pub(crate) pool_slot: Option<PoolSlot>,
+}
+
+impl AccessorTask<SharedCtx> for GuestTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        let GuestTask {
+            instance,
+            job,
+            pool_slot,
+        } = self;
+        let GuestJob { call, reply } = job;
+        let outcome = call.call(accessor, instance).await;
+        if let Err(e) = &outcome
+            && let Some(slot) = &pool_slot
+        {
+            tracing::warn!(
+                err = ?e,
+                "dispatched call failed; retiring the instance that served it"
+            );
+            slot.retire_instance();
+        }
+        // The dispatcher may have gone; the call still ran, because a guest
+        // subtask cannot be cancelled from the host.
+        let _ = reply.send(outcome);
+        Ok(())
+    }
+}
+
+/// The ingress a workload's service serves plugin-dispatched calls on.
+///
+/// One per workload, shared by every plugin that dispatches to its service, and
+/// rebuilt per incarnation: a restarted service is a new instance with a new
+/// channel, and the sender held here is swapped for it, exactly as the
+/// host-invoked ingresses beside it are re-registered.
+///
+/// The channel is created when a plugin *claims* the service, during resolve,
+/// rather than when the service starts — so a plugin that begins dispatching
+/// the moment it is told the workload resolved queues those calls instead of
+/// finding nothing to send them to.
+#[derive(Default)]
+pub(crate) struct ServiceCalls {
+    state: Mutex<ServiceCallState>,
+}
+
+#[derive(Default)]
+struct ServiceCallState {
+    /// Sender for the incarnation now running, or for the queue waiting on the
+    /// first one. `None` until a plugin claims the service.
+    tx: Option<mpsc::Sender<GuestJob>>,
+    /// The receiver the next incarnation takes. Holds the claim-time queue
+    /// until the service first starts.
+    rx: Option<mpsc::Receiver<GuestJob>>,
+    /// Live claims. The ingress exists while there is at least one, so a claim
+    /// taken speculatively — a host component plugin resolving a route it may
+    /// then discard in favour of a component's — leaves nothing behind when it
+    /// goes.
+    claims: usize,
+    /// Whether the service has started. A claim after that cannot be served:
+    /// its ingress would have to be added to a driver that is already running.
+    started: bool,
+}
+
+impl ServiceCalls {
+    fn lock(&self) -> std::sync::MutexGuard<'_, ServiceCallState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Claim the service as a dispatch target, creating its ingress if this is
+    /// the first claim. Several claims share the one ingress, which lasts as
+    /// long as the last of them.
+    pub(crate) fn claim(self: &Arc<Self>) -> anyhow::Result<ServiceClaim> {
+        let mut state = self.lock();
+        if state.started {
+            bail!(
+                "the workload's service is already running, so it cannot be claimed as a \
+                 dispatch target; resolve the target while the workload resolves"
+            );
+        }
+        if state.tx.is_none() {
+            let (tx, rx) = mpsc::channel(INGRESS_BACKLOG);
+            state.tx = Some(tx);
+            state.rx = Some(rx);
+        }
+        state.claims += 1;
+        Ok(ServiceClaim {
+            calls: Arc::clone(self),
+            released: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    /// Give one claim back. The ingress goes with the last of them, but only
+    /// while the service has yet to start: once it is running with one, closing
+    /// the channel would end its driver, and a plugin letting go of a target is
+    /// no reason to stop the service.
+    fn release_claim(&self) {
+        let mut state = self.lock();
+        state.claims = state.claims.saturating_sub(1);
+        if state.claims == 0 && !state.started {
+            state.tx = None;
+            state.rx = None;
+        }
+    }
+
+    /// Whether any plugin claimed this service, and so whether it has to be run
+    /// with an ingress to serve them.
+    pub(crate) fn claimed(&self) -> bool {
+        self.lock().tx.is_some()
+    }
+
+    /// Record that the service is starting, whichever way it runs.
+    ///
+    /// What a claim after this point would produce is a channel no driver ever
+    /// serves — a dispatch into it would wait forever — so this is what makes
+    /// such a claim an error instead.
+    pub(crate) fn mark_started(&self) {
+        self.lock().started = true;
+    }
+
+    /// The receiver an incarnation of the service serves its dispatched calls
+    /// on, or `None` when nothing claimed it.
+    ///
+    /// The first incarnation inherits the channel the claim created, along with
+    /// whatever queued on it before the service started. Each later one gets a
+    /// fresh channel, and the sender dispatchers hold is swapped for it — calls
+    /// still queued on the faulted incarnation's channel end with it, as an
+    /// inbound request to a restarting service does.
+    pub(crate) fn next_incarnation(&self) -> Option<mpsc::Receiver<GuestJob>> {
+        let mut state = self.lock();
+        state.tx.as_ref()?;
+        // The claim's receiver is there exactly once, which is what marks this
+        // as the first incarnation.
+        if let Some(rx) = state.rx.take() {
+            return Some(rx);
+        }
+        let (tx, rx) = mpsc::channel(INGRESS_BACKLOG);
+        state.tx = Some(tx);
+        Some(rx)
+    }
+
+    /// Stop accepting calls: the workload is going away, so a dispatch that
+    /// would otherwise wait on a reply that can never come fails instead.
+    pub(crate) fn shutdown(&self) {
+        let mut state = self.lock();
+        state.tx = None;
+        state.rx = None;
+    }
+
+    fn sender(&self) -> Option<mpsc::Sender<GuestJob>> {
+        self.lock().tx.clone()
+    }
+}
+
+/// One live claim on a service's dispatch ingress: proof that the service will
+/// be run with one, and what keeps it in place.
+///
+/// Held by whoever may dispatch — a [`DispatchTarget`], or the route a host
+/// component plugin resolved — and released when they let go. A route that
+/// loses to a component's is released explicitly rather than left to its drop,
+/// so the service's ingress reflects the routing decision at the moment it is
+/// made, not whenever the last handle to the losing route goes away.
+pub(crate) struct ServiceClaim {
+    calls: Arc<ServiceCalls>,
+    released: std::sync::atomic::AtomicBool,
+}
+
+impl ServiceClaim {
+    /// The ingress this claim holds open.
+    pub(crate) fn calls(&self) -> &Arc<ServiceCalls> {
+        &self.calls
+    }
+
+    /// Give this claim back now rather than when it drops. Idempotent, so the
+    /// drop that follows does nothing.
+    pub(crate) fn release(&self) {
+        if !self
+            .released
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            self.calls.release_claim();
+        }
+    }
+}
+
+impl Clone for ServiceClaim {
+    /// A copy of a claim is a claim of its own, so the ingress outlives whichever
+    /// of them is dropped first. Never refused: an existing claim is proof the
+    /// service was claimed in time, whatever it has done since.
+    fn clone(&self) -> Self {
+        self.calls.lock().claims += 1;
+        Self {
+            calls: Arc::clone(&self.calls),
+            released: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+impl Drop for ServiceClaim {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+/// One workload item a host plugin can dispatch [`GuestCall`]s to, resolved
+/// once from [`ResolvedWorkload::dispatch_target`].
+///
+/// Cheap to clone and safe to hold for the life of the binding. It pins *which*
+/// item calls go to, not the instance that serves them: a component's warm set
+/// and a service's incarnations both turn over underneath it.
+///
+/// The workload is behind an [`Arc`] because cloning a [`ResolvedWorkload`] is
+/// not cheap — it copies the service's `Linker` by value, string pool and all —
+/// and a target is expected to be cloned per dispatch.
+#[derive(Clone)]
+pub struct DispatchTarget {
+    workload: Arc<ResolvedWorkload>,
+    item: TargetItem,
+}
+
+#[derive(Clone)]
+enum TargetItem {
+    /// A component: instantiated per call, or served on a warm instance.
+    Component {
+        id: Arc<str>,
+        /// Resolved once, with the target, rather than per call: pre-linking a
+        /// component against its linker checks every import, which is exactly
+        /// the work `InstancePre` exists to do ahead of time. The HTTP
+        /// entrypoint captures one the same way, at the same point.
+        pre: InstancePre<SharedCtx>,
+        /// The warm set this component's calls run on, or `None` when each gets
+        /// a store of its own. Read once, with `pre` and under the same lock:
+        /// which pool serves a component is settled when the workload resolves,
+        /// so a per-call re-read would cost a lock to learn the same answer —
+        /// and would disagree with the `InstancePre` beside it, which is pinned
+        /// here either way.
+        pool: Option<Arc<InstancePool>>,
+    },
+    /// The workload's long-lived service, reached through the ingress this
+    /// claim holds open. Behind an `Arc` so cloning a target is one atomic
+    /// rather than a lock on the ingress to count one more claim.
+    Service(Arc<ServiceClaim>),
+}
+
+impl std::fmt::Debug for DispatchTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("DispatchTarget");
+        s.field("workload_id", &self.workload.id());
+        match &self.item {
+            TargetItem::Component { id, .. } => s.field("component", id),
+            TargetItem::Service(_) => s.field("service", &self.workload.service_id()),
+        };
+        s.finish()
+    }
+}
+
+impl DispatchTarget {
+    /// Resolve `item_id` — a component of `workload`, or its service — as a
+    /// dispatch target. See [`ResolvedWorkload::dispatch_target`].
+    pub(crate) async fn resolve(
+        workload: &ResolvedWorkload,
+        item_id: &str,
+    ) -> anyhow::Result<Self> {
+        let item = if workload.is_service_item(item_id) {
+            // Asked for by name, so a service that can never serve a dispatched
+            // call is an error here rather than something to skip past.
+            TargetItem::Service(Arc::new(workload.claim_service_dispatch()?))
+        } else {
+            let (id, pre, pool) = workload.component_dispatch(item_id).await?;
+            TargetItem::Component { id, pre, pool }
+        };
+        Ok(Self {
+            // Copied once per target: cloning a `ResolvedWorkload` copies the
+            // service's `Linker` by value, so it is worth paying here rather
+            // than on every clone of the target.
+            workload: Arc::new(workload.clone()),
+            item,
+        })
+    }
+
+    /// The workload this target belongs to.
+    pub fn workload(&self) -> &ResolvedWorkload {
+        &self.workload
+    }
+
+    /// Run `call` on a live instance of this item, and wait for it.
+    ///
+    /// Where it runs is the host's to choose (see the [module docs]); what it
+    /// does is the caller's. The `Err` a call returns comes back here, as does a
+    /// failure to reach an instance at all — a component that will not
+    /// instantiate, or a service that is not running.
+    ///
+    /// # How long it may take
+    ///
+    /// No host timeout bounds the call: the host cannot know what the plugin
+    /// asked the guest to do, and a batch handler that takes minutes is the
+    /// point of this interface. A caller that wants a deadline imposes its own
+    /// by dropping this future, which reclaims a store built for the call alone.
+    /// It cannot end guest work already running on a *shared* instance, though —
+    /// a warm one or the service — because a guest subtask cannot be cancelled
+    /// from the host: that call runs to completion on the instance, with nowhere
+    /// left to report its outcome.
+    ///
+    /// [module docs]: self
+    pub async fn dispatch(&self, call: impl GuestCall) -> anyhow::Result<()> {
+        // A target outlives the workload it names: a plugin holds one until it
+        // is unbound, and teardown begins before that. Without this a dispatch
+        // racing a stop would build — and, for a pooled component, *park* — a
+        // fresh instance in a workload the host has already stopped.
+        if self.workload.released() {
+            bail!(
+                "workload '{}' has stopped and takes no more dispatched calls",
+                self.workload.id()
+            );
+        }
+        let call = Box::new(call);
+        match &self.item {
+            TargetItem::Component { id, pre, pool } => {
+                dispatch_to_component(&self.workload, id, pre, pool.as_ref(), call).await
+            }
+            TargetItem::Service(claim) => dispatch_to_service(claim.calls(), call).await,
+        }
+    }
+}
+
+/// Deliver a call to the workload's running service, and wait for it.
+pub(crate) async fn dispatch_to_service(
+    calls: &ServiceCalls,
+    call: Box<dyn GuestCall>,
+) -> anyhow::Result<()> {
+    let tx = calls
+        .sender()
+        .context("the workload's service is not accepting dispatched calls")?;
+    let (reply, reply_rx) = oneshot::channel();
+    tx.send(GuestJob { call, reply })
+        .await
+        .map_err(|_| anyhow::anyhow!("the workload's service is no longer running"))?;
+    reply_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("the workload's service dropped the dispatched call"))?
+}
+
+/// Run a call on `component_id`: on one of its warm instances when it keeps
+/// any, otherwise — and when every warm instance is busy and the pool is full —
+/// on a store built, instantiated and dropped for this call alone.
+async fn dispatch_to_component(
+    workload: &ResolvedWorkload,
+    component_id: &str,
+    pre: &InstancePre<SharedCtx>,
+    pool: Option<&Arc<InstancePool>>,
+    call: Box<dyn GuestCall>,
+) -> anyhow::Result<()> {
+    // An instance built for a pool that then declined the call: the store of
+    // its own below is that instance, rather than a second one beside it.
+    let mut reclaimed = None;
+    let call = if let Some(pool) = pool {
+        let (reply, reply_rx) = oneshot::channel();
+        let job = InstanceJob::Guest(GuestJob { call, reply });
+        let outcome =
+            instance_pool::offer_or_install(pool, pre, job, || workload.new_store(component_id))
+                .await?;
+        match outcome {
+            Ok(()) => {
+                return reply_rx
+                    .await
+                    .map_err(|_| anyhow::anyhow!("pooled instance dropped the dispatched call"))?;
+            }
+            // Every warm instance was busy; run it in a store of its own.
+            Err(Declined {
+                job: InstanceJob::Guest(job),
+                instance,
+            }) => {
+                tracing::debug!(
+                    component_id,
+                    "warm instances saturated; dispatching to a store of its own"
+                );
+                reclaimed = instance;
+                job.call
+            }
+            // A job comes back as the variant it went in as, so this is
+            // unreachable — but not worth a panic on a dispatch path.
+            Err(_) => {
+                debug_assert!(false, "a dispatched job cannot come back as another kind");
+                bail!("instance pool returned another kind of job for a dispatched call");
+            }
+        }
+    } else {
+        call
+    };
+
+    let ComponentInstance {
+        mut store,
+        instance,
+    } = match reclaimed {
+        Some(built) => built,
+        None => {
+            let mut store = workload.new_store(component_id).await?;
+            let instance = pre.instantiate_async(&mut store).await?;
+            ComponentInstance { store, instance }
+        }
+    };
+    // The store travels into the task, so a dispatcher cancelled mid-call drops
+    // it with the task rather than leaving it running.
+    let mut task = AbortOnDropHandle::new(tokio::spawn(async move {
+        store
+            .run_concurrent(async move |accessor| call.call(accessor, instance).await)
+            .await
+            .map_err(|e| anyhow::anyhow!("dispatched call store faulted: {e:#}"))?
+    }));
+    (&mut task).await.context("dispatched call task failed")?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::ServiceCalls;
+
+    /// A service nothing claimed runs without an ingress, and has no sender for
+    /// a call to be delivered on.
+    #[test]
+    fn unclaimed_service_has_no_ingress() {
+        let calls = Arc::new(ServiceCalls::default());
+        assert!(!calls.claimed());
+        assert!(calls.next_incarnation().is_none());
+        assert!(calls.sender().is_none());
+    }
+
+    /// Several plugins claiming the one service share its ingress, and the
+    /// first incarnation serves the very channel the claim created — so a call
+    /// dispatched before the service started is still waiting on it.
+    #[test]
+    fn claims_share_one_ingress_and_the_first_incarnation_takes_it() {
+        let calls = Arc::new(ServiceCalls::default());
+        let _first_claim = calls.claim().expect("first claim");
+        let queued = calls.sender().expect("a claim opens the ingress");
+        let _second_claim = calls.claim().expect("second claim");
+        assert!(
+            queued.same_channel(&calls.sender().expect("still open")),
+            "a second claim must not replace the channel the first is dispatching on"
+        );
+
+        calls.mark_started();
+        let first = calls.next_incarnation().expect("claimed, so it has one");
+        assert!(
+            queued.same_channel(&calls.sender().expect("still open")),
+            "the first incarnation serves the claim-time channel, queue and all"
+        );
+        drop(first);
+    }
+
+    /// A claim given back before the service starts takes its ingress with it —
+    /// but only the last one does, so a plugin that resolved a service route and
+    /// then routed to a component instead cannot strand the service with an
+    /// ingress nothing sends on, nor take one another plugin still wants.
+    #[test]
+    fn the_last_claim_released_takes_the_ingress_with_it() {
+        let calls = Arc::new(ServiceCalls::default());
+        let one = calls.claim().expect("first claim");
+        let two = calls.claim().expect("second claim");
+
+        one.release();
+        assert!(
+            calls.claimed(),
+            "a claim released while another is held must leave the ingress in place"
+        );
+        // Releasing twice is the same as releasing once: the drop below must not
+        // take the ingress from a claim that is still held.
+        one.release();
+        assert!(calls.claimed(), "a repeated release must not double-count");
+
+        drop(two);
+        assert!(
+            !calls.claimed(),
+            "the last claim released takes the ingress with it, so the service is not \
+             run with one"
+        );
+        assert!(calls.next_incarnation().is_none());
+    }
+
+    /// Once the service is running with an ingress, a claim going away does not
+    /// take it: closing the channel would end the driver, and a plugin letting
+    /// go of a target is no reason to stop the service.
+    #[test]
+    fn releasing_a_claim_after_the_service_started_keeps_the_ingress() {
+        let calls = Arc::new(ServiceCalls::default());
+        let claim = calls.claim().expect("claim");
+        calls.mark_started();
+        let _rx = calls.next_incarnation().expect("first incarnation");
+
+        drop(claim);
+        assert!(
+            calls.claimed(),
+            "a running service keeps the ingress it was started with"
+        );
+    }
+
+    /// Each restart gets a fresh channel, and dispatchers are swapped onto it.
+    #[test]
+    fn a_restart_swaps_the_channel() {
+        let calls = Arc::new(ServiceCalls::default());
+        let _claim = calls.claim().expect("claim");
+        calls.mark_started();
+        let _first = calls.next_incarnation().expect("first incarnation");
+        let before = calls.sender().expect("open");
+
+        let _second = calls.next_incarnation().expect("restarted incarnation");
+        let after = calls.sender().expect("open");
+        assert!(
+            !before.same_channel(&after),
+            "a restarted service serves a new channel, so dispatchers must be moved to it"
+        );
+    }
+
+    /// A claim once the service is running is refused: its ingress could only be
+    /// added to a driver that is already serving, so a call dispatched into it
+    /// would wait forever.
+    #[test]
+    fn a_claim_after_the_service_started_is_refused() {
+        let calls = Arc::new(ServiceCalls::default());
+        calls.mark_started();
+        assert!(calls.claim().is_err());
+        assert!(!calls.claimed());
+    }
+
+    /// Shutdown closes the ingress, so a later dispatch fails instead of waiting
+    /// on a driver that is being torn down.
+    #[test]
+    fn shutdown_closes_the_ingress() {
+        let calls = Arc::new(ServiceCalls::default());
+        let _claim = calls.claim().expect("claim");
+        calls.mark_started();
+        let _rx = calls.next_incarnation().expect("first incarnation");
+        calls.shutdown();
+        assert!(calls.sender().is_none());
+        assert!(!calls.claimed());
+    }
+}

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -53,6 +53,7 @@ use wasmtime::error::Context as _;
 use wasmtime_wasi_http::p3::bindings::Service;
 
 use crate::engine::ctx::SharedCtx;
+use crate::engine::dispatch::{GuestJob, GuestTask};
 use crate::engine::instance_pool::ComponentInstance;
 use crate::host::http::ServiceHttpJob;
 use crate::host::trigger_service::HttpTask;
@@ -77,7 +78,7 @@ pub(crate) struct LinkedJob {
 
 /// Work an instance can be given. Every shape runs as a concurrent task on the
 /// same instance, so a component reached several ways shares one warm set
-/// rather than keeping one per trigger.
+/// rather than keeping one per way in.
 pub(crate) enum InstanceJob {
     /// An inbound HTTP request (`wasi:http/handler@0.3`). Boxed to keep the
     /// variants a similar size; a declined job carries the whole request back.
@@ -100,6 +101,10 @@ pub(crate) enum InstanceJob {
     /// 48-byte [`Val`] per byte a store-independent lowering would cost.
     #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     Plugin(Box<dyn PluginJob>),
+    /// Work a host plugin dispatched into this component (see
+    /// [`crate::engine::dispatch`]). Unboxed: it is two pointers, and the call
+    /// it carries is already behind one.
+    Guest(GuestJob),
 }
 
 /// A call a plugin hands to the pool, run on whichever instance is free.
@@ -437,7 +442,7 @@ impl Accepts {
         match job {
             InstanceJob::Http(_) => self.http,
             InstanceJob::Messaging(_) => self.messaging,
-            InstanceJob::Linked(_) | InstanceJob::Plugin(_) => true,
+            InstanceJob::Linked(_) | InstanceJob::Plugin(_) | InstanceJob::Guest(_) => true,
         }
     }
 }
@@ -500,6 +505,13 @@ impl InstanceDriver {
                             // timed-out call left running.
                             _ = task_state.drained.notified() => break,
                         };
+                        // One slot for whichever arm runs: it holds this call's
+                        // in-flight guard, so it is moved exactly once and the
+                        // arm that declines a job drops it right here.
+                        let slot = PoolSlot {
+                            state: Arc::clone(&task_state),
+                            _in_flight: guard,
+                        };
                         let spawned = match job {
                             InstanceJob::Http(job) => {
                                 let ServiceHttpJob {
@@ -522,10 +534,7 @@ impl InstanceDriver {
                                     req,
                                     resp_tx,
                                     abandoned,
-                                    pool_slot: Some(PoolSlot {
-                                        state: Arc::clone(&task_state),
-                                        _in_flight: guard,
-                                    }),
+                                    pool_slot: Some(slot),
                                 })
                             }
                             InstanceJob::Messaging(job) => {
@@ -552,27 +561,23 @@ impl InstanceDriver {
                                     result_tx,
                                     abandoned,
                                     attributes,
-                                    pool_slot: Some(PoolSlot {
-                                        state: Arc::clone(&task_state),
-                                        _in_flight: guard,
-                                    }),
+                                    pool_slot: Some(slot),
                                 })
                             }
                             InstanceJob::Linked(job) => accessor.spawn(LinkedTask {
                                 instance,
                                 job,
-                                slot: PoolSlot {
-                                    state: Arc::clone(&task_state),
-                                    _in_flight: guard,
-                                },
+                                slot,
                             }),
                             InstanceJob::Plugin(job) => accessor.spawn(PluginTask {
                                 instance,
                                 job,
-                                slot: PoolSlot {
-                                    state: Arc::clone(&task_state),
-                                    _in_flight: guard,
-                                },
+                                slot,
+                            }),
+                            InstanceJob::Guest(job) => accessor.spawn(GuestTask {
+                                instance,
+                                job,
+                                pool_slot: Some(slot),
                             }),
                         };
                         if let Err(e) = spawned {

--- a/crates/wash-runtime/src/engine/instance_driver.rs
+++ b/crates/wash-runtime/src/engine/instance_driver.rs
@@ -43,8 +43,6 @@
 //! with it, so every call in flight on that instance fails rather than just
 //! one. That is bounded by `max_concurrency`, and by `1/pool_size` of the pool.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -93,41 +91,16 @@ pub(crate) enum InstanceJob {
     /// `max_concurrency`; the sync `@0.2.0` export holds `&mut Store` for the
     /// length of its call and keeps its per-message store.
     Messaging(Box<crate::host::trigger_service::MessagingJob>),
-    /// A call a host plugin supplies, made on a pooled instance.
+    /// A call a host plugin dispatched into this component (see
+    /// [`crate::engine::dispatch`]).
     ///
     /// The engine routes it like any other job and never looks inside: the
     /// plugin keeps its own payload and makes its own typed call. That is what
     /// lets a delivery carry, say, a NATS message's bytes rather than the one
     /// 48-byte [`Val`] per byte a store-independent lowering would cost.
-    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
-    Plugin(Box<dyn PluginJob>),
-    /// Work a host plugin dispatched into this component (see
-    /// [`crate::engine::dispatch`]). Unboxed: it is two pointers, and the call
-    /// it carries is already behind one.
+    /// Unboxed: it is a handful of pointers, and the call it carries is already
+    /// behind one.
     Guest(GuestJob),
-}
-
-/// A call a plugin hands to the pool, run on whichever instance is free.
-///
-/// Implemented by the plugin so the engine needs none of its types. The
-/// plugin's own bindgen call takes an [`Accessor`] rather than a `&mut Store`,
-/// so it runs inside the driver's long-lived `run_concurrent` exactly as a
-/// linked call does — several at a time on one instance, up to
-/// `max_concurrency`.
-pub(crate) trait PluginJob: Send + 'static {
-    /// Names this job in a driver log line.
-    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
-    fn describe(&self) -> &str;
-
-    /// Runs the call. Owns replying to whoever is waiting for it, and may
-    /// retire the instance through `slot` when it ends leaving guest state
-    /// indeterminate — the same contract [`LinkedTask`] follows.
-    fn run<'a>(
-        self: Box<Self>,
-        accessor: &'a Accessor<SharedCtx>,
-        instance: Instance,
-        slot: Option<PoolSlot>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 }
 
 /// Times one guest invocation, and records it when dropped.
@@ -176,7 +149,6 @@ impl InvocationSample {
 
     /// Mark what went wrong, for a call site that knows. The value is a short
     /// bounded name — `trap`, `timeout` — never anything a caller supplies.
-    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
     pub(crate) fn failed(&mut self, error: &'static str) {
         self.error = Some(error);
     }
@@ -188,20 +160,6 @@ impl Drop for InvocationSample {
             return;
         };
         meter.record(&self.attributes, started.elapsed(), self.error);
-    }
-}
-
-/// Drives one [`PluginJob`] as an ordinary pooled task.
-struct PluginTask {
-    instance: Instance,
-    job: Box<dyn PluginJob>,
-    slot: PoolSlot,
-}
-
-impl AccessorTask<SharedCtx> for PluginTask {
-    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
-        self.job.run(accessor, self.instance, Some(self.slot)).await;
-        Ok(())
     }
 }
 
@@ -436,13 +394,13 @@ impl Accepts {
     /// Whether this instance can be given `job` at all.
     ///
     /// A linked call names the export index it resolved against this very
-    /// component, and a plugin job binds its own view when it runs, so neither
-    /// is gated here.
+    /// component, and a dispatched call binds its own view when it runs, so
+    /// neither is gated here.
     fn takes(self, job: &InstanceJob) -> bool {
         match job {
             InstanceJob::Http(_) => self.http,
             InstanceJob::Messaging(_) => self.messaging,
-            InstanceJob::Linked(_) | InstanceJob::Plugin(_) | InstanceJob::Guest(_) => true,
+            InstanceJob::Linked(_) | InstanceJob::Guest(_) => true,
         }
     }
 }
@@ -565,11 +523,6 @@ impl InstanceDriver {
                                 })
                             }
                             InstanceJob::Linked(job) => accessor.spawn(LinkedTask {
-                                instance,
-                                job,
-                                slot,
-                            }),
-                            InstanceJob::Plugin(job) => accessor.spawn(PluginTask {
                                 instance,
                                 job,
                                 slot,

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -50,6 +50,7 @@
 //!    down with the call should not be pooled.
 
 use std::collections::{BTreeMap, HashSet};
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, MutexGuard, Once};
 use std::time::Duration;
@@ -95,6 +96,41 @@ pub(crate) fn poolable(
         }
     }
     Some(pool)
+}
+
+/// Offer `job` to `pool`'s warm instances, building one more when the pool has
+/// room for it.
+///
+/// `Ok(Ok(()))` means an instance took the call. `Ok(Err(declined))` hands it
+/// back because every warm instance was busy and the pool is full — the caller
+/// runs it in a store of its own, which is what an unpooled component pays for
+/// every call, and on the instance the decline handed back where there is one.
+/// `Err` is a component that would not instantiate.
+///
+/// The store is built out here rather than inside [`InstancePool::try_dispatch`],
+/// which runs under the pool's lock: awaiting is allowed here, a request a warm
+/// instance can already serve does not pay for a store it will not use, and a
+/// component that fails to instantiate reports that to the caller rather than
+/// only to the log.
+pub(crate) async fn offer_or_install<F, S>(
+    pool: &Arc<InstancePool>,
+    pre: &wasmtime::component::InstancePre<SharedCtx>,
+    job: InstanceJob,
+    new_store: F,
+) -> anyhow::Result<Result<(), Declined>>
+where
+    F: FnOnce() -> S,
+    S: Future<Output = anyhow::Result<wasmtime::Store<SharedCtx>>>,
+{
+    match pool.try_dispatch(job) {
+        Dispatch::Sent => Ok(Ok(())),
+        Dispatch::NeedsInstance(job) => {
+            let mut store = new_store().await?;
+            let instance = pre.instantiate_async(&mut store).await?;
+            Ok(pool.dispatch_on_new(ComponentInstance { store, instance }, job))
+        }
+        Dispatch::Saturated(job) => Ok(Err(Declined::without_instance(job))),
+    }
 }
 
 /// What [`InstancePool::try_dispatch`] did with a call.

--- a/crates/wash-runtime/src/engine/instance_pool.rs
+++ b/crates/wash-runtime/src/engine/instance_pool.rs
@@ -970,20 +970,24 @@ mod tests {
     /// payload. Never run: these tests only ask where the pool would put it.
     fn plugin_job() -> InstanceJob {
         struct NeverRun;
-        impl crate::engine::instance_driver::PluginJob for NeverRun {
+        impl crate::engine::dispatch::GuestCall for NeverRun {
             fn describe(&self) -> &str {
                 "test"
             }
-            fn run<'a>(
+            fn call<'a>(
                 self: Box<Self>,
                 _: &'a wasmtime::component::Accessor<crate::engine::ctx::SharedCtx>,
                 _: wasmtime::component::Instance,
-                _: Option<crate::engine::instance_driver::PoolSlot>,
-            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+            ) -> crate::engine::dispatch::GuestCallFuture<'a> {
                 unreachable!("the pool never runs this job")
             }
         }
-        InstanceJob::Plugin(Box::new(NeverRun))
+        InstanceJob::Guest(crate::engine::dispatch::GuestJob::new(
+            Box::new(NeverRun),
+            tokio::sync::oneshot::channel().0,
+            crate::engine::abandon::DispatchedCall::new("test", std::time::Duration::MAX).flag(),
+            Arc::from([]),
+        ))
     }
 
     /// Instances still admitting calls.

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -979,6 +979,11 @@ pub(crate) struct ServiceExportCall {
     /// looking for one before falling back to a clone, and for a signature that
     /// cannot hold one — a batch of records, say — that walk is the whole cost.
     pub(crate) plain: bool,
+    /// What calls on this export are measured under, built where the route was
+    /// wired: neither the identity nor the operation can change under a
+    /// resolved workload, and rebuilding the set per call would allocate a
+    /// vector and five strings to arrive at the same answer every time.
+    pub(crate) attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
 /// Run a call on the workload's service, on the instance already running it.
@@ -1025,20 +1030,25 @@ async fn invoke_service_export(
         func_idx: inv.func_idx,
         import_name: inv.import_name.clone(),
         export_name: inv.export_name.clone(),
+        operation: Arc::from(format!("{}#{}", inv.import_name, inv.export_name)),
         args,
         result_tys: Arc::clone(&service_call.result_tys),
         plain: service_call.plain,
         reply,
     };
-    crate::engine::dispatch::dispatch_to_service(&service_call.calls, Box::new(call))
-        .await
-        .map_err(|e| {
-            wasmtime::format_err!(
-                "{}.{} could not be delivered to the workload's service: {e:#}",
-                inv.import_name,
-                inv.export_name
-            )
-        })?;
+    crate::engine::dispatch::dispatch_to_service(
+        &service_call.calls,
+        Box::new(call),
+        Arc::clone(&service_call.attributes),
+    )
+    .await
+    .map_err(|e| {
+        wasmtime::format_err!(
+            "{}.{} could not be delivered to the workload's service: {e:#}",
+            inv.import_name,
+            inv.export_name
+        )
+    })?;
     // The dispatch above returns once the call has run, so its outcome is
     // already here.
     let relocated = reply_rx
@@ -1068,6 +1078,8 @@ struct ServiceExportTask {
     func_idx: ComponentExportIndex,
     import_name: Arc<str>,
     export_name: Arc<str>,
+    /// `interface#func`, what this call is named in the host's logs and metrics.
+    operation: Arc<str>,
     args: Vec<Relocated>,
     result_tys: Arc<[Type]>,
     /// See [`ServiceExportCall::plain`].
@@ -1077,6 +1089,10 @@ struct ServiceExportTask {
 
 #[cfg(feature = "host-component-plugins")]
 impl crate::engine::dispatch::GuestCall for ServiceExportTask {
+    fn describe(&self) -> &str {
+        &self.operation
+    }
+
     fn call<'a>(
         self: Box<Self>,
         accessor: &'a Accessor<SharedCtx>,
@@ -1091,6 +1107,7 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
                 result_tys,
                 plain,
                 reply,
+                ..
             } = *self;
 
             let prepared = accessor.with(|mut access| -> wasmtime::Result<_> {
@@ -1107,35 +1124,23 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
                 Ok(prepared) => prepared,
                 Err(e) => {
                     let _ = reply.send(Err(e));
-                    return Ok(());
+                    return Ok(Some("host"));
                 }
             };
 
             let mut results = vec![Val::Bool(false); result_tys.len()];
-            let call_timeout = crate::timeouts::ephemeral_call();
-            match timeout(
-                call_timeout,
-                func.call_concurrent(accessor, &arg_vals, &mut results),
-            )
-            .await
+            // Unbounded here: the deadline is the host's, enforced around this
+            // call and from the dispatcher's own task, which a non-yielding
+            // guest cannot block. A trap is reported to the caller *and* faults
+            // the service store, which the supervisor restarts.
+            if let Err(e) = func
+                .call_concurrent(accessor, &arg_vals, &mut results)
+                .await
             {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    let _ = reply.send(Err(
-                        e.context(format!("{import_name}.{export_name} trapped"))
-                    ));
-                    return Ok(());
-                }
-                // The guest work is still running on the service's instance: a
-                // guest subtask cannot be cancelled from the host, and the
-                // service is the workload's one instance, so there is nothing to
-                // retire. The caller is told, and the service keeps serving.
-                Err(e) => {
-                    let _ = reply.send(Err(wasmtime::format_err!(
-                        "{import_name}.{export_name} timed out after {call_timeout:?}: {e}"
-                    )));
-                    return Ok(());
-                }
+                let _ = reply.send(Err(
+                    e.context(format!("{import_name}.{export_name} trapped"))
+                ));
+                return Ok(Some("trap"));
             }
 
             // Extracted in the service store, whose own `run_concurrent` keeps
@@ -1153,8 +1158,9 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
                     )
                 })
             };
+            let refused = extracted.is_err().then_some("host");
             let _ = reply.send(extracted);
-            Ok(())
+            Ok(refused)
         })
     }
 }

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -2,14 +2,20 @@
 //!
 //! When one component in a workload imports a function that another component
 //! exports, the linker wires the import to one of the `invoke_*` helpers here.
-//! Each call is dispatched, by signature, down one of two paths:
+//! Each call is dispatched, by signature, down one of these paths (see
+//! [`LinkedTarget`]):
 //!
 //! - the **shared-store path** ([`invoke_shared_store_linked_export`] /
 //!   [`invoke_linked_sync_export`]), where the callee was pre-instantiated into
 //!   the caller's long-lived store and handles can cross the boundary by
-//!   identity, and
+//!   identity,
 //! - the **ephemeral path** ([`invoke_ephemeral_linked_export`]), where a
-//!   plain-value call runs in a throwaway store built per call.
+//!   plain-value call runs in a throwaway store built per call, and
+//! - the **service path** ([`invoke_service_export`]), where the callee is the
+//!   workload's long-lived service and the call is delivered to the instance
+//!   already running it rather than to a store of its own. Only a host
+//!   component plugin's call reaches this: within a workload, a service is
+//!   never a callee.
 //!
 //! Store creation for both paths is also here: [`ComponentCtxTemplate`] is the
 //! cheap recipe for a component's [`Ctx`], [`build_ctx_from_template`] turns one
@@ -22,6 +28,7 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 use tokio::time::timeout;
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, trace};
 use wasmtime::component::{
     Accessor, ComponentExportIndex, InstancePre, Val,
@@ -36,7 +43,7 @@ use crate::engine::abandon::{AbandonedCallPolicy, arm_epoch_deadline};
 use crate::engine::ctx::SharedTlsProvider;
 use crate::engine::ctx::{AccessorActiveCtxGuard, Ctx, SharedCtx, StoreActiveCtxGuard};
 use crate::engine::instance_driver::{InstanceJob, LinkedJob};
-use crate::engine::instance_pool::{self, ComponentInstance, Declined, Dispatch, InstancePool};
+use crate::engine::instance_pool::{self, ComponentInstance, InstancePool};
 use crate::engine::store::relocate::{self, Relocated, bridgeable_element_type};
 use crate::engine::store::stream_pump::Done;
 use crate::engine::value::{carries_cross_store_handle, lift_results, lower_params};
@@ -148,6 +155,9 @@ pub(crate) fn component_ctx_template_from_metadata_with_tls(
 /// a deep copy of the engine/handler/component map.
 #[derive(Clone)]
 pub(crate) struct EphemeralLinkedCall {
+    /// The callee, pre-linked and ready to instantiate into whichever store
+    /// this call ends up running in.
+    pub(crate) pre: InstancePre<SharedCtx>,
     pub(crate) engine: wasmtime::Engine,
     pub(crate) http_handler: Arc<dyn crate::host::http::HostHandler>,
     /// The meter of the host this call runs on; see
@@ -520,11 +530,28 @@ async fn callee_identity(
 pub(crate) struct LinkedExportInvocation {
     pub(crate) import_name: Arc<str>,
     pub(crate) export_name: Arc<str>,
-    pub(crate) pre: InstancePre<SharedCtx>,
     pub(crate) plugin_component_id: Arc<str>,
     pub(crate) func_idx: ComponentExportIndex,
     pub(crate) param_tys: Arc<std::sync::OnceLock<Arc<[Type]>>>,
-    pub(crate) ephemeral_call: Option<Arc<EphemeralLinkedCall>>,
+    pub(crate) target: LinkedTarget,
+}
+
+/// Where a linked call runs, decided when the import was wired.
+#[derive(Clone)]
+pub(crate) enum LinkedTarget {
+    /// The callee was pre-instantiated into the caller's own store and is
+    /// reached through it, so handles keep their identity across the call.
+    SharedStore,
+    /// The callee gets a store of its own — one of its warm instances, or one
+    /// built for this call — and the call's values are copied or relocated into
+    /// it.
+    Ephemeral(Arc<EphemeralLinkedCall>),
+    /// The callee is the workload's long-lived service, which is never
+    /// instantiated a second time: the call is delivered to the instance
+    /// already running (see [`crate::engine::dispatch`]). Only a host component
+    /// plugin's call is ever wired this way.
+    #[cfg(feature = "host-component-plugins")]
+    Service(Arc<ServiceExportCall>),
 }
 
 pub(crate) async fn invoke_linked_async_export(
@@ -533,22 +560,17 @@ pub(crate) async fn invoke_linked_async_export(
     results: &mut [Val],
     inv: &LinkedExportInvocation,
 ) -> wasmtime::Result<()> {
-    if let Some(ephemeral_call) = &inv.ephemeral_call {
-        invoke_ephemeral_linked_export(accessor, params, results, inv, ephemeral_call).await
-    } else {
-        invoke_shared_store_linked_export(accessor, params, results, inv).await
-    }
-}
-
-/// Aborts the wrapped task when dropped before it completes, so a cancelled
-/// caller (e.g. a client disconnect tearing down the request future) reclaims
-/// the ephemeral store's core-instance slots immediately instead of leaving a
-/// detached task to run to its timeout.
-struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
-
-impl<T> Drop for AbortOnDrop<T> {
-    fn drop(&mut self) {
-        self.0.abort();
+    match &inv.target {
+        LinkedTarget::Ephemeral(call) => {
+            invoke_ephemeral_linked_export(accessor, params, results, inv, call).await
+        }
+        #[cfg(feature = "host-component-plugins")]
+        LinkedTarget::Service(service_call) => {
+            invoke_service_export(accessor, params, results, inv, service_call).await
+        }
+        LinkedTarget::SharedStore => {
+            invoke_shared_store_linked_export(accessor, params, results, inv).await
+        }
     }
 }
 
@@ -590,7 +612,7 @@ async fn invoke_ephemeral_linked_export(
 /// Args are extracted in the caller store, so each source stream begins pumping
 /// under the caller's long-lived runtime; the call then runs in a throwaway
 /// store, where result streams are extracted before the store is torn down. The
-/// store-driving task is **detached** (leaked after initial [`AbortOnDrop`]
+/// store-driving task is **detached** (leaked after initial [`AbortOnDropHandle`]
 /// wrapping): it must outlive
 /// this call to keep producing into result streams while the caller consumes
 /// them. It self-terminates when a result stream's consumer is dropped — which
@@ -610,24 +632,14 @@ async fn invoke_ephemeral_relocated(
     let attributes = linked_attributes(ephemeral_call, inv).await;
     // Extract args in the caller store: source-stream pumps run under the
     // caller's (long-lived) runtime, so their drain signals are dropped here.
-    let args = accessor.with(|mut access| -> wasmtime::Result<Vec<Relocated>> {
-        let mut dones: Vec<Done> = Vec::new();
-        let mut out = Vec::with_capacity(params.len());
-        for (v, t) in params.iter().zip(param_tys.iter()) {
-            out.push(relocate::extract(
-                access.as_context_mut(),
-                v,
-                t,
-                &mut dones,
-            )?);
-        }
-        Ok(out)
+    let args = accessor.with(|mut access| {
+        extract_all(access.as_context_mut(), params, &param_tys, &mut Vec::new())
     })?;
 
     let (ready_tx, ready_rx) =
         futures::channel::oneshot::channel::<wasmtime::Result<Vec<Relocated>>>();
     let ephemeral_call = Arc::clone(ephemeral_call);
-    let callee_pre = inv.pre.clone();
+    let callee_pre = ephemeral_call.pre.clone();
     let func_idx = inv.func_idx;
     let import_name = inv.import_name.clone();
     let export_name = inv.export_name.clone();
@@ -651,7 +663,7 @@ async fn invoke_ephemeral_relocated(
     // ephemeral store's core-instance slots, rather than leaving it to run to its
     // timeout. Once results are handed back the task must outlive this call to
     // drain result streams, so the guard is forgotten (detached) on success.
-    let task = AbortOnDrop(tokio::task::spawn(async move {
+    let task = AbortOnDropHandle::new(tokio::task::spawn(async move {
         let mut store = match new_ephemeral_store(&ephemeral_call).await {
             Ok(s) => s,
             Err(e) => {
@@ -707,15 +719,12 @@ async fn invoke_ephemeral_relocated(
                     accessor.with(
                         |mut access| -> wasmtime::Result<(Vec<Relocated>, Vec<Done>)> {
                             let mut dones: Vec<Done> = Vec::new();
-                            let mut out = Vec::with_capacity(results_buf.len());
-                            for (r, t) in results_buf.iter().zip(result_tys.iter()) {
-                                out.push(relocate::extract(
-                                    access.as_context_mut(),
-                                    r,
-                                    t,
-                                    &mut dones,
-                                )?);
-                            }
+                            let out = extract_all(
+                                access.as_context_mut(),
+                                &results_buf,
+                                &result_tys,
+                                &mut dones,
+                            )?;
                             Ok((out, dones))
                         },
                     )
@@ -771,13 +780,7 @@ async fn invoke_ephemeral_relocated(
 
     // Inject results into the caller store; result-stream producers pull from
     // the still-draining ephemeral store.
-    accessor.with(|mut access| -> wasmtime::Result<()> {
-        for (i, r) in relocated.into_iter().enumerate() {
-            let v = relocate::inject(access.as_context_mut(), r)?;
-            *results.get_mut(i).context("result index out of bounds")? = v;
-        }
-        Ok(())
-    })?;
+    accessor.with(|mut access| inject_results(access.as_context_mut(), relocated, results))?;
 
     trace!(
         name = %inv.import_name,
@@ -839,21 +842,11 @@ async fn invoke_ephemeral_plain(
             abandoned: call.flag(),
             attributes: Arc::clone(&attributes),
         }));
-        let outcome = match pool.try_dispatch(job) {
-            Dispatch::Sent => Ok(()),
-            // The pool has room. Build and instantiate the store out here,
-            // where awaiting is allowed and where a component that fails to
-            // instantiate reports that failure to this call rather than only
-            // to the log.
-            Dispatch::NeedsInstance(job) => {
-                let mut store = new_ephemeral_store(ephemeral_call).await.map_err(|e| {
-                    wasmtime::format_err!("new pooled store creation failed: {e:#}")
-                })?;
-                let instance = inv.pre.instantiate_async(&mut store).await?;
-                pool.dispatch_on_new(ComponentInstance { store, instance }, job)
-            }
-            Dispatch::Saturated(job) => Err(Declined::without_instance(job)),
-        };
+        let outcome = instance_pool::offer_or_install(pool, &ephemeral_call.pre, job, || {
+            new_ephemeral_store(ephemeral_call)
+        })
+        .await
+        .map_err(|e| wasmtime::format_err!("new pooled store creation failed: {e:#}"))?;
         match outcome {
             Ok(()) => {
                 let vals = call
@@ -896,7 +889,7 @@ async fn invoke_ephemeral_plain(
             let mut store = new_ephemeral_store(ephemeral_call)
                 .await
                 .map_err(|e| wasmtime::format_err!("new ephemeral store creation failed: {e:#}"))?;
-            let instance = inv.pre.instantiate_async(&mut store).await?;
+            let instance = ephemeral_call.pre.instantiate_async(&mut store).await?;
             ComponentInstance { store, instance }
         }
     };
@@ -917,7 +910,7 @@ async fn invoke_ephemeral_plain(
 
     // The store travels into the task, so a caller cancelled mid-call drops it
     // with the task rather than leaving it running.
-    let mut task = AbortOnDrop(tokio::task::spawn(async move {
+    let mut task = AbortOnDropHandle::new(tokio::task::spawn(async move {
         let _abandoned = watch_guard;
         store
             .run_concurrent(async move |accessor| {
@@ -950,7 +943,7 @@ async fn invoke_ephemeral_plain(
             .and_then(|inner| inner)
     }));
     let vals = call
-        .await_reply(&mut task.0)
+        .await_reply(&mut task)
         .await
         .ok_or_else(|| wasmtime::format_err!("ephemeral linked call produced no result in time"))?
         .map_err(|e| wasmtime::format_err!("ephemeral linked call task failed: {e}"))??;
@@ -963,6 +956,239 @@ async fn invoke_ephemeral_plain(
         "invoked ephemeral dynamic export"
     );
 
+    Ok(())
+}
+
+/// A call into an export of the workload's long-lived service, captured when
+/// the import was wired.
+///
+/// The service is never instantiated a second time — it *is* the workload's
+/// running instance — so this carries no `InstancePre` and no store recipe, only
+/// the ingress the call is delivered over and the types it must be moved across
+/// the boundary with. Everything crosses as [`Relocated`], plain values
+/// included: a handle-free value relocates as itself, and using one path for
+/// both keeps `stream<T>`/`future<T>` working without a second implementation.
+#[cfg(feature = "host-component-plugins")]
+pub(crate) struct ServiceExportCall {
+    /// The ingress the running service serves dispatched calls on.
+    pub(crate) calls: Arc<crate::engine::dispatch::ServiceCalls>,
+    pub(crate) param_tys: Arc<[Type]>,
+    pub(crate) result_tys: Arc<[Type]>,
+    /// Whether this signature can carry a handle at all. Classified once, here,
+    /// because relocation answers it per *value*: `extract` walks a value tree
+    /// looking for one before falling back to a clone, and for a signature that
+    /// cannot hold one — a batch of records, say — that walk is the whole cost.
+    pub(crate) plain: bool,
+}
+
+/// Run a call on the workload's service, on the instance already running it.
+///
+/// Arguments are extracted in the caller's store — so any source-stream pump
+/// runs under the caller's own (long-lived) runtime — delivered to the service,
+/// and its results injected back here. Neither store is torn down by this call,
+/// which is what makes it simpler than the ephemeral path beside it: there is no
+/// store lifetime to keep alive while result streams drain.
+#[cfg(feature = "host-component-plugins")]
+async fn invoke_service_export(
+    accessor: &Accessor<SharedCtx>,
+    params: &[Val],
+    results: &mut [Val],
+    inv: &LinkedExportInvocation,
+    service_call: &Arc<ServiceExportCall>,
+) -> wasmtime::Result<()> {
+    let args = if service_call.plain {
+        // Nothing in this signature can carry a handle, so relocation would
+        // walk every value only to clone it. Skip to the clone.
+        params.iter().cloned().map(Relocated::Val).collect()
+    } else {
+        accessor.with(|mut access| {
+            // The drain signals belong to pumps running under the caller's
+            // store, which outlives this call, so they are dropped rather than
+            // awaited.
+            extract_all(
+                access.as_context_mut(),
+                params,
+                &service_call.param_tys,
+                &mut Vec::new(),
+            )
+        })?
+    };
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        "invoking service export"
+    );
+
+    let (reply, reply_rx) = tokio::sync::oneshot::channel();
+    let call = ServiceExportTask {
+        func_idx: inv.func_idx,
+        import_name: inv.import_name.clone(),
+        export_name: inv.export_name.clone(),
+        args,
+        result_tys: Arc::clone(&service_call.result_tys),
+        plain: service_call.plain,
+        reply,
+    };
+    crate::engine::dispatch::dispatch_to_service(&service_call.calls, Box::new(call))
+        .await
+        .map_err(|e| {
+            wasmtime::format_err!(
+                "{}.{} could not be delivered to the workload's service: {e:#}",
+                inv.import_name,
+                inv.export_name
+            )
+        })?;
+    // The dispatch above returns once the call has run, so its outcome is
+    // already here.
+    let relocated = reply_rx
+        .await
+        .map_err(|_| wasmtime::format_err!("the service dropped the call before replying"))??;
+
+    accessor.with(|mut access| inject_results(access.as_context_mut(), relocated, results))?;
+
+    trace!(
+        name = %inv.import_name,
+        fn_name = %inv.export_name,
+        "invoked service export"
+    );
+
+    Ok(())
+}
+
+/// The service side of [`invoke_service_export`]: injects the arguments into the
+/// service store, calls the export on the running instance, and relocates the
+/// results back out.
+///
+/// A trap here is reported to the caller *and* faults the service store, which
+/// the service supervisor restarts — the same outcome an inbound HTTP request
+/// that trapped has.
+#[cfg(feature = "host-component-plugins")]
+struct ServiceExportTask {
+    func_idx: ComponentExportIndex,
+    import_name: Arc<str>,
+    export_name: Arc<str>,
+    args: Vec<Relocated>,
+    result_tys: Arc<[Type]>,
+    /// See [`ServiceExportCall::plain`].
+    plain: bool,
+    reply: tokio::sync::oneshot::Sender<wasmtime::Result<Vec<Relocated>>>,
+}
+
+#[cfg(feature = "host-component-plugins")]
+impl crate::engine::dispatch::GuestCall for ServiceExportTask {
+    fn call<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: wasmtime::component::Instance,
+    ) -> crate::engine::dispatch::GuestCallFuture<'a> {
+        Box::pin(async move {
+            let ServiceExportTask {
+                func_idx,
+                import_name,
+                export_name,
+                args,
+                result_tys,
+                plain,
+                reply,
+            } = *self;
+
+            let prepared = accessor.with(|mut access| -> wasmtime::Result<_> {
+                let func = instance.get_func(&mut access, func_idx).with_context(|| {
+                    format!("function not found for service export {import_name}.{export_name}")
+                })?;
+                let mut arg_vals = Vec::with_capacity(args.len());
+                for arg in args {
+                    arg_vals.push(relocate::inject(access.as_context_mut(), arg)?);
+                }
+                Ok((func, arg_vals))
+            });
+            let (func, arg_vals) = match prepared {
+                Ok(prepared) => prepared,
+                Err(e) => {
+                    let _ = reply.send(Err(e));
+                    return Ok(());
+                }
+            };
+
+            let mut results = vec![Val::Bool(false); result_tys.len()];
+            let call_timeout = crate::timeouts::ephemeral_call();
+            match timeout(
+                call_timeout,
+                func.call_concurrent(accessor, &arg_vals, &mut results),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    let _ = reply.send(Err(
+                        e.context(format!("{import_name}.{export_name} trapped"))
+                    ));
+                    return Ok(());
+                }
+                // The guest work is still running on the service's instance: a
+                // guest subtask cannot be cancelled from the host, and the
+                // service is the workload's one instance, so there is nothing to
+                // retire. The caller is told, and the service keeps serving.
+                Err(e) => {
+                    let _ = reply.send(Err(wasmtime::format_err!(
+                        "{import_name}.{export_name} timed out after {call_timeout:?}: {e}"
+                    )));
+                    return Ok(());
+                }
+            }
+
+            // Extracted in the service store, whose own `run_concurrent` keeps
+            // any result-stream pumps running — so the drain signals are dropped
+            // here rather than awaited.
+            let extracted = if plain {
+                Ok(results.into_iter().map(Relocated::Val).collect())
+            } else {
+                accessor.with(|mut access| {
+                    extract_all(
+                        access.as_context_mut(),
+                        &results,
+                        &result_tys,
+                        &mut Vec::new(),
+                    )
+                })
+            };
+            let _ = reply.send(extracted);
+            Ok(())
+        })
+    }
+}
+
+/// Prepare `vals` to cross a store boundary, appending the drain signal of any
+/// stream/future pump it sets up to `dones`.
+///
+/// Whether those signals are awaited or dropped is the caller's to decide, and
+/// it differs by path: a store about to be torn down has to wait for its result
+/// streams to drain, while one that goes on running does not.
+fn extract_all(
+    mut access: StoreContextMut<'_, SharedCtx>,
+    vals: &[Val],
+    tys: &[Type],
+    dones: &mut Vec<Done>,
+) -> wasmtime::Result<Vec<Relocated>> {
+    let mut out = Vec::with_capacity(vals.len());
+    for (val, ty) in vals.iter().zip(tys.iter()) {
+        out.push(relocate::extract(access.as_context_mut(), val, ty, dones)?);
+    }
+    Ok(out)
+}
+
+/// Rebuild relocated values in this store and write them into the caller's
+/// result slots.
+fn inject_results(
+    mut access: StoreContextMut<'_, SharedCtx>,
+    relocated: Vec<Relocated>,
+    results: &mut [Val],
+) -> wasmtime::Result<()> {
+    for (i, r) in relocated.into_iter().enumerate() {
+        let v = relocate::inject(access.as_context_mut(), r)?;
+        *results.get_mut(i).context("result index out of bounds")? = v;
+    }
     Ok(())
 }
 

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -842,11 +842,16 @@ async fn invoke_ephemeral_plain(
             abandoned: call.flag(),
             attributes: Arc::clone(&attributes),
         }));
-        let outcome = instance_pool::offer_or_install(pool, &ephemeral_call.pre, job, || {
+        // The label belongs to store creation alone: a component that will not
+        // instantiate fails inside `offer_or_install` too, and reporting that as
+        // a store failure points an operator at the wrong thing.
+        let outcome = instance_pool::offer_or_install(pool, &ephemeral_call.pre, job, || async {
             new_ephemeral_store(ephemeral_call)
+                .await
+                .map_err(|e| anyhow::anyhow!("new pooled store creation failed: {e:#}"))
         })
         .await
-        .map_err(|e| wasmtime::format_err!("new pooled store creation failed: {e:#}"))?;
+        .map_err(|e| wasmtime::format_err!("{e:#}"))?;
         match outcome {
             Ok(()) => {
                 let vals = call
@@ -1049,11 +1054,11 @@ async fn invoke_service_export(
             inv.export_name
         )
     })?;
-    // The dispatch above returns once the call has run, so its outcome is
-    // already here.
+    // The dispatch above returns once the call has run, and reports a call that
+    // did not — so anything waiting here is a success.
     let relocated = reply_rx
         .await
-        .map_err(|_| wasmtime::format_err!("the service dropped the call before replying"))??;
+        .map_err(|_| wasmtime::format_err!("the service dropped the call before replying"))?;
 
     accessor.with(|mut access| inject_results(access.as_context_mut(), relocated, results))?;
 
@@ -1070,9 +1075,9 @@ async fn invoke_service_export(
 /// service store, calls the export on the running instance, and relocates the
 /// results back out.
 ///
-/// A trap here is reported to the caller *and* faults the service store, which
-/// the service supervisor restarts — the same outcome an inbound HTTP request
-/// that trapped has.
+/// A trap here is reported to the caller as the host's own `Err` — the call did
+/// not complete — *and* faults the service store, which the service supervisor
+/// restarts. The same outcome an inbound HTTP request that trapped has.
 #[cfg(feature = "host-component-plugins")]
 struct ServiceExportTask {
     func_idx: ComponentExportIndex,
@@ -1084,7 +1089,10 @@ struct ServiceExportTask {
     result_tys: Arc<[Type]>,
     /// See [`ServiceExportCall::plain`].
     plain: bool,
-    reply: tokio::sync::oneshot::Sender<wasmtime::Result<Vec<Relocated>>>,
+    /// The results, when the call completed. A call that did not says so by
+    /// returning `Err`, which is what the caller reads instead — so nothing but
+    /// a success ever travels here.
+    reply: tokio::sync::oneshot::Sender<Vec<Relocated>>,
 }
 
 #[cfg(feature = "host-component-plugins")]
@@ -1122,10 +1130,10 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
             });
             let (func, arg_vals) = match prepared {
                 Ok(prepared) => prepared,
-                Err(e) => {
-                    let _ = reply.send(Err(e));
-                    return Ok(Some("host"));
-                }
+                // Reported by returning rather than on `reply`: a call that did
+                // not complete is the host's `Err`, and the caller reads that
+                // instead of the results channel.
+                Err(e) => return Err(anyhow::anyhow!("{e:#}")),
             };
 
             let mut results = vec![Val::Bool(false); result_tys.len()];
@@ -1137,10 +1145,9 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
                 .call_concurrent(accessor, &arg_vals, &mut results)
                 .await
             {
-                let _ = reply.send(Err(
-                    e.context(format!("{import_name}.{export_name} trapped"))
+                return Err(anyhow::anyhow!(
+                    "{import_name}.{export_name} trapped: {e:#}"
                 ));
-                return Ok(Some("trap"));
             }
 
             // Extracted in the service store, whose own `run_concurrent` keeps
@@ -1158,9 +1165,8 @@ impl crate::engine::dispatch::GuestCall for ServiceExportTask {
                     )
                 })
             };
-            let refused = extracted.is_err().then_some("host");
-            let _ = reply.send(extracted);
-            Ok(refused)
+            let _ = reply.send(extracted.map_err(|e| anyhow::anyhow!("{e:#}"))?);
+            Ok(None)
         })
     }
 }

--- a/crates/wash-runtime/src/engine/mod.rs
+++ b/crates/wash-runtime/src/engine/mod.rs
@@ -219,6 +219,7 @@ pub fn targets_wasip3_http(component: &Component) -> bool {
 
 pub mod abandon;
 pub mod ctx;
+pub mod dispatch;
 pub mod guest_memory;
 pub(crate) mod instance_driver;
 pub(crate) mod instance_pool;

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -2010,7 +2010,22 @@ impl ResolvedWorkload {
             }
             return match export_named(service.component_exports().ok(), interface) {
                 Some(export) => ItemExport::Service { export },
-                None => ItemExport::None,
+                // The world says it serves this and the component does not name
+                // it so: a version the two spell differently, or exports that
+                // would not parse. Loudly, because everything downstream reads
+                // the same as a service that simply does not export it — the
+                // workload deploys healthy and every call naming it fails with
+                // nothing to connect that to the service.
+                None => {
+                    tracing::warn!(
+                        workload_id = %self.id,
+                        service = item_id,
+                        %interface,
+                        "the workload\'s service declares this interface but exports no \
+                         instance matching it; deploying without that route"
+                    );
+                    ItemExport::None
+                }
             };
         }
         let components = self.components.read().await;

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -1731,6 +1731,11 @@ impl ResolvedWorkload {
     /// a warm instance, a store built for it, or the running service — is the
     /// host's to decide; see [`crate::engine::dispatch`].
     ///
+    /// `plugin` is the dispatcher's own [`HostPlugin::id`], which names it in
+    /// the guest-execution metrics its calls produce. It is `'static` because a
+    /// plugin id is fixed for the life of the build, and the attribute would
+    /// otherwise be a dimension traffic could invent.
+    ///
     /// # What it changes for a service
     ///
     /// A claimed service is run with an ingress for those calls, so it outlives
@@ -1750,8 +1755,12 @@ impl ResolvedWorkload {
     ///   starts.
     ///
     /// [`HostPlugin::on_workload_resolved`]: crate::plugin::HostPlugin::on_workload_resolved
-    pub async fn dispatch_target(&self, item_id: &str) -> anyhow::Result<DispatchTarget> {
-        DispatchTarget::resolve(self, item_id).await
+    pub async fn dispatch_target(
+        &self,
+        item_id: &str,
+        plugin: &'static str,
+    ) -> anyhow::Result<DispatchTarget> {
+        DispatchTarget::resolve(self, item_id, plugin).await
     }
 
     /// Whether `item_id` names this workload's service rather than one of its
@@ -1844,13 +1853,14 @@ impl ResolvedWorkload {
     /// store holds the whole linked set, so keeping it warm keeps all of them
     /// warm.
     ///
-    /// For a dispatch path that keeps its own warm set rather than going
-    /// through the shared [`InstancePool`] (the `wasmcloud:nats` subscriber,
-    /// whose calls carry typed resources no [`InstanceJob`] can).
-    ///
-    /// [`InstanceJob`]: crate::engine::instance_driver::InstanceJob
-    #[cfg_attr(not(feature = "wasmcloud-nats"), allow(dead_code))]
-    pub(crate) async fn warm_instance_policy(&self, component_id: &str) -> InstancePolicy {
+    /// For a plugin that has to keep a warm set of its own rather than
+    /// dispatching through [`Self::dispatch_target`] — the `wasmcloud:nats`
+    /// subscriber's JetStream deliveries, whose call carries a typed `resource`
+    /// handle that is an index into the very store table it must run in, so its
+    /// argument cannot exist before the store is chosen. Anything that *can*
+    /// take the dispatch path should, and get the pool itself rather than only
+    /// the numbers describing it.
+    pub async fn warm_instance_policy(&self, component_id: &str) -> InstancePolicy {
         match self.instance_pool_for_component(component_id).await {
             Some(pool) => pool.policy(),
             None => InstancePolicy::Ephemeral,
@@ -2159,6 +2169,8 @@ impl ResolvedWorkload {
             bail!("the workload's service does not export {interface}");
         };
         let service_id: Arc<str> = Arc::from(service.id());
+        let service_identity =
+            crate::observability::WorkloadIdentity::new(self.namespace(), self.name(), "service");
 
         let mut invocations = BTreeMap::new();
         for func in funcs {
@@ -2194,6 +2206,8 @@ impl ResolvedWorkload {
                         param_tys: func.param_tys.into(),
                         result_tys: func.result_tys.into(),
                         plain,
+                        attributes: service_identity
+                            .attributes("linked", &format!("{interface}#{}", func.name)),
                     })),
                 },
             );

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -20,14 +20,17 @@ use wasmtime_wasi::p2::bindings::CommandPre;
 #[cfg(feature = "wasi-tls")]
 use crate::engine::ctx::SharedTlsProvider;
 #[cfg(feature = "host-component-plugins")]
-use crate::engine::linked_call::{types_are_bridge_safe, types_are_ephemeral_safe};
+use crate::engine::linked_call::{
+    ServiceExportCall, types_are_bridge_safe, types_are_ephemeral_safe,
+};
 use crate::{
     engine::{
         ctx::SharedCtx,
+        dispatch::{DispatchTarget, INGRESS_BACKLOG, ServiceCalls, ServiceClaim},
         instance_pool::{self, InstancePolicy, InstancePool},
         linked_call::{
             ComponentCtxTemplate, EphemeralCallMode, EphemeralLinkedCall, LinkedExportInvocation,
-            func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
+            LinkedTarget, func_is_bridge_safe, func_is_ephemeral_safe, invoke_linked_async_export,
             invoke_linked_sync_export, new_store_from_templates,
         },
         volumes::{ResolvedVolumeMount, resolve_component_volume_mounts_in_map},
@@ -50,8 +53,7 @@ pub(crate) struct ExternalCallFunc<'a> {
 
 /// What [`ResolvedWorkload::item_exporting`] found about the one item it was
 /// asked about: whether that item exports an interface a host component plugin
-/// imports, and — for a component, the only kind a plugin can call — how to
-/// address the export.
+/// imports, and how to address the export.
 #[cfg(feature = "host-component-plugins")]
 pub(crate) enum ItemExport {
     /// A component exports it.
@@ -67,14 +69,32 @@ pub(crate) enum ItemExport {
         /// by the plugin's name misses it.
         export: Arc<str>,
     },
-    /// The workload's long-lived service exports it. A plugin cannot call it:
-    /// reaching the *running* service means routing into its live instance, the
-    /// way inbound messaging does, and a call built like a component's would
-    /// instead instantiate a second copy whose state is not the one the service
-    /// has been accumulating.
-    Service,
+    /// The workload's long-lived service exports it. Reached by routing into
+    /// the instance already running, the way inbound HTTP and messaging are —
+    /// never by instantiating a second copy, whose state would not be the one
+    /// the service has been accumulating.
+    Service {
+        /// The service's own name for the export, as for a component.
+        export: Arc<str>,
+    },
     /// Neither — this item bound to the plugin for a capability it imports.
     None,
+}
+
+/// The item's own name for the export serving `interface`, if it has one.
+///
+/// Not the plugin's name for the import: the two agree except where matching
+/// tolerated a version on one side only, and addressing the export on an
+/// instance needs the name the item actually used.
+#[cfg(feature = "host-component-plugins")]
+fn export_named(
+    exports: Option<Vec<(String, ComponentItem)>>,
+    interface: &WitInterface,
+) -> Option<Arc<str>> {
+    exports?
+        .into_iter()
+        .find(|(name, _)| WitInterface::from(name.as_str()).contains(interface))
+        .map(|(name, _)| Arc::from(name))
 }
 
 /// Type alias for tracking bound plugins with their matched interfaces during binding.
@@ -592,6 +612,15 @@ pub struct ResolvedWorkload {
     invocation: crate::observability::InvocationMeter,
     /// An optional service component that runs once to completion or for the duration of the workload
     service: Option<WorkloadService>,
+    /// The ingress plugin-dispatched calls reach the service on, once one has
+    /// claimed it as a [`DispatchTarget`]. Present whether or not the workload
+    /// has a service — an unclaimed one costs a lock and an empty option.
+    service_calls: Arc<ServiceCalls>,
+    /// Set when the workload is being torn down. A [`DispatchTarget`] outlives
+    /// the workload it names — a plugin holds one until it is unbound, and is
+    /// unbound only after teardown has begun — so a dispatch already on its way
+    /// checks this rather than instantiating into a workload that is going away.
+    released: Arc<std::sync::atomic::AtomicBool>,
     /// The requested host [`WitInterface`]s to resolve this workload
     host_interfaces: Vec<WitInterface>,
     /// TLS provider override for `wasi:tls` client connections in this workload.
@@ -672,23 +701,32 @@ impl ServiceStoreRecipe {
 /// paired senders to register with the host-side HTTP/messaging ingresses. Called
 /// once per incarnation (start and each restart) so a restarted service gets fresh
 /// channels whose senders replace the stale registrations.
+///
+/// The plugin-dispatch ingress is built the same way, but its sender is swapped
+/// inside [`ServiceCalls`] rather than returned: dispatchers hold the ingress
+/// itself, so a restart replaces the channel under them with nothing to
+/// re-register.
 #[allow(clippy::type_complexity)]
 fn build_trigger_ingresses(
     serves_http: bool,
     serves_messaging: bool,
+    service_calls: &ServiceCalls,
 ) -> (
     Vec<crate::host::trigger_service::Ingress>,
     Option<tokio::sync::mpsc::Sender<crate::host::http::ServiceHttpJob>>,
     Option<tokio::sync::mpsc::Sender<crate::host::trigger_service::MessagingJob>>,
 ) {
     let mut ingresses = Vec::new();
+    if let Some(rx) = service_calls.next_incarnation() {
+        ingresses.push(crate::host::trigger_service::Ingress::Guest(rx));
+    }
     let http_tx = serves_http.then(|| {
-        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        let (tx, rx) = tokio::sync::mpsc::channel(INGRESS_BACKLOG);
         ingresses.push(crate::host::trigger_service::Ingress::Http(rx));
         tx
     });
     let messaging_tx = serves_messaging.then(|| {
-        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        let (tx, rx) = tokio::sync::mpsc::channel(INGRESS_BACKLOG);
         ingresses.push(crate::host::trigger_service::Ingress::Messaging(rx));
         tx
     });
@@ -699,18 +737,25 @@ impl ResolvedWorkload {
     /// Executes the service, if present, and returns whether it was run.
     #[instrument(name="execute_service", skip_all, fields(workload.id = self.id.as_ref(), workload.name = self.name.as_ref(), workload.namespace = self.namespace.as_ref()))]
     pub(crate) async fn execute_service(&mut self) -> anyhow::Result<Option<Arc<JoinHandle<()>>>> {
+        // Which ingresses the service runs with is settled here, so a plugin
+        // claiming it as a dispatch target from now on is refused rather than
+        // handed a channel nothing would ever serve.
+        self.service_calls.mark_started();
         if self
             .service
             .as_ref()
             .is_some_and(|s| s.metadata.targets_p3())
         {
-            // A p3 service that also exports a host-invoked handler (today
-            // `wasi:http/handler`) co-drives it with `cli/run` on one instance
-            // (see the `trigger service` module).
-            if self.service.as_ref().is_some_and(|s| {
-                crate::engine::exports_wasi_http(&s.metadata.component)
-                    || crate::engine::exports_messaging_handler(&s.metadata.component)
-            }) {
+            // A p3 service that also serves something the host delivers to it —
+            // a host-invoked handler export (today `wasi:http/handler`), or
+            // calls a plugin dispatches to it — co-drives that with `cli/run`
+            // on one instance (see the `trigger service` module).
+            if self.service_calls.claimed()
+                || self.service.as_ref().is_some_and(|s| {
+                    crate::engine::exports_wasi_http(&s.metadata.component)
+                        || crate::engine::exports_messaging_handler(&s.metadata.component)
+                })
+            {
                 return self.execute_trigger_service().await;
             }
             return self.execute_service_p3().await;
@@ -871,8 +916,20 @@ impl ResolvedWorkload {
         // instantiating a component per request/message. The first registration is
         // synchronous (before the driver spawns) so a delivery immediately after
         // start finds the handler; restarts re-register from inside the supervisor.
+        // What a failing `cli/run` costs this service. A service the host only
+        // *dispatches* to would, without that ingress, run as a plain p3
+        // service — where a `cli/run` error ends the incarnation and spends a
+        // restart. Keep that: which plugins a workload binds must not change
+        // what its `maxRestarts` means. A service whose handler exports are the
+        // point keeps the standing behavior, where the handlers go on serving.
+        let cli_run_error = if serves_http || serves_messaging {
+            crate::host::trigger_service::CliRunError::Logged
+        } else {
+            crate::host::trigger_service::CliRunError::Fatal
+        };
+        let service_calls = Arc::clone(&self.service_calls);
         let (ingresses, http_tx, messaging_tx) =
-            build_trigger_ingresses(serves_http, serves_messaging);
+            build_trigger_ingresses(serves_http, serves_messaging, &service_calls);
         if let Some(http_tx) = http_tx {
             self.http_handler
                 .on_service_http_resolved(self.id(), &ingress_hostnames, http_tx)
@@ -900,7 +957,7 @@ impl ResolvedWorkload {
                     Some(ingresses) => ingresses,
                     None => {
                         let (ingresses, http_tx, messaging_tx) =
-                            build_trigger_ingresses(serves_http, serves_messaging);
+                            build_trigger_ingresses(serves_http, serves_messaging, &service_calls);
                         if let Some(http_tx) = http_tx
                             && let Err(e) = http_handler
                                 .on_service_http_resolved(&workload_id, &ingress_hostnames, http_tx)
@@ -918,8 +975,13 @@ impl ResolvedWorkload {
                         ingresses
                     }
                 };
-                match crate::host::trigger_service::run_trigger_driver(&mut store, &pre, ingresses)
-                    .await
+                match crate::host::trigger_service::run_trigger_driver(
+                    &mut store,
+                    &pre,
+                    ingresses,
+                    cli_run_error,
+                )
+                .await
                 {
                     Ok(()) => {
                         info!("trigger service exited");
@@ -953,8 +1015,25 @@ impl ResolvedWorkload {
         Ok(Some(handle))
     }
 
+    /// Let go of everything this workload is running, as the first step of
+    /// tearing it down (see `crate::host::release`, the one funnel every
+    /// teardown path goes through).
+    ///
+    /// Dispatch stops here rather than when the plugins are unbound: a plugin
+    /// still holding a [`DispatchTarget`] must not build — or park — an
+    /// instance in a workload that is going away.
+    pub(crate) fn begin_teardown(&self) {
+        self.released
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        // Close the dispatch ingress too, so a plugin mid-delivery to the
+        // service is told now rather than waiting on a reply from a driver that
+        // is about to be aborted.
+        self.service_calls.shutdown();
+        self.stop_service();
+    }
+
     /// Aborts the running service [`JoinHandle`] if it exists.
-    pub(crate) fn stop_service(&self) {
+    fn stop_service(&self) {
         if let Some(service) = &self.service
             && let Some(handle) = &service.handle
         {
@@ -1318,8 +1397,7 @@ impl ResolvedWorkload {
                                 let relocate = !plain_safe
                                     && is_service_workload
                                     && func_is_bridge_safe(&func_ty);
-                                let ephemeral_call = if export_is_async && (plain_safe || relocate)
-                                {
+                                let target = if export_is_async && (plain_safe || relocate) {
                                     let mode = if relocate {
                                         EphemeralCallMode::Relocated {
                                             param_tys: func_ty.params().map(|(_, ty)| ty).collect(),
@@ -1328,7 +1406,8 @@ impl ResolvedWorkload {
                                     } else {
                                         EphemeralCallMode::PlainValue
                                     };
-                                    Some(Arc::new(EphemeralLinkedCall {
+                                    LinkedTarget::Ephemeral(Arc::new(EphemeralLinkedCall {
+                                        pre: pre.clone(),
                                         invocation: self.invocation.clone(),
                                         engine: plugin_engine.clone(),
                                         http_handler: self.http_handler.clone(),
@@ -1340,17 +1419,16 @@ impl ResolvedWorkload {
                                         mode,
                                     }))
                                 } else {
-                                    None
+                                    LinkedTarget::SharedStore
                                 };
 
                                 let inv = LinkedExportInvocation {
                                     import_name: import_name.into(),
                                     export_name: export_name.into(),
-                                    pre: pre.clone(),
                                     plugin_component_id: plugin_component.id.clone(),
                                     func_idx,
                                     param_tys: Arc::default(),
-                                    ephemeral_call,
+                                    target,
                                 };
 
                                 linked_components.insert(inv.plugin_component_id.clone());
@@ -1495,6 +1573,13 @@ impl ResolvedWorkload {
         &self.namespace
     }
 
+    /// Id of this workload's long-lived service, if it has one. A plugin is
+    /// handed item ids without being told which kind each is; this is how one
+    /// tells the service apart from a component.
+    pub fn service_id(&self) -> Option<&str> {
+        self.service.as_ref().map(|s| s.id())
+    }
+
     /// Returns the number of components in this workload.
     /// Does not include the service component if one is defined.
     pub async fn component_count(&self) -> usize {
@@ -1513,6 +1598,12 @@ impl ResolvedWorkload {
     /// without a call to hang the number on — the only correct instrument for a
     /// store several calls share. See
     /// [`crate::engine::abandon::GuestExecution`].
+    ///
+    /// This is the raw store, and a store of its own is what the component asked
+    /// *not* to have when it set `poolSize`. A host plugin calling into a
+    /// workload should go through [`Self::dispatch_target`] instead, which
+    /// serves the call on a warm instance where there is one — and reaches the
+    /// workload's service, which has no store to build at all.
     pub async fn new_store(
         &self,
         component_id: &str,
@@ -1622,6 +1713,115 @@ impl ResolvedWorkload {
             // something.
             name.as_deref().unwrap_or("unknown"),
         )
+    }
+
+    /// Whether this workload is being torn down, and so must take no more
+    /// dispatched calls.
+    pub(crate) fn released(&self) -> bool {
+        self.released.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Resolve one of this workload's items — a component, or its service — as
+    /// something a host plugin can dispatch work to.
+    ///
+    /// This is how a plugin that drives an external event stream reaches the
+    /// workload's guest code: it resolves a target for each item it was told
+    /// about, from [`HostPlugin::on_workload_resolved`], and dispatches through
+    /// it for as long as the workload runs. Where the call ends up running —
+    /// a warm instance, a store built for it, or the running service — is the
+    /// host's to decide; see [`crate::engine::dispatch`].
+    ///
+    /// # What it changes for a service
+    ///
+    /// A claimed service is run with an ingress for those calls, so it outlives
+    /// its own `cli/run`: a push-mode handler whose `run` returns — or which has
+    /// no long-running work at all — stays up to keep receiving. Its restart
+    /// budget still means what the workload said it means, though: a `cli/run`
+    /// that *fails* ends the incarnation and spends one restart, exactly as it
+    /// would without any of this.
+    ///
+    /// # Errors
+    ///
+    /// - the workload has no such item, or
+    /// - the item is a service that cannot serve dispatched calls: a p2 service
+    ///   has no concurrent driver to run one alongside its `cli/run`, and a
+    ///   service already running cannot have an ingress added to it — which is
+    ///   why this belongs in `on_workload_resolved`, before the workload
+    ///   starts.
+    ///
+    /// [`HostPlugin::on_workload_resolved`]: crate::plugin::HostPlugin::on_workload_resolved
+    pub async fn dispatch_target(&self, item_id: &str) -> anyhow::Result<DispatchTarget> {
+        DispatchTarget::resolve(self, item_id).await
+    }
+
+    /// Whether `item_id` names this workload's service rather than one of its
+    /// components.
+    ///
+    /// Says nothing about whether that service *can* serve dispatched calls —
+    /// see [`Self::service_can_dispatch`], which the callers ask separately
+    /// because they answer a refusal differently.
+    pub(crate) fn is_service_item(&self, item_id: &str) -> bool {
+        self.service.as_ref().is_some_and(|s| s.id() == item_id)
+    }
+
+    /// Claim this workload's service as a dispatch target, refusing when it
+    /// could never serve one. The claim keeps the service's ingress in place
+    /// (see [`ServiceClaim`]); dropping or releasing it before the service
+    /// starts takes the ingress back.
+    pub(crate) fn claim_service_dispatch(&self) -> anyhow::Result<ServiceClaim> {
+        self.service_can_dispatch()?;
+        self.service_calls.claim()
+    }
+
+    /// Whether this workload's service could serve a call dispatched to it.
+    ///
+    /// A p2 service drives `wasi:cli/run` and nothing else: it has no
+    /// concurrent driver for a call to run alongside that, so there is nowhere
+    /// to deliver one. Asking for such a target is an error; *finding* one while
+    /// binding a plugin is not, and leaves the workload deploying without that
+    /// route.
+    pub(crate) fn service_can_dispatch(&self) -> anyhow::Result<()> {
+        let service = self
+            .service
+            .as_ref()
+            .context("workload has no service to dispatch to")?;
+        ensure!(
+            service.metadata.targets_p3(),
+            "workload '{}' runs a p2 service, which drives `wasi:cli/run` alone and cannot serve \
+             a call dispatched to it; a service a plugin calls into must target wasip3",
+            self.id
+        );
+        Ok(())
+    }
+
+    /// What dispatching to `component_id` needs, resolved once: this workload's
+    /// own key for it (so a caller holding one does not keep a second copy of
+    /// the id), the component pre-linked against its linker, and the warm set
+    /// its calls run on.
+    ///
+    /// All three under one read lock, so a dispatch takes none: what they answer
+    /// is settled when the workload resolves (see
+    /// [`WorkloadComponent::pre_instantiate_ref`] and [`instance_pool::poolable`]).
+    pub(crate) async fn component_dispatch(
+        &self,
+        component_id: &str,
+    ) -> anyhow::Result<(Arc<str>, InstancePre<SharedCtx>, Option<Arc<InstancePool>>)> {
+        let components = self.components.read().await;
+        let (id, component) = components.get_key_value(component_id).with_context(|| {
+            format!(
+                "workload '{}' has no item '{component_id}' to dispatch to",
+                self.id
+            )
+        })?;
+        let pre = component.pre_instantiate_ref().with_context(|| {
+            format!("component '{component_id}' cannot be pre-instantiated to dispatch to")
+        })?;
+        let pool = instance_pool::poolable(
+            &components,
+            component_id,
+            &component.metadata.linked_components,
+        );
+        Ok((Arc::clone(id), pre, pool))
     }
 
     pub(crate) async fn instance_pool_for_component(
@@ -1756,6 +1956,13 @@ impl ResolvedWorkload {
         })
     }
 
+    /// Pre-link `component_id` against its linker, ready to instantiate into a
+    /// store the caller owns.
+    ///
+    /// Only a *component* has one: the workload's service is already
+    /// instantiated, so a plugin that would call into either goes through
+    /// [`Self::dispatch_target`], which covers both and keeps warm instances in
+    /// play.
     pub async fn instantiate_pre(
         &self,
         component_id: &str,
@@ -1788,29 +1995,19 @@ impl ResolvedWorkload {
         if let Some(service) = &self.service
             && service.id() == item_id
         {
-            return if exports(&service.world()) {
-                ItemExport::Service
-            } else {
-                ItemExport::None
+            if !exports(&service.world()) {
+                return ItemExport::None;
+            }
+            return match export_named(service.component_exports().ok(), interface) {
+                Some(export) => ItemExport::Service { export },
+                None => ItemExport::None,
             };
         }
         let components = self.components.read().await;
         let Some(component) = components.get(item_id) else {
             return ItemExport::None;
         };
-        // The export's own name, not the plugin's name for the import: the two
-        // agree except where matching tolerated a version on one side only, and
-        // addressing the instance needs the name the component actually used.
-        let Some(export) = component
-            .component_exports()
-            .ok()
-            .and_then(|exports| {
-                exports
-                    .into_iter()
-                    .find(|(name, _)| WitInterface::from(name.as_str()).contains(interface))
-            })
-            .map(|(name, _)| Arc::from(name))
-        else {
+        let Some(export) = export_named(component.component_exports().ok(), interface) else {
             return ItemExport::None;
         };
         ItemExport::Component {
@@ -1824,9 +2021,10 @@ impl ResolvedWorkload {
     /// where the plugin serves what a workload imports.
     ///
     /// A plugin runs in a store of its own, so such a call can never share one
-    /// with the callee: every invocation returned takes the ephemeral path,
-    /// which builds a store for the callee per call (or reuses one of its warm
-    /// instances) and moves arguments and results across the boundary.
+    /// with the callee: arguments and results always move across the boundary.
+    /// A component is called in a store of its own — one of its warm instances,
+    /// or one built for the call — and the workload's service on the instance
+    /// it already runs as.
     ///
     /// A function the callee does not export, or whose signature carries a
     /// `resource` or `error-context` handle that cannot cross, fails the
@@ -1905,11 +2103,11 @@ impl ResolvedWorkload {
                 LinkedExportInvocation {
                     import_name: Arc::from(interface),
                     export_name: Arc::from(func.name),
-                    pre: pre.clone(),
                     plugin_component_id: Arc::clone(&component_id),
                     func_idx,
                     param_tys: Arc::default(),
-                    ephemeral_call: Some(Arc::new(EphemeralLinkedCall {
+                    target: LinkedTarget::Ephemeral(Arc::new(EphemeralLinkedCall {
+                        pre: pre.clone(),
                         invocation: self.invocation.clone(),
                         engine: engine.clone(),
                         http_handler: self.http_handler.clone(),
@@ -1919,6 +2117,83 @@ impl ResolvedWorkload {
                         #[cfg(feature = "wasi-tls")]
                         tls_provider: self.tls_provider.clone(),
                         mode,
+                    })),
+                },
+            );
+        }
+        Ok(invocations)
+    }
+
+    /// [`Self::external_export_invocations`] for the workload's service.
+    ///
+    /// The service already runs; a call reaches it over the ingress `claim`
+    /// holds open, on the instance driving `cli/run`, so there is no store to
+    /// build and no `InstancePre` to instantiate.
+    ///
+    /// The caller brings the claim rather than one being taken here, because the
+    /// claim is what makes the service run with an ingress at all: a caller that
+    /// resolves these invocations and then discards them — a plugin routing to a
+    /// component instead — must be able to take that back.
+    ///
+    /// Every argument and result crosses as a relocated value, so the same
+    /// signatures a component may serve are exactly the ones a service may:
+    /// plain values, `stream<T>` and `future<T>`, and nothing carrying a
+    /// `resource` handle.
+    #[cfg(feature = "host-component-plugins")]
+    pub(crate) fn service_export_invocations(
+        &self,
+        claim: &ServiceClaim,
+        interface: &str,
+        funcs: &[ExternalCallFunc<'_>],
+    ) -> anyhow::Result<BTreeMap<Arc<str>, LinkedExportInvocation>> {
+        // No `service_can_dispatch` check here: holding a claim is proof of it,
+        // since `claim_service_dispatch` refuses to mint one otherwise.
+        let service = self
+            .service
+            .as_ref()
+            .context("workload has no service to call into")?;
+        let component = &service.metadata.component;
+        let Some((ComponentItem::ComponentInstance(_), instance_idx)) =
+            component.get_export(None, interface)
+        else {
+            bail!("the workload's service does not export {interface}");
+        };
+        let service_id: Arc<str> = Arc::from(service.id());
+
+        let mut invocations = BTreeMap::new();
+        for func in funcs {
+            let Some((ComponentItem::ComponentFunc(_), func_idx)) =
+                component.get_export(Some(&instance_idx), func.name)
+            else {
+                bail!(
+                    "the workload's service exports {interface} but not {}, which a host \
+                     component plugin imports; the workload's copy of the interface disagrees \
+                     with the plugin's",
+                    func.name
+                );
+            };
+            ensure!(
+                types_are_bridge_safe(func.param_tys) && types_are_bridge_safe(func.result_tys),
+                "{interface}#{} carries a handle that cannot cross the boundary between a \
+                 plugin's store and a workload's; only plain values, `stream<T>`, and \
+                 `future<T>` can",
+                func.name
+            );
+            let plain = types_are_ephemeral_safe(func.param_tys)
+                && types_are_ephemeral_safe(func.result_tys);
+            invocations.insert(
+                Arc::from(func.name),
+                LinkedExportInvocation {
+                    import_name: Arc::from(interface),
+                    export_name: Arc::from(func.name),
+                    plugin_component_id: Arc::clone(&service_id),
+                    func_idx,
+                    param_tys: Arc::default(),
+                    target: LinkedTarget::Service(Arc::new(ServiceExportCall {
+                        calls: Arc::clone(claim.calls()),
+                        param_tys: func.param_tys.into(),
+                        result_tys: func.result_tys.into(),
+                        plain,
                     })),
                 },
             );
@@ -2667,6 +2942,8 @@ impl UnresolvedWorkload {
             namespace: self.namespace.clone(),
             components: Arc::new(RwLock::new(self.components)),
             service: self.service,
+            service_calls: Arc::default(),
+            released: Arc::default(),
             host_interfaces: self.host_interfaces,
             http_handler: http_handler.clone(),
             invocation: meters.invocation.clone(),

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -2444,29 +2444,19 @@ async fn invoke_component_handler(
         let mut reclaimed = None;
         let req = if let Some(pool) = pool.as_ref() {
             use crate::engine::instance_driver::InstanceJob;
-            use crate::engine::instance_pool::{Declined, Dispatch};
+            use crate::engine::instance_pool::Declined;
             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
             let call = DispatchedCall::new("HTTP (pooled)", crate::timeouts::http_response());
-            let outcome = match pool.try_dispatch(InstanceJob::Http(Box::new(ServiceHttpJob {
+            let job = InstanceJob::Http(Box::new(ServiceHttpJob {
                 req,
                 resp_tx,
                 abandoned: call.flag(),
-            }))) {
-                Dispatch::Sent => Ok(()),
-                // The pool has room. Build and instantiate the store out here,
-                // where awaiting is allowed and where a component that fails
-                // to instantiate reports that failure to this request rather
-                // than only to the log.
-                Dispatch::NeedsInstance(job) => {
-                    let mut store = workload_handle.new_store(component_id).await?;
-                    let instance = instance_pre.instantiate_async(&mut store).await?;
-                    pool.dispatch_on_new(
-                        crate::engine::instance_pool::ComponentInstance { store, instance },
-                        job,
-                    )
-                }
-                Dispatch::Saturated(job) => Err(Declined::without_instance(job)),
-            };
+            }));
+            let outcome =
+                crate::engine::instance_pool::offer_or_install(pool, &instance_pre, job, || {
+                    workload_handle.new_store(component_id)
+                })
+                .await?;
             match outcome {
                 Ok(()) => {
                     let (resp, watch) = call
@@ -2495,6 +2485,7 @@ async fn invoke_component_handler(
                             InstanceJob::Linked(_) => "linked",
                             InstanceJob::Messaging(_) => "messaging",
                             InstanceJob::Plugin(_) => "plugin",
+                            InstanceJob::Guest(_) => "dispatched",
                             InstanceJob::Http(_) => "http",
                         }
                     );

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -2484,7 +2484,6 @@ async fn invoke_component_handler(
                         match other {
                             InstanceJob::Linked(_) => "linked",
                             InstanceJob::Messaging(_) => "messaging",
-                            InstanceJob::Plugin(_) => "plugin",
                             InstanceJob::Guest(_) => "dispatched",
                             InstanceJob::Http(_) => "http",
                         }

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -253,7 +253,7 @@ pub enum HostWorkload {
 /// [`Reservation`] over the whole call. See [`HostApi::workload_stop`] for the
 /// ownership rules that guarantee it.
 async fn release(workload_id: &str, resolved: &ResolvedWorkload) {
-    resolved.stop_service();
+    resolved.begin_teardown();
     if let Err(e) = resolved.unbind_all_plugins().await {
         warn!(
             workload_id,

--- a/crates/wash-runtime/src/host/trigger_service/capability.rs
+++ b/crates/wash-runtime/src/host/trigger_service/capability.rs
@@ -13,6 +13,7 @@ use wasmtime::component::types::Type;
 use wasmtime::component::{Accessor, AccessorTask, ComponentExportIndex, Instance, Val};
 use wasmtime::error::Context as _;
 
+use super::InFlightGuard;
 use crate::engine::ctx::{CallerIdentity, SharedCtx};
 use crate::engine::store::relocate::{self, Relocated};
 use crate::host::job_registry::{JobGuard, JobRegistry};
@@ -210,24 +211,6 @@ pub(super) struct CapabilityTask {
     /// completes or the task is otherwise dropped (e.g. store teardown). Held
     /// across the `.await` so the retire runs however the task ends.
     pub(super) job_guard: JobGuard,
-}
-
-/// Decrements a plugin store's in-flight capability-call counter on drop, so a
-/// slot is reclaimed whether the task completes normally or is cancelled. Backs
-/// the non-blocking admission ceiling (see [`MAX_INFLIGHT_CAPABILITY_CALLS`] for
-/// why a plain atomic rather than a [`tokio::sync::Semaphore`]).
-pub(super) struct InFlightGuard(Arc<AtomicUsize>);
-
-impl InFlightGuard {
-    pub(super) fn new(counter: Arc<AtomicUsize>) -> Self {
-        Self(counter)
-    }
-}
-
-impl Drop for InFlightGuard {
-    fn drop(&mut self) {
-        self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-    }
 }
 
 /// Free every resource whose proxy a caller has dropped since the last flush,

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -20,6 +20,14 @@
 //! [`capability`]); this module holds the shared [`Ingress`] enum, the
 //! `prepare`/`serve` dispatch, and the [`run_trigger_driver`] loop.
 //!
+//! The [`Ingress::Guest`] variant is the one that carries no interface of its
+//! own: a host plugin dispatching work into the service supplies the call
+//! itself, and the ingress only resolves the instance to run it on (see
+//! [`crate::engine::dispatch`]). That is what makes a service reachable on an
+//! interface the host has never heard of — without it, a service exporting a
+//! plugin's interface deploys and then never receives anything, because a
+//! service has no per-call instantiation to fall back on.
+//!
 //! The [`Ingress::Capability`] variant generalizes this to *host component
 //! plugins*: instead of HTTP requests or messages, the host pushes cross-store
 //! capability calls (a workload importing `acme:kv/store`, `wasi:keyvalue`, ...)
@@ -41,6 +49,7 @@ use wasmtime_wasi::p3::bindings::Command;
 use wasmtime_wasi_http::p3::bindings::Service;
 
 use crate::engine::ctx::SharedCtx;
+use crate::engine::dispatch::{GuestJob, GuestTask};
 use crate::host::http::ServiceHttpJob;
 #[cfg(feature = "host-component-plugins")]
 use crate::host::job_registry::JobRegistry;
@@ -74,6 +83,12 @@ pub enum Ingress {
     /// `wasmcloud:messaging/handler@0.3.0` — the messaging subscriber delivers
     /// received messages here. Trigger services are p3-only.
     Messaging(tokio::sync::mpsc::Receiver<MessagingJob>),
+    /// Work a host plugin dispatched to this service, whatever interface it
+    /// exports (see [`crate::engine::dispatch`]). Unlike the ingresses above,
+    /// which each name one interface the host knows, this one carries the
+    /// plugin's own call and only resolves the instance for it — which is what
+    /// lets a service serve an interface the host has never heard of.
+    Guest(tokio::sync::mpsc::Receiver<GuestJob>),
     /// Cross-store capability calls for a host component plugin. `funcs` lists
     /// every exported function to resolve up front; `rx` delivers the calls;
     /// `registry` tracks each served call as a cancellable job; `replay` holds
@@ -115,6 +130,12 @@ impl Ingress {
                     rx,
                 })
             }
+            // Nothing to bind up front: a dispatched call brings its own
+            // bindings and resolves them against the instance itself.
+            Ingress::Guest(rx) => Ok(PreparedIngress::Guest {
+                instance: *instance,
+                rx,
+            }),
             #[cfg(feature = "host-component-plugins")]
             Ingress::Capability {
                 funcs,
@@ -166,6 +187,10 @@ enum PreparedIngress {
     Messaging {
         handler: Arc<messaging::AsyncMessaging>,
         rx: tokio::sync::mpsc::Receiver<MessagingJob>,
+    },
+    Guest {
+        instance: Instance,
+        rx: tokio::sync::mpsc::Receiver<GuestJob>,
     },
     #[cfg(feature = "host-component-plugins")]
     Capability {
@@ -236,6 +261,20 @@ impl PreparedIngress {
                         pool_slot: None,
                     }) {
                         tracing::error!(err = %e, "failed to spawn messaging invocation task");
+                    }
+                }
+                ServeOutcome::Shutdown
+            }
+            PreparedIngress::Guest { instance, rx } => {
+                while let Some(job) = rx.recv().await {
+                    // No pool slot: a service's instance is the workload's one
+                    // long-lived item, not one of a pool's to retire.
+                    if let Err(e) = accessor.spawn(GuestTask {
+                        instance: *instance,
+                        job,
+                        pool_slot: None,
+                    }) {
+                        tracing::error!(err = %e, "failed to spawn dispatched call task");
                     }
                 }
                 ServeOutcome::Shutdown
@@ -397,7 +436,12 @@ impl TriggerService {
         ingresses: Vec<Ingress>,
     ) -> Self {
         let driver = tokio::spawn(async move {
-            if let Err(e) = run_trigger_driver(&mut store, &pre, ingresses).await {
+            // A host component plugin's `cli/run`, where it has one at all, is
+            // incidental to the capabilities it serves: an error there is
+            // reported, and the plugin goes on serving.
+            if let Err(e) =
+                run_trigger_driver(&mut store, &pre, ingresses, CliRunError::Logged).await
+            {
                 tracing::error!(err = %e, "trigger service driver faulted");
             }
         });
@@ -415,6 +459,7 @@ pub(crate) async fn run_trigger_driver(
     store: &mut Store<SharedCtx>,
     pre: &InstancePre<SharedCtx>,
     ingresses: Vec<Ingress>,
+    cli_run_error: CliRunError,
 ) -> anyhow::Result<()> {
     let instance = pre
         .instantiate_async(&mut *store)
@@ -453,7 +498,10 @@ pub(crate) async fn run_trigger_driver(
             .run_concurrent(async |accessor| {
                 // Spawn the cli/run co-driver once (first entry only).
                 if let Some(command) = command.take()
-                    && let Err(e) = accessor.spawn(RunTask { command })
+                    && let Err(e) = accessor.spawn(RunTask {
+                        command,
+                        on_error: cli_run_error,
+                    })
                 {
                     tracing::error!(err = %e, "failed to spawn cli/run co-driver task");
                 }
@@ -487,16 +535,38 @@ pub(crate) async fn run_trigger_driver(
     Ok(())
 }
 
+/// What a `wasi:cli/run` that returns an error does to the incarnation running
+/// it. The caller states this rather than the driver inferring it, because what
+/// it turns on is whether the workload asked for this run loop to be supervised
+/// — not which ingresses happen to be attached.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliRunError {
+    /// End the incarnation, leaving the restart decision to the supervisor.
+    /// What a service gets when `cli/run` is the work it was deployed to do.
+    Fatal,
+    /// Report it and keep serving. What a service whose handlers are the point
+    /// gets, and what a host component plugin's incidental `cli/run` gets.
+    Logged,
+}
+
 /// Drives the service's `wasi:cli/run` export (its long-running work).
 struct RunTask {
     command: Command,
+    on_error: CliRunError,
 }
 
 impl AccessorTask<SharedCtx> for RunTask {
     async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
         match self.command.wasi_cli_run().call_run(accessor).await {
             Ok(Ok(())) => tracing::info!("service cli/run exited successfully"),
-            Ok(Err(())) => tracing::error!("service cli/run exited with error"),
+            Ok(Err(())) => {
+                tracing::error!("service cli/run exited with error");
+                // Returning the error faults `run_concurrent`, which is what
+                // ends the incarnation and hands the restart decision over.
+                if self.on_error == CliRunError::Fatal {
+                    return Err(wasmtime::format_err!("service cli/run exited with error"));
+                }
+            }
             Err(e) => tracing::error!(err = %e, "service cli/run trapped"),
         }
         Ok(())

--- a/crates/wash-runtime/src/host/trigger_service/mod.rs
+++ b/crates/wash-runtime/src/host/trigger_service/mod.rs
@@ -135,6 +135,7 @@ impl Ingress {
             Ingress::Guest(rx) => Ok(PreparedIngress::Guest {
                 instance: *instance,
                 rx,
+                in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }),
             #[cfg(feature = "host-component-plugins")]
             Ingress::Capability {
@@ -191,6 +192,10 @@ enum PreparedIngress {
     Guest {
         instance: Instance,
         rx: tokio::sync::mpsc::Receiver<GuestJob>,
+        /// Calls this incarnation has in flight, against
+        /// [`MAX_INFLIGHT_GUEST_CALLS`]. Fresh per incarnation, like the
+        /// channel beside it.
+        in_flight: Arc<std::sync::atomic::AtomicUsize>,
     },
     #[cfg(feature = "host-component-plugins")]
     Capability {
@@ -265,15 +270,41 @@ impl PreparedIngress {
                 }
                 ServeOutcome::Shutdown
             }
-            PreparedIngress::Guest { instance, rx } => {
+            PreparedIngress::Guest {
+                instance,
+                rx,
+                in_flight,
+            } => {
                 while let Some(job) = rx.recv().await {
+                    // Taking a job off the channel and spawning it is what the
+                    // queue depth cannot bound: the loop never blocks, so
+                    // without this a plugin dispatching from many tasks at once
+                    // piles calls onto the one service instance without limit.
+                    // Refused rather than awaited, for the reason
+                    // `MAX_INFLIGHT_CAPABILITY_CALLS` gives: a dispatched call
+                    // may re-enter the service, and a slot held by an ancestor
+                    // waiting on it would deadlock.
+                    if in_flight.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                        >= MAX_INFLIGHT_GUEST_CALLS
+                    {
+                        in_flight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                        job.refuse(anyhow::anyhow!(
+                            "the workload\'s service is at its in-flight dispatched-call \
+                             ceiling ({MAX_INFLIGHT_GUEST_CALLS})"
+                        ));
+                        continue;
+                    }
                     // No pool slot: a service's instance is the workload's one
                     // long-lived item, not one of a pool's to retire.
-                    if let Err(e) = accessor.spawn(GuestTask {
-                        instance: *instance,
-                        job,
-                        pool_slot: None,
-                    }) {
+                    let spawned = accessor.spawn(GuestServeTask {
+                        task: GuestTask {
+                            instance: *instance,
+                            job,
+                            pool_slot: None,
+                        },
+                        in_flight: InFlightGuard::new(Arc::clone(in_flight)),
+                    });
+                    if let Err(e) = spawned {
                         tracing::error!(err = %e, "failed to spawn dispatched call task");
                     }
                 }
@@ -547,6 +578,54 @@ pub(crate) enum CliRunError {
     /// Report it and keep serving. What a service whose handlers are the point
     /// gets, and what a host component plugin's incidental `cli/run` gets.
     Logged,
+}
+
+/// Releases one in-flight slot when the call holding it ends, however it ends —
+/// normally, by trapping, or by being dropped.
+///
+/// Backs both non-blocking admission ceilings on a long-lived instance:
+/// [`MAX_INFLIGHT_GUEST_CALLS`] on a service, and the capability-call ceiling on
+/// a host component plugin's store. See the latter for why a plain atomic
+/// rather than a [`tokio::sync::Semaphore`].
+pub(super) struct InFlightGuard(Arc<std::sync::atomic::AtomicUsize>);
+
+impl InFlightGuard {
+    pub(super) fn new(counter: Arc<std::sync::atomic::AtomicUsize>) -> Self {
+        Self(counter)
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// How many plugin-dispatched calls a service serves at once.
+///
+/// A service has no `maxConcurrency` of its own — it is one instance, sized by
+/// the workload rather than by a pool — so this is the only ceiling on what a
+/// push-mode plugin can pile onto it. Matched to the capability ingress's
+/// ceiling, which bounds the other unbounded ingress on the same instance for
+/// the same reason, and enforced the same way: a non-blocking reservation that
+/// *refuses* over the ceiling, never an awaited permit, so a dispatched call
+/// that re-enters the service cannot deadlock on a slot its own ancestor holds.
+pub(crate) const MAX_INFLIGHT_GUEST_CALLS: usize = 512;
+
+/// Serves one dispatched call and gives its in-flight slot back, however it
+/// ends.
+struct GuestServeTask {
+    task: GuestTask,
+    in_flight: InFlightGuard,
+}
+
+impl AccessorTask<SharedCtx> for GuestServeTask {
+    async fn run(self, accessor: &Accessor<SharedCtx>) -> wasmtime::Result<()> {
+        let GuestServeTask { task, in_flight } = self;
+        let outcome = task.run(accessor).await;
+        drop(in_flight);
+        outcome
+    }
 }
 
 /// Drives the service's `wasi:cli/run` export (its long-running work).

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -43,6 +43,7 @@ use wasmtime::component::types::Type;
 use wasmtime::component::{Accessor, GuestTaskId, Linker, Resource, ResourceType, Val};
 
 use crate::engine::ctx::SharedCtx;
+use crate::engine::dispatch::ServiceClaim;
 use crate::engine::linked_call::{LinkedExportInvocation, invoke_linked_async_export};
 use crate::engine::workload::{ExternalCallFunc, ItemExport, ResolvedWorkload};
 
@@ -54,6 +55,14 @@ use super::{ComponentHostPluginState, ExportedInterface, caller_root_task};
 /// `wasmcloud:host` against this definition, so the constant does not move when
 /// the package version does.
 pub(super) const HOST_WORKLOAD_CALL_INTERFACE: &str = "wasmcloud:host/workload-call@0.1.2";
+
+/// The name a workload's service is routed and logged under. It has no manifest
+/// name of its own — a workload names its components, not its service — and a
+/// route is reported by name, so the service needs one. Angle brackets keep it
+/// from reading as a component's (a manifest name is a Kubernetes-style label,
+/// which cannot contain them). Which route wins does not depend on it; see
+/// [`InterfaceRoute::precedence`].
+const SERVICE_ROUTE_NAME: &str = "<service>";
 
 /// A live `target` handle, as the guest holds it: the workload it names and the
 /// task it was opened on. The routes it directs calls to live on that task's
@@ -68,16 +77,43 @@ struct TargetHandle {
     task: Option<GuestTaskId>,
 }
 
-/// The one component of a workload serving an interface this plugin imports,
-/// with a resolved invocation per function of that interface.
-#[derive(Clone)]
+/// The one item of a workload serving an interface this plugin imports, with a
+/// resolved invocation per function of that interface.
 struct InterfaceRoute {
-    /// Manifest name of the serving component. The tie-break when several
-    /// components of one workload export the same interface — the host
-    /// dispatches to one, and picking by name keeps that choice stable across
-    /// deploys, where component ids (fresh UUIDs) would not.
+    /// Manifest name of the serving component, or [`SERVICE_ROUTE_NAME`] for the
+    /// workload's service. Half of the tie-break when several items of one
+    /// workload export the same interface — the host dispatches to one, and
+    /// picking by name keeps that choice stable across deploys, where component
+    /// ids (fresh UUIDs) would not.
     component_name: Arc<str>,
+    /// The claim on the service's dispatch ingress, when this route is the
+    /// workload's service. Its presence is the other half of the tie-break, and
+    /// it comes first: a component wins over the service whatever the two are
+    /// called. That is deliberate rather than a consequence of how the names
+    /// sort — before a service could be called at all, a component was the only
+    /// thing this could route to, and a workload that has both keeps going where
+    /// it always went.
+    ///
+    /// Holding the claim *here* is what keeps the service's ingress in step with
+    /// the routing: a service route that loses gives its claim back, so the
+    /// service is not run with an ingress nothing will ever send on.
+    service_claim: Option<ServiceClaim>,
     funcs: BTreeMap<Arc<str>, Arc<LinkedExportInvocation>>,
+}
+
+impl InterfaceRoute {
+    /// Order two routes for the same interface, lowest wins.
+    fn precedence(&self) -> (bool, &str) {
+        (self.service_claim.is_some(), &self.component_name)
+    }
+
+    /// Give back the service ingress this route claimed, if it is the service's
+    /// and it lost.
+    fn release_service_claim(&self) {
+        if let Some(claim) = &self.service_claim {
+            claim.release();
+        }
+    }
 }
 
 /// Every interface of one workload this plugin can call, keyed by the plugin's
@@ -199,25 +235,35 @@ impl WorkloadCalls {
         item_id: &str,
     ) -> anyhow::Result<()> {
         for import in &self.imports {
-            let (component_name, export_name) =
+            let (component_name, export_name, service_claim) =
                 match workload.item_exporting(item_id, &import.wit).await {
-                    ItemExport::Component { name, export } => (name, export),
-                    ItemExport::Service => {
-                        // Loudly, not silently: the workload deploys and reports
-                        // healthy either way, so without this the only symptom
-                        // is the plugin never seeing it in `callable` and every
-                        // call naming it failing, with nothing to connect that
-                        // to the service.
-                        warn!(
-                            id = self.plugin_id,
-                            workload_id = workload.id(),
-                            service = item_id,
-                            interface = %import.name,
-                            "a workload's long-lived service exports an interface this plugin \
-                             calls, but a service is not callable from a plugin yet; move the \
-                             export to a component to make it reachable"
-                        );
-                        continue;
+                    ItemExport::Component { name, export } => (name, export, None),
+                    ItemExport::Service { export } => {
+                        // A service that could never be dispatched to (a p2 one,
+                        // which drives `cli/run` and nothing else) is skipped
+                        // with a warning rather than failing the deploy: the
+                        // workload did not ask for this route, the plugin's
+                        // presence is what discovered it, and refusing to start
+                        // over it would take down a workload that ran fine
+                        // before the plugin was loaded.
+                        if let Err(e) = workload.service_can_dispatch() {
+                            warn!(
+                                id = self.plugin_id,
+                                workload_id = workload.id(),
+                                service = item_id,
+                                interface = %import.name,
+                                err = %e,
+                                "a workload's service exports an interface this plugin calls, \
+                                 but cannot be dispatched to; deploying without that route"
+                            );
+                            continue;
+                        }
+                        // Taken before the invocations are resolved, because the
+                        // claim is what will make the service run with an
+                        // ingress at all. It travels with the route, and goes
+                        // back if this route loses or resolving fails.
+                        let claim = workload.claim_service_dispatch()?;
+                        (Arc::from(SERVICE_ROUTE_NAME), export, Some(claim))
                     }
                     ItemExport::None => continue,
                 };
@@ -232,17 +278,25 @@ impl WorkloadCalls {
                 .collect();
             // Addressed by the component's own export name, which matching may
             // have accepted despite differing from the plugin's import name.
-            let invocations = workload
-                .external_export_invocations(item_id, &export_name, &funcs)
-                .await
-                .with_context(|| {
-                    format!(
-                        "component '{item_id}' cannot serve {} for host component plugin '{}'",
-                        import.name, self.plugin_id
-                    )
-                })?;
+            // A service is called on the instance already running it; a
+            // component is called in a store of its own.
+            let invocations = match &service_claim {
+                Some(claim) => workload.service_export_invocations(claim, &export_name, &funcs),
+                None => {
+                    workload
+                        .external_export_invocations(item_id, &export_name, &funcs)
+                        .await
+                }
+            }
+            .with_context(|| {
+                format!(
+                    "item '{item_id}' cannot serve {} for host component plugin '{}'",
+                    import.name, self.plugin_id
+                )
+            })?;
             let route = InterfaceRoute {
                 component_name,
+                service_claim,
                 funcs: invocations
                     .into_iter()
                     .map(|(name, inv)| (name, Arc::new(inv)))
@@ -279,21 +333,28 @@ impl WorkloadCalls {
                 slot.insert(Arc::new(route));
             }
             Entry::Occupied(mut slot) => {
-                // The host dispatches this interface to one component per
-                // workload, so a second exporter is ignored — deterministically,
-                // by name, mirroring how the HTTP entrypoint picks among several
-                // components carrying the same export.
-                let (selected, ignored) = if route.component_name < slot.get().component_name {
+                // The host dispatches this interface to one item per workload,
+                // so a second exporter is ignored — deterministically, by
+                // precedence, mirroring how the HTTP entrypoint picks among
+                // several components carrying the same export.
+                let (selected, ignored, loser) = if route.precedence() < slot.get().precedence() {
                     let ignored = Arc::clone(&slot.get().component_name);
                     let selected = Arc::clone(&route.component_name);
-                    slot.insert(Arc::new(route));
-                    (selected, ignored)
+                    let displaced = slot.insert(Arc::new(route));
+                    (selected, ignored, displaced)
                 } else {
                     (
                         Arc::clone(&slot.get().component_name),
                         Arc::clone(&route.component_name),
+                        Arc::new(route),
                     )
                 };
+                // One funnel, so neither branch can forget: the route that lost
+                // gives back the service ingress it claimed, and a service
+                // nothing routes to is not run with one. Released here rather
+                // than left to the losing route's drop, which an open `target`
+                // handle can delay.
+                loser.release_service_claim();
                 warn!(
                     id = self.plugin_id,
                     %workload_id,
@@ -1082,6 +1143,7 @@ mod tests {
             generation: 0,
             route: Arc::new(InterfaceRoute {
                 component_name: Arc::from("test-component"),
+                service_claim: None,
                 funcs: BTreeMap::new(),
             }),
             job,
@@ -1195,6 +1257,7 @@ mod tests {
             Arc::from(IFACE),
             InterfaceRoute {
                 component_name: Arc::from("events-caller"),
+                service_claim: None,
                 funcs: BTreeMap::new(),
             },
         );
@@ -1215,6 +1278,58 @@ mod tests {
         );
     }
 
+    /// Where a component and the workload's service both export the interface,
+    /// the component is routed to — whichever order they are claimed in, and
+    /// whatever they are called. A component was the only thing this could route
+    /// to before a service could be called at all, so a workload with both keeps
+    /// going where it always went.
+    ///
+    /// The service also gives its dispatch ingress back when it loses. Keeping
+    /// it would run the service with an ingress nothing will ever send on, and a
+    /// service that runs to completion would never finish serving it.
+    #[test]
+    fn a_component_wins_the_route_over_the_service() {
+        // `<service>` sorts before a letter but after a digit, so a name-only
+        // tie-break would answer these two cases differently.
+        for component in ["events-caller", "0-caller"] {
+            for service_first in [true, false] {
+                // A real ingress, so a route carries exactly what a resolved one
+                // carries — including the claim the loser must give back.
+                let ingress = Arc::new(crate::engine::dispatch::ServiceCalls::default());
+                let route = |name: &str, is_service: bool| InterfaceRoute {
+                    component_name: Arc::from(name),
+                    service_claim: is_service
+                        .then(|| ingress.claim().expect("the service is claimable")),
+                    funcs: BTreeMap::new(),
+                };
+                let calls = WorkloadCalls::new("test-plugin", Vec::new());
+                let claimed = if service_first {
+                    [route(SERVICE_ROUTE_NAME, true), route(component, false)]
+                } else {
+                    [route(component, false), route(SERVICE_ROUTE_NAME, true)]
+                };
+                for route in claimed {
+                    calls.insert_route("wl-a", Arc::from(IFACE), route);
+                }
+
+                let (_generation, routed) =
+                    calls.route_for("wl-a", IFACE).expect("a route is claimed");
+                let order = if service_first { "first" } else { "second" };
+                assert_eq!(
+                    routed.component_name.as_ref(),
+                    component,
+                    "component '{component}' should serve it (service claimed \
+                     {order}): {SERVICE_ROUTE_NAME} won instead"
+                );
+                assert!(
+                    !ingress.claimed(),
+                    "the service lost the route (claimed {order}), so it must not be run \
+                     with a dispatch ingress"
+                );
+            }
+        }
+    }
+
     /// A `target` handle names one *deployment*, not a workload id. Held across
     /// a stop and a redeploy under the same id, its routes still name components
     /// of the workload that went away, so the generation it captured has to read
@@ -1228,6 +1343,7 @@ mod tests {
                 Arc::from("acme:events/handler@0.1.0"),
                 InterfaceRoute {
                     component_name: Arc::from("events-caller"),
+                    service_claim: None,
                     funcs: BTreeMap::new(),
                 },
             );

--- a/crates/wash-runtime/src/plugin/component_host/workload_call.rs
+++ b/crates/wash-runtime/src/plugin/component_host/workload_call.rs
@@ -262,8 +262,29 @@ impl WorkloadCalls {
                         // claim is what will make the service run with an
                         // ingress at all. It travels with the route, and goes
                         // back if this route loses or resolving fails.
-                        let claim = workload.claim_service_dispatch()?;
-                        (Arc::from(SERVICE_ROUTE_NAME), export, Some(claim))
+                        //
+                        // Refused the same way as the p2 case above, and for the
+                        // same reason: past `service_can_dispatch` the only
+                        // refusal left is a service that has already started, so
+                        // this is a route that arrived too late — not grounds to
+                        // fail a workload that ran fine before the plugin was
+                        // loaded.
+                        match workload.claim_service_dispatch() {
+                            Ok(claim) => (Arc::from(SERVICE_ROUTE_NAME), export, Some(claim)),
+                            Err(e) => {
+                                warn!(
+                                    id = self.plugin_id,
+                                    workload_id = workload.id(),
+                                    service = item_id,
+                                    interface = %import.name,
+                                    err = %e,
+                                    "a workload\'s service exports an interface this plugin calls, \
+                                     but can no longer be claimed as a dispatch target; deploying \
+                                     without that route"
+                                );
+                                continue;
+                            }
+                        }
                     }
                     ItemExport::None => continue,
                 };

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -563,6 +563,14 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// has been successfully bound and resolved. The default implementation
     /// does nothing.
     ///
+    /// A plugin that *calls into* the workload — pushing an event stream at an
+    /// interface the workload exports, rather than serving one it imports —
+    /// resolves its [`ResolvedWorkload::dispatch_target`] here and holds it for
+    /// the life of the binding. Here specifically: the workload has not started
+    /// yet, which is what lets a target naming its long-lived service reserve
+    /// the ingress the service will serve calls on. See
+    /// [`crate::engine::dispatch`].
+    ///
     /// # Arguments
     /// * `workload` - The fully resolved workload
     /// * `component_id` - The ID of the specific component within the workload

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/subscriber.rs
@@ -13,6 +13,7 @@ use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, warn};
 
+use crate::engine::dispatch::{GuestCall, GuestCallFuture};
 use crate::engine::instance_driver::InstanceJob;
 use crate::engine::instance_pool::{ComponentInstance, Declined, Dispatch};
 use crate::engine::workload::ResolvedWorkload;
@@ -137,16 +138,6 @@ struct HandlerTarget {
 /// `result<_, string>`, or a host failure that kept it from being reached.
 type DeliveryReply = tokio::sync::oneshot::Sender<anyhow::Result<Result<(), String>>>;
 
-/// Re-arms this call's epoch deadline and hands back the store's abandon set,
-/// the way [`LinkedTask`] does — a pooled store is reused, so the countdown has
-/// to measure this call rather than the instance's whole life.
-fn call_guard(accessor: &Accessor<SharedCtx>) -> Arc<crate::engine::abandon::AbandonedCalls> {
-    accessor.with(|mut access| {
-        crate::engine::abandon::rearm_for_call(&mut access);
-        Arc::clone(&access.get().abandoned)
-    })
-}
-
 /// The WIT export each delivery flavour invokes, and what its measurements are
 /// grouped by. Bounded by the interface set, so it is safe as an attribute.
 const CORE_OPERATION: &str = "wasmcloud:nats/core-handler#handle-message";
@@ -161,30 +152,21 @@ const JETSTREAM_OPERATION: &str = "wasmcloud:nats/jetstream-handler#handle-messa
 /// `subscription-capacity-bytes` exists to prevent.
 struct CoreDeliveryJob {
     msg: core_bindings::wasmcloud::nats::types::NatsMessage,
-    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
     reply: DeliveryReply,
-    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
-impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
+impl GuestCall for CoreDeliveryJob {
     fn describe(&self) -> &str {
         CORE_OPERATION
     }
 
-    fn run<'a>(
+    fn call<'a>(
         self: Box<Self>,
         accessor: &'a Accessor<SharedCtx>,
         instance: crate::wasmtime::component::Instance,
-        slot: Option<crate::engine::instance_driver::PoolSlot>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+    ) -> GuestCallFuture<'a> {
         Box::pin(async move {
-            let Self {
-                msg,
-                abandoned,
-                reply,
-                attributes,
-            } = *self;
-            let calls = call_guard(accessor);
+            let Self { msg, reply } = *self;
             let proxy = accessor.with(|mut access| {
                 core_bindings::Subscriber::new(&mut access, &instance).map_err(|e| {
                     anyhow::anyhow!(
@@ -196,54 +178,28 @@ impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
                 Ok(p) => p,
                 Err(e) => {
                     let _ = reply.send(Err(e));
-                    return;
+                    return Ok(Some("host"));
                 }
             };
-            let executed = accessor.with(|mut access| Arc::clone(&access.get().executed));
-            // Bounds this task, which the dispatcher's own deadline cannot: a
-            // guest subtask is not cancellable from the host, so a delivery
-            // that never returns would hold its in-flight slot for the life of
-            // the workload. Retiring is what ends it — the driver stops
-            // admitting, drains, and the store's teardown takes the stalled
-            // work with it. The same contract [`LinkedTask`] follows.
-            let mut sample =
-                crate::engine::instance_driver::InvocationSample::start(&executed, attributes);
-            let outcome = tokio::time::timeout(
-                crate::timeouts::ephemeral_call(),
-                crate::engine::abandon::watch_until_abandoned(
-                    &calls,
-                    abandoned,
-                    proxy
-                        .wasmcloud_nats_core_handler()
-                        .call_handle_message(accessor, msg),
-                ),
-            )
-            .await;
-            let _ = reply.send(match outcome {
-                Ok(Ok(inner)) => {
+            match proxy
+                .wasmcloud_nats_core_handler()
+                .call_handle_message(accessor, msg)
+                .await
+            {
+                Ok(inner) => {
                     // The guest's own `result<_, string>`: it ran and said no,
                     // which is a failed delivery even though nothing trapped.
-                    if inner.is_err() {
-                        sample.failed("handler");
-                    }
-                    Ok(inner)
+                    let refused = inner.is_err().then_some("handler");
+                    let _ = reply.send(Ok(inner));
+                    Ok(refused)
                 }
-                // A host failure mid-call leaves guest state indeterminate.
-                Ok(Err(e)) => {
-                    sample.failed("trap");
-                    if let Some(slot) = slot {
-                        slot.retire_instance();
-                    }
+                // A host failure mid-call leaves guest state indeterminate, so
+                // the engine retires the instance that served it.
+                Err(e) => {
+                    let _ = reply.send(Err(anyhow::anyhow!("{e:#}")));
                     Err(anyhow::anyhow!("{e:#}"))
                 }
-                Err(e) => {
-                    sample.failed("timeout");
-                    if let Some(slot) = slot {
-                        slot.retire_instance();
-                    }
-                    Err(anyhow::anyhow!("delivery timed out: {e}"))
-                }
-            });
+            }
         })
     }
 }
@@ -253,31 +209,25 @@ impl crate::engine::instance_driver::PluginJob for CoreDeliveryJob {
 struct KvDeliveryJob {
     bucket: String,
     entry: kv_bindings::wasmcloud::nats::kv::Entry,
-    abandoned: Arc<crate::engine::abandon::AbandonFlag>,
     reply: DeliveryReply,
-    attributes: Arc<[opentelemetry::KeyValue]>,
 }
 
-impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
+impl GuestCall for KvDeliveryJob {
     fn describe(&self) -> &str {
         KV_OPERATION
     }
 
-    fn run<'a>(
+    fn call<'a>(
         self: Box<Self>,
         accessor: &'a Accessor<SharedCtx>,
         instance: crate::wasmtime::component::Instance,
-        slot: Option<crate::engine::instance_driver::PoolSlot>,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+    ) -> GuestCallFuture<'a> {
         Box::pin(async move {
             let Self {
                 bucket,
                 entry,
-                abandoned,
                 reply,
-                attributes,
             } = *self;
-            let calls = call_guard(accessor);
             let proxy = accessor.with(|mut access| {
                 kv_bindings::KvWatcher::new(&mut access, &instance).map_err(|e| {
                     anyhow::anyhow!(
@@ -289,54 +239,28 @@ impl crate::engine::instance_driver::PluginJob for KvDeliveryJob {
                 Ok(p) => p,
                 Err(e) => {
                     let _ = reply.send(Err(e));
-                    return;
+                    return Ok(Some("host"));
                 }
             };
-            let executed = accessor.with(|mut access| Arc::clone(&access.get().executed));
-            // Bounds this task, which the dispatcher's own deadline cannot: a
-            // guest subtask is not cancellable from the host, so a delivery
-            // that never returns would hold its in-flight slot for the life of
-            // the workload. Retiring is what ends it — the driver stops
-            // admitting, drains, and the store's teardown takes the stalled
-            // work with it. The same contract [`LinkedTask`] follows.
-            let mut sample =
-                crate::engine::instance_driver::InvocationSample::start(&executed, attributes);
-            let outcome = tokio::time::timeout(
-                crate::timeouts::ephemeral_call(),
-                crate::engine::abandon::watch_until_abandoned(
-                    &calls,
-                    abandoned,
-                    proxy
-                        .wasmcloud_nats_kv_handler()
-                        .call_handle_event(accessor, bucket, entry),
-                ),
-            )
-            .await;
-            let _ = reply.send(match outcome {
-                Ok(Ok(inner)) => {
+            match proxy
+                .wasmcloud_nats_kv_handler()
+                .call_handle_event(accessor, bucket, entry)
+                .await
+            {
+                Ok(inner) => {
                     // The guest's own `result<_, string>`: it ran and said no,
                     // which is a failed delivery even though nothing trapped.
-                    if inner.is_err() {
-                        sample.failed("handler");
-                    }
-                    Ok(inner)
+                    let refused = inner.is_err().then_some("handler");
+                    let _ = reply.send(Ok(inner));
+                    Ok(refused)
                 }
-                // A host failure mid-call leaves guest state indeterminate.
-                Ok(Err(e)) => {
-                    sample.failed("trap");
-                    if let Some(slot) = slot {
-                        slot.retire_instance();
-                    }
+                // A host failure mid-call leaves guest state indeterminate, so
+                // the engine retires the instance that served it.
+                Err(e) => {
+                    let _ = reply.send(Err(anyhow::anyhow!("{e:#}")));
                     Err(anyhow::anyhow!("{e:#}"))
                 }
-                Err(e) => {
-                    sample.failed("timeout");
-                    if let Some(slot) = slot {
-                        slot.retire_instance();
-                    }
-                    Err(anyhow::anyhow!("delivery timed out: {e}"))
-                }
-            });
+            }
         })
     }
 }
@@ -373,7 +297,7 @@ async fn build_instance(
 /// Runs one delivery: through the workload's instance pool when the component
 /// opted into pooling, and in a store of its own otherwise.
 ///
-/// The job crosses as [`InstanceJob::Plugin`], so a core or KV delivery takes
+/// The job crosses as [`InstanceJob::Guest`], so a core or KV delivery takes
 /// the same path as inbound HTTP and linked calls and honours the same
 /// `poolSize`, `maxInvocations` and `maxConcurrency` the component declared —
 /// including several deliveries in flight on one instance, which the plugin's
@@ -400,19 +324,29 @@ async fn build_instance(
 async fn run_delivery(
     workload: &ResolvedWorkload,
     target: &HandlerTarget,
-    job: Box<dyn crate::engine::instance_driver::PluginJob>,
+    guest_call: Box<dyn GuestCall>,
     reply_rx: tokio::sync::oneshot::Receiver<anyhow::Result<Result<(), String>>>,
     call: crate::engine::abandon::DispatchedCall,
     cancel_token: &CancellationToken,
 ) -> anyhow::Result<Result<(), String>> {
     let component_id = target.component_id.as_ref();
-    let mut job = job;
+    let what = Arc::<str>::from(guest_call.describe());
+    // The engine's own outcome for the delivery — whether the call completed at
+    // all. What the *handler* answered comes back on `reply_rx`, which is the
+    // job's own, because only the plugin can read its interface's error type.
+    let (ran_tx, ran_rx) = tokio::sync::oneshot::channel();
+    let mut job = crate::engine::dispatch::GuestJob::new(
+        guest_call,
+        ran_tx,
+        call.flag(),
+        Arc::clone(&target.attributes),
+    );
     // An instance built for a pool that then declined the delivery: the store
     // of its own below is that instance.
     let mut reclaimed = None;
 
     if let Some(pool) = workload.instance_pool_for_component(component_id).await {
-        let outcome = match pool.try_dispatch(InstanceJob::Plugin(job)) {
+        let outcome = match pool.try_dispatch(InstanceJob::Guest(job)) {
             Dispatch::Sent => Ok(()),
             // Built out here, where awaiting is allowed and where a component
             // that fails to instantiate reports it to this delivery rather
@@ -429,22 +363,21 @@ async fn run_delivery(
         };
         match outcome {
             Ok(()) => {
-                return call
-                    .await_reply(reply_rx)
+                call.await_reply(ran_rx)
                     .await
                     .ok_or_else(|| anyhow::anyhow!("pooled instance produced no reply in time"))?
+                    .map_err(|_| anyhow::anyhow!("pooled instance dropped the delivery"))??;
+                return reply_rx
+                    .await
                     .map_err(|_| anyhow::anyhow!("pooled instance dropped the delivery"))?;
             }
             // Every instance was busy and the pool is full, so run the very
             // same job in a store of its own.
             Err(declined) => {
-                let InstanceJob::Plugin(returned) = declined.job else {
+                let InstanceJob::Guest(returned) = declined.job else {
                     return Err(anyhow::anyhow!("pool returned the wrong job kind"));
                 };
-                debug!(
-                    job = returned.describe(),
-                    "warm instances saturated; own store"
-                );
+                debug!(job = %what, "warm instances saturated; own store");
                 job = returned;
                 reclaimed = declined.instance;
             }
@@ -459,7 +392,7 @@ async fn run_delivery(
         // up at, so the teardown it gives up for is checked here instead.
         Some(_) if cancel_token.is_cancelled() => {
             debug!(
-                job = job.describe(),
+                job = %what,
                 "workload torn down before the delivery ran; abandoning it"
             );
             return Ok(Ok(()));
@@ -478,13 +411,9 @@ async fn run_delivery(
     // `arm_after` runs inside `await_reply`, so a cold delivery that skipped it
     // would be unbounded while looking bounded. Giving up here drops the
     // future, and with it the store, which is what ends the guest's work.
-    call.await_reply(store.run_concurrent(async move |accessor| {
-        // No pool slot: nothing to retire, the store goes when this ends.
-        job.run(accessor, instance, None).await;
-    }))
-    .await
-    .ok_or_else(|| anyhow::anyhow!("delivery produced no reply in time"))?
-    .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    call.await_reply(job.run_on_store(&mut store, instance))
+        .await
+        .ok_or_else(|| anyhow::anyhow!("delivery produced no reply in time"))??;
     reply_rx
         .await
         .map_err(|_| anyhow::anyhow!("delivery task dropped the reply"))?
@@ -2142,13 +2071,7 @@ pub(super) async fn spawn_core_subscriptions(
                             "wasmcloud:nats core delivery",
                             crate::timeouts::ephemeral_call(),
                         );
-                        let job: Box<dyn crate::engine::instance_driver::PluginJob> =
-                            Box::new(CoreDeliveryJob {
-                                msg,
-                                abandoned: call.flag(),
-                                reply,
-                                attributes: Arc::clone(&target.attributes),
-                            });
+                        let job: Box<dyn GuestCall> = Box::new(CoreDeliveryJob { msg, reply });
                         let span = tracing::span!(
                             tracing::Level::INFO,
                             "incoming_nats_core_message",
@@ -2424,14 +2347,11 @@ pub(super) async fn spawn_kv_watches(
                                 "wasmcloud:nats kv delivery",
                                 crate::timeouts::ephemeral_call(),
                             );
-                            let job: Box<dyn crate::engine::instance_driver::PluginJob> =
-                                Box::new(KvDeliveryJob {
-                                    bucket: bucket_for_label.clone(),
-                                    entry: kv_entry_to_kv_handler_wit(&entry),
-                                    abandoned: call.flag(),
-                                    reply,
-                                    attributes: Arc::clone(&target.attributes),
-                                });
+                            let job: Box<dyn GuestCall> = Box::new(KvDeliveryJob {
+                                bucket: bucket_for_label.clone(),
+                                entry: kv_entry_to_kv_handler_wit(&entry),
+                                reply,
+                            });
                             let span = tracing::span!(
                                 tracing::Level::INFO,
                                 "incoming_nats_kv_event",

--- a/crates/wash-runtime/src/plugin/wasmcloud_nats/warm.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_nats/warm.rs
@@ -11,9 +11,8 @@
 //! The engine already has an opt-in for exactly this — `poolSize`,
 //! `maxInvocations`, `maxConcurrency` on the component, decoded once into
 //! [`InstancePolicy`] — and core and KV deliveries take it: they cross as an
-//! [`InstanceJob::Plugin`] and the pool routes them like any other call.
-//! **JetStream
-//! cannot.** Its call carries a `message-handle` resource, which is an index
+//! [`InstanceJob::Guest`] and the pool routes them like any other call.
+//! **JetStream cannot.** Its call carries a `message-handle` resource, which is an index
 //! into one store's resource table, so the argument cannot be built until the
 //! store is chosen — and a job the pool hands back has already been pushed
 //! into a table it no longer belongs to. Its settle-ack ownership and its

--- a/crates/wash-runtime/tests/fixtures/Cargo.lock
+++ b/crates/wash-runtime/tests/fixtures/Cargo.lock
@@ -131,6 +131,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch-target"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
 name = "ephemeral-callee-p3"
 version = "0.0.0"
 dependencies = [
@@ -159,6 +166,13 @@ dependencies = [
 
 [[package]]
 name = "events-plugin"
+version = "0.0.0"
+dependencies = [
+ "wit-bindgen 0.60.0",
+]
+
+[[package]]
+name = "events-service"
 version = "0.0.0"
 dependencies = [
  "wit-bindgen 0.60.0",

--- a/crates/wash-runtime/tests/fixtures/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/Cargo.toml
@@ -71,6 +71,8 @@ members = [
     "http-egress-plugin-caller",
     "events-plugin",
     "events-caller",
+    "events-service",
+    "dispatch-target",
 ]
 
 [workspace.dependencies]

--- a/crates/wash-runtime/tests/fixtures/acme-events/events.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-events/events.wit
@@ -37,6 +37,29 @@ interface metrics {
     report: async func(measurement: string) -> result<string, metrics-error>;
 }
 
+/// A third interface in the plugin's *calling* direction, carrying a
+/// `stream<u8>` each way. A call on it cannot cross the store boundary by
+/// copying — the host has to relocate the stream — so this is what exercises
+/// that path into a *running* service, where neither store is built for the
+/// call and neither is torn down after it.
+///
+/// Only the service fixture exports it. The component fixture beside it does
+/// not, which keeps the two shapes of callee distinguishable in one workload.
+interface bulk {
+    use wasmcloud:host/types@0.1.4.{call-error};
+
+    /// Drain a stream the plugin opened and answer how many bytes it carried:
+    /// the argument direction, pumped out of the plugin's store and into the
+    /// service's.
+    absorb: async func(data: stream<u8>) -> result<u64, call-error>;
+
+    /// Answer with a stream of `count` bytes for the plugin to drain: the
+    /// result direction, extracted in the service's own store. Wrapped in a
+    /// `result` like everything else here, so a call the host cannot complete
+    /// comes back as a value rather than trapping the plugin.
+    emit: async func(count: u64) -> result<stream<u8>, call-error>;
+}
+
 interface control {
     /// Call `handler.notify` back on the CALLING workload, naming no target —
     /// the host routes it to whichever workload's capability call this is.
@@ -70,6 +93,14 @@ interface control {
     /// where the host still has to report `not-exported`, and it has to say so
     /// through this interface's own error type.
     report-inherited: async func(measurement: string) -> string;
+
+    /// Send `bytes` bytes to `id`'s `bulk.absorb` as a stream, and report what
+    /// it counted — the argument direction of a relocated call.
+    bulk-absorb: async func(id: string, bytes: u64) -> string;
+
+    /// Drain `count` bytes from `id`'s `bulk.emit` and report how many
+    /// arrived — the result direction.
+    bulk-emit: async func(id: string, count: u64) -> string;
 
     /// What the plugin saw when it tried to open a target for `id` from inside
     /// each `wasmcloud:host/workload-lifecycle` hook, as

--- a/crates/wash-runtime/tests/fixtures/acme-tasks/tasks.wit
+++ b/crates/wash-runtime/tests/fixtures/acme-tasks/tasks.wit
@@ -1,0 +1,15 @@
+package acme:tasks@0.1.0;
+
+/// A bespoke work package in the direction a plugin *calls*: nothing on the
+/// host serves `runner`, so a workload that exports it is the implementation
+/// the host routes a plugin's calls to.
+///
+/// Every function is an `async func` over primitives, so a call crosses the
+/// store boundary as plain values.
+interface runner {
+    /// Handle one unit of work. The reply carries how many calls this
+    /// *instance* has served, so a caller can tell a reused warm instance from
+    /// a freshly built one — and a workload's long-lived service (which serves
+    /// every call on the one instance it is) from either.
+    run: async func(message: string) -> string;
+}

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/dispatch_target.wasm

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dispatch-target"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/src/lib.rs
@@ -32,6 +32,9 @@ struct Component;
 
 impl RunnerGuest for Component {
     async fn run(message: String) -> String {
+        // A dispatched call that does not complete, so a test can ask what
+        // becomes of the instance that was serving it.
+        assert!(message != "trap", "deliberate runner.run trap");
         let served = SERVED.fetch_add(1, Ordering::SeqCst) + 1;
         format!("{message}:{served}")
     }
@@ -43,8 +46,12 @@ impl RunGuest for Component {
         // still serving dispatched calls — the case where a workload's
         // `maxRestarts` has to mean the same thing whether or not a plugin
         // pushes into the service.
-        if std::env::var("RUN_EXIT").as_deref() == Ok("error") {
-            return Err(());
+        match std::env::var("RUN_EXIT").as_deref() {
+            Ok("error") => return Err(()),
+            // The same failure the guest reports by trapping rather than by
+            // answering, which a plain p3 service spends a restart on too.
+            Ok("trap") => panic!("deliberate cli/run trap"),
+            _ => {}
         }
         // Otherwise services are long-lived: park instead of returning, so the
         // workload stays deployed for as long as the test needs it.

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/src/lib.rs
@@ -1,0 +1,61 @@
+//! Workload item a host plugin dispatches `acme:tasks/runner` calls to.
+//!
+//! Every reply counts the calls THIS instance has served, which is what makes
+//! the fixture load-bearing: the count is instance state, so it says whether
+//! the host reused an instance or built one for the call.
+//!
+//! - a component that keeps no instances warm answers `msg:1` every time (a
+//!   fresh instance per call),
+//! - a component with a warm pool answers `msg:1`, `msg:2`, ... (one instance
+//!   serving them all), and
+//! - a service answers the same way, on the one instance it already is.
+//!
+//! `wasi:cli/run` parks rather than returning, so deployed as a service this
+//! stays the workload's long-lived item for as long as a test needs it.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "target", generate_all });
+}
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use bindings::exports::acme::tasks::runner::Guest as RunnerGuest;
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::wasi::clocks::monotonic_clock;
+
+/// Calls served by this instance. Lives in the instance's own linear memory, so
+/// it restarts at zero in a fresh one.
+static SERVED: AtomicU32 = AtomicU32::new(0);
+
+struct Component;
+
+impl RunnerGuest for Component {
+    async fn run(message: String) -> String {
+        let served = SERVED.fetch_add(1, Ordering::SeqCst) + 1;
+        format!("{message}:{served}")
+    }
+}
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        // `RUN_EXIT=error` fails the service's own long-running work while it is
+        // still serving dispatched calls — the case where a workload's
+        // `maxRestarts` has to mean the same thing whether or not a plugin
+        // pushes into the service.
+        if std::env::var("RUN_EXIT").as_deref() == Ok("error") {
+            return Err(());
+        }
+        // Otherwise services are long-lived: park instead of returning, so the
+        // workload stays deployed for as long as the test needs it.
+        loop {
+            monotonic_clock::wait_for(60_000_000_000).await;
+        }
+    }
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{Component, bindings};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/wit/world.wit
@@ -1,0 +1,14 @@
+package acme:dispatchtarget@0.1.0;
+
+/// A workload item a host plugin dispatches work to, deployable BOTH ways: as
+/// an ordinary component (where a call runs on one of its warm instances, or on
+/// a store built for that call alone) and as the workload's long-lived service
+/// (where every call runs on the single instance the service already is).
+///
+/// It exports `wasi:cli/run` so it is a conventional service in the second
+/// shape; deployed as a component, that export is simply never called.
+world target {
+    import wasi:clocks/monotonic-clock@0.3.0;
+    export acme:tasks/runner@0.1.0;
+    export wasi:cli/run@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/dispatch-target/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/dispatch-target/wkg.toml
@@ -1,0 +1,7 @@
+[overrides]
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:tasks" = { path = "../acme-tasks" }

--- a/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-caller/src/lib.rs
@@ -10,6 +10,8 @@
 //! - `GET /echo?msg=M`           -> `control.echo(M)`          -> handling tag
 //! - `GET /dispatch?id=W&msg=M`  -> `control.dispatch(W, M)`   -> W's tag + W
 //! - `GET /nested?id=W&msg=M`    -> `control.nested(W, M)`     -> `W|self`
+//! - `GET /bulk-absorb?id=W&n=N` -> `control.bulk-absorb(W, N)` -> bytes W read
+//! - `GET /bulk-emit?id=W&n=N`   -> `control.bulk-emit(W, N)`   -> bytes W sent
 //! - `GET /callable`             -> `control.callable()`       -> `id=iface,…` a line
 //! - `GET /report?id=W&m=M`      -> `control.report(W, M)`     -> no target for it
 //! - `GET /report-inherited?m=M` -> `control.report-inherited(M)` -> borrowed error case
@@ -71,6 +73,18 @@ impl HttpGuest for Component {
             let id = query_get(query, "id").unwrap_or_default();
             let msg = query_get(query, "msg").unwrap_or_default();
             let reply = control::nested(id, msg).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/bulk-absorb") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let n = query_get(query, "n").and_then(|n| n.parse().ok()).unwrap_or(0);
+            let reply = control::bulk_absorb(id, n).await;
+            return Ok(make_response(200, reply.into_bytes()));
+        }
+        if route.starts_with("/bulk-emit") {
+            let id = query_get(query, "id").unwrap_or_default();
+            let n = query_get(query, "n").and_then(|n| n.parse().ok()).unwrap_or(0);
+            let reply = control::bulk_emit(id, n).await;
             return Ok(make_response(200, reply.into_bytes()));
         }
         if route.starts_with("/callable") {

--- a/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/src/lib.rs
@@ -28,13 +28,14 @@ mod bindings {
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
-use bindings::acme::events::{handler, metrics};
+use bindings::acme::events::{bulk, handler, metrics};
 use bindings::wasmcloud::host::types::CallError;
 use bindings::exports::acme::events::control::Guest;
 use bindings::exports::wasmcloud::host::workload_lifecycle::{
     Guest as LifecycleGuest, WorkloadInfo,
 };
 use bindings::wasmcloud::host::workload_call::{self, Target};
+use wit_bindgen::StreamResult;
 
 /// Workload id -> what each lifecycle hook saw when it tried to open a target
 /// for that workload. Instance memory, so it is empty again after a restart.
@@ -45,6 +46,12 @@ static PROBE: Mutex<BTreeMap<String, String>> = Mutex::new(BTreeMap::new());
 /// workload alone — the pairing is what makes a handle proof the call routes.
 const HANDLER: &str = "acme:events/handler@0.1.0";
 const METRICS: &str = "acme:events/metrics@0.1.0";
+const BULK: &str = "acme:events/bulk@0.1.0";
+
+/// Bytes per write, and per read on the way back. Small enough that a test
+/// payload takes several of each, so a single-chunk transfer cannot pass for a
+/// working pump.
+const CHUNK: usize = 256;
 
 /// Try to open a target for `id` from inside a hook and append what happened.
 fn probe(id: &str, phase: &str) {
@@ -175,6 +182,51 @@ impl Guest for EventsPlugin {
             Ok(reply) => reply,
             Err(err) => metrics_failure(err),
         }
+    }
+
+    /// Opens a stream in THIS store and hands it to the callee, so the host has
+    /// to pump it across: the bytes are produced here, in the plugin, and read
+    /// there, in whatever store serves the call.
+    async fn bulk_absorb(id: String, bytes: u64) -> String {
+        let Some(_target) = Target::open(&id, BULK) else {
+            return format!("unroutable:{id}");
+        };
+        let (mut tx, rx) = bindings::wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            let chunk = vec![b'x'; CHUNK];
+            let mut written: u64 = 0;
+            while written < bytes {
+                let n = ((bytes - written) as usize).min(chunk.len());
+                tx.write_all(chunk[..n].to_vec()).await;
+                written += n as u64;
+            }
+            drop(tx);
+        });
+        match bulk::absorb(rx).await {
+            Ok(counted) => format!("absorbed:{counted}"),
+            Err(err) => failed(err),
+        }
+    }
+
+    /// Drains a stream the callee opened, which is the other direction: the
+    /// bytes are produced in its store and read here, after the call returned.
+    async fn bulk_emit(id: String, count: u64) -> String {
+        let Some(_target) = Target::open(&id, BULK) else {
+            return format!("unroutable:{id}");
+        };
+        let mut data = match bulk::emit(count).await {
+            Ok(data) => data,
+            Err(err) => return failed(err),
+        };
+        let mut total: u64 = 0;
+        loop {
+            let (result, chunk) = data.read(Vec::with_capacity(CHUNK)).await;
+            total += chunk.len() as u64;
+            if matches!(result, StreamResult::Dropped) {
+                break;
+            }
+        }
+        format!("emitted:{total}")
     }
 
     async fn lifecycle_probe(id: String) -> String {

--- a/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-plugin/wit/world.wit
@@ -14,6 +14,10 @@ world events-plugin {
     // A second interface in the same direction that no workload exports, so
     // `callable` has to report per workload which of the two is reachable.
     import acme:events/metrics@0.1.0;
+    // A third, carrying a `stream<u8>` each way: only a workload's SERVICE
+    // exports it, so calls on it are relocated into a store that is already
+    // running rather than copied into one built for the call.
+    import acme:events/bulk@0.1.0;
     // Names which workload a call goes to, and lists the ones that can be
     // called at all. Unused for `echo`, which inherits its caller.
     import wasmcloud:host/workload-call@0.1.4;

--- a/crates/wash-runtime/tests/fixtures/events-service/.wash/config.yaml
+++ b/crates/wash-runtime/tests/fixtures/events-service/.wash/config.yaml
@@ -1,0 +1,5 @@
+build:
+  # `wash build` runs `wit fetch` (resolving the wkg.toml local refs), then this
+  # command; a wasm32-wasip1 core module is wrapped into a component afterward.
+  command: cargo build --target wasm32-wasip1 --release
+  component_path: ../target/wasm32-wasip1/release/events_service.wasm

--- a/crates/wash-runtime/tests/fixtures/events-service/Cargo.toml
+++ b/crates/wash-runtime/tests/fixtures/events-service/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "events-service"
+edition = "2021"
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["async-spawn", "inter-task-wakeup"] }

--- a/crates/wash-runtime/tests/fixtures/events-service/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/events-service/src/lib.rs
@@ -1,0 +1,94 @@
+//! Workload SERVICE exporting `acme:events/handler`, which a host component
+//! plugin calls back into.
+//!
+//! The component fixture beside this one (`events-caller`) is the same
+//! direction on a component; this is the shape that has no per-call
+//! instantiation to fall back on, so a plugin reaches it only if the host
+//! delivers the call to the running service itself.
+//!
+//! Every reply is `{EVENT_TAG}:{message}:{n}`, where `n` counts the calls this
+//! instance has served. The tag says WHICH workload handled it and the count
+//! says it was handled on one long-lived instance rather than a fresh one.
+
+mod bindings {
+    #![allow(unsafe_code)]
+    wit_bindgen::generate!({ world: "event-service", generate_all });
+}
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use bindings::exports::acme::events::bulk::Guest as BulkGuest;
+use bindings::exports::acme::events::handler::{CallError, Guest as HandlerGuest};
+use bindings::exports::wasi::cli::run::Guest as RunGuest;
+use bindings::wasi::clocks::monotonic_clock;
+use wit_bindgen::{StreamReader, StreamResult};
+
+/// Bytes per read on the way in, and per write on the way out.
+const CHUNK: usize = 256;
+
+/// Calls served by this instance, restarting at zero in a fresh one.
+static SERVED: AtomicU32 = AtomicU32::new(0);
+
+struct Component;
+
+/// This workload's own name, from its manifest environment, so two deploys of
+/// this same wasm can be told apart in a callback's reply.
+fn tag() -> String {
+    std::env::var("EVENT_TAG").unwrap_or_else(|_| "untagged".to_string())
+}
+
+impl HandlerGuest for Component {
+    async fn notify(message: String) -> Result<String, CallError> {
+        let served = SERVED.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(format!("{}:{message}:{served}", tag()))
+    }
+}
+
+impl BulkGuest for Component {
+    /// Reads a stream the plugin opened in ITS store: the bytes arrive over the
+    /// host's pump, on this instance, while it goes on serving everything else.
+    async fn absorb(mut data: StreamReader<u8>) -> Result<u64, CallError> {
+        let mut total: u64 = 0;
+        loop {
+            let (result, chunk) = data.read(Vec::with_capacity(CHUNK)).await;
+            total += chunk.len() as u64;
+            if matches!(result, StreamResult::Dropped) {
+                break;
+            }
+        }
+        Ok(total)
+    }
+
+    /// Opens a stream in this store for the plugin to drain, which keeps
+    /// producing after the call itself has returned.
+    async fn emit(count: u64) -> Result<StreamReader<u8>, CallError> {
+        let (mut tx, rx) = bindings::wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            let chunk = vec![b'y'; CHUNK];
+            let mut written: u64 = 0;
+            while written < count {
+                let n = ((count - written) as usize).min(chunk.len());
+                tx.write_all(chunk[..n].to_vec()).await;
+                written += n as u64;
+            }
+            drop(tx);
+        });
+        Ok(rx)
+    }
+}
+
+impl RunGuest for Component {
+    async fn run() -> Result<(), ()> {
+        // Long-lived: park rather than returning, so the service is still the
+        // workload's running item when the plugin calls into it.
+        loop {
+            monotonic_clock::wait_for(60_000_000_000).await;
+        }
+    }
+}
+
+mod export {
+    #![allow(unsafe_code)]
+    use super::{Component, bindings};
+    bindings::export!(Component with_types_in bindings);
+}

--- a/crates/wash-runtime/tests/fixtures/events-service/wit/world.wit
+++ b/crates/wash-runtime/tests/fixtures/events-service/wit/world.wit
@@ -1,0 +1,18 @@
+package acme:eventsservice@0.1.0;
+
+/// The workload SERVICE half of `acme:events`: it exports `handler` for the
+/// host component plugin to call back into, and nothing else of the package.
+///
+/// A service is the workload's long-lived item, so every call the plugin makes
+/// runs on the instance already running `cli/run` rather than on one built for
+/// the call — which is the whole reason a push-mode handler would be written as
+/// a service instead of a component.
+world event-service {
+    import wasi:clocks/monotonic-clock@0.3.0;
+    export acme:events/handler@0.1.0;
+    /// The stream-carrying half of the same direction: a call on this cannot be
+    /// copied across the store boundary, so it is what exercises relocation
+    /// into an instance that is already running.
+    export acme:events/bulk@0.1.0;
+    export wasi:cli/run@0.3.0;
+}

--- a/crates/wash-runtime/tests/fixtures/events-service/wkg.toml
+++ b/crates/wash-runtime/tests/fixtures/events-service/wkg.toml
@@ -1,0 +1,10 @@
+[overrides]
+# `acme:events/handler` reports a failed call with the host's own `call-error`,
+# so the workload exporting it resolves `wasmcloud:host` too.
+"wasmcloud:host" = { path = "../../../../../wit/host/wit" }
+"wasi:cli" = { path = "../p3-wit-deps/wasi-cli-0.3.0" }
+"wasi:clocks" = { path = "../p3-wit-deps/wasi-clocks-0.3.0" }
+"wasi:filesystem" = { path = "../p3-wit-deps/wasi-filesystem-0.3.0" }
+"wasi:random" = { path = "../p3-wit-deps/wasi-random-0.3.0" }
+"wasi:sockets" = { path = "../p3-wit-deps/wasi-sockets-0.3.0" }
+"acme:events" = { path = "../acme-events" }

--- a/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
+++ b/crates/wash-runtime/tests/integration_plugin_calls_workload.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 
 use wash_runtime::host::HostApi;
 use wash_runtime::types::{
-    Component, LocalResources, Workload, WorkloadStartRequest, WorkloadStopRequest,
+    Component, LocalResources, Service, Workload, WorkloadStartRequest, WorkloadStopRequest,
 };
 use wash_runtime::wit::WitInterface;
 
@@ -28,6 +28,7 @@ use common::{http_incoming_handler_interface, req, start_host_with_component_plu
 
 const EVENTS_PLUGIN_WASM: &[u8] = include_bytes!("wasm/events_plugin.wasm");
 const EVENTS_CALLER_WASM: &[u8] = include_bytes!("wasm/events_caller.wasm");
+const EVENTS_SERVICE_WASM: &[u8] = include_bytes!("wasm/events_service.wasm");
 const PLUGIN_ID: &str = "acme-events-plugin";
 
 /// The `acme:events` binding: `control` the plugin serves, `handler` the
@@ -419,6 +420,138 @@ async fn test_callable_reports_each_workloads_callable_interfaces() -> Result<()
     assert_eq!(
         body, "wl-alpha=acme:events/handler@0.1.0",
         "a stopped workload should no longer be callable"
+    );
+
+    Ok(())
+}
+
+/// The `handler` half of `acme:events` alone: a workload whose SERVICE exports
+/// it imports nothing else of the package, so its manifest entry names only
+/// what the service's own world has.
+fn acme_events_handler_interface() -> WitInterface {
+    WitInterface {
+        namespace: "acme".to_string(),
+        package: "events".to_string(),
+        interfaces: ["handler".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+/// A workload whose only item is a SERVICE exporting `acme:events/handler`.
+fn events_service_workload(workload_id: &str, tag: &str) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: workload_id.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(EVENTS_SERVICE_WASM),
+                local_resources: LocalResources {
+                    environment: HashMap::from([("EVENT_TAG".to_string(), tag.to_string())]),
+                    ..LocalResources::default()
+                },
+                max_restarts: 0,
+            }),
+            components: vec![],
+            host_interfaces: vec![acme_events_handler_interface()],
+            volumes: vec![],
+        },
+    }
+}
+
+/// A plugin can call a workload whose exporting item is its long-lived SERVICE
+/// rather than a component, and the call lands on the instance already running
+/// — the only place a service's accumulated state lives.
+///
+/// The reply counts the calls that instance has served, so the second call
+/// answering `2` is what separates "reached the running service" from "quietly
+/// instantiated a second copy of it".
+#[tokio::test]
+async fn test_plugin_dispatches_to_a_service() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    h.workload_start(events_service_workload("wl-svc", "svc"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-svc&msg=one").await?;
+    assert_eq!(status.as_u16(), 200, "/dispatch should succeed");
+    assert_eq!(
+        body, "svc:dispatch:wl-svc:one:1",
+        "a target naming a service-only workload should reach its service's handler export"
+    );
+
+    let (_status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-svc&msg=two").await?;
+    assert_eq!(
+        body, "svc:dispatch:wl-svc:two:2",
+        "the second call should be served by the same running instance, not a fresh one"
+    );
+
+    // A service is callable exactly while it runs, as a component is.
+    h.workload_stop(WorkloadStopRequest {
+        workload_id: "wl-svc".to_string(),
+    })
+    .await?;
+    let (_status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-svc&msg=gone").await?;
+    assert_eq!(
+        body, "unroutable:wl-svc",
+        "a stopped service should no longer be callable"
+    );
+
+    Ok(())
+}
+
+/// A `stream<u8>` crosses into a running service and back out of it.
+///
+/// `handler.notify` carries only plain values, which the host copies; `bulk`
+/// carries a stream each way, which it cannot — the host pumps it between two
+/// stores that both go on running, neither built for this call nor dropped
+/// after it. `absorb` is the argument direction (opened in the plugin's store,
+/// read in the service's) and `emit` the result direction (opened in the
+/// service's store and drained in the plugin's *after* the call returned), so
+/// between them every relocation site on this path is exercised.
+///
+/// The byte counts are what carry the assertion: several chunks each way, so a
+/// pump that delivered only its first would be caught.
+#[tokio::test]
+async fn test_a_stream_crosses_into_a_running_service() -> Result<()> {
+    let (addr, h) =
+        start_host_with_component_plugin_by_host("127.0.0.1:0", PLUGIN_ID, EVENTS_PLUGIN_WASM)
+            .await?;
+    h.workload_start(events_workload("wl-alpha", "alpha", "alpha"))
+        .await?;
+    h.workload_start(events_service_workload("wl-svc", "svc"))
+        .await?;
+    let client = reqwest::Client::new();
+
+    let (status, body) = req(&client, &addr, "alpha", "/bulk-absorb?id=wl-svc&n=1000").await?;
+    assert_eq!(status.as_u16(), 200, "/bulk-absorb should succeed");
+    assert_eq!(
+        body, "absorbed:1000",
+        "every byte the plugin wrote should reach the running service"
+    );
+
+    let (status, body) = req(&client, &addr, "alpha", "/bulk-emit?id=wl-svc&n=1000").await?;
+    assert_eq!(status.as_u16(), 200, "/bulk-emit should succeed");
+    assert_eq!(
+        body, "emitted:1000",
+        "every byte the service wrote should reach the plugin, after the call returned"
+    );
+
+    // The service is still serving both interfaces afterwards: a relocated call
+    // leaves its store running, unlike the ephemeral path's, which is dropped
+    // once its result streams drain.
+    let (_status, body) = req(&client, &addr, "alpha", "/dispatch?id=wl-svc&msg=after").await?;
+    assert_eq!(
+        body, "svc:dispatch:wl-svc:after:1",
+        "the service should still answer plain calls once the streams are done"
     );
 
     Ok(())

--- a/crates/wash-runtime/tests/integration_plugin_dispatch.rs
+++ b/crates/wash-runtime/tests/integration_plugin_dispatch.rs
@@ -80,6 +80,10 @@ struct RunCall {
 }
 
 impl GuestCall for RunCall {
+    fn describe(&self) -> &str {
+        "acme:tasks/runner#run"
+    }
+
     fn call<'a>(
         self: Box<Self>,
         accessor: &'a Accessor<SharedCtx>,
@@ -98,8 +102,9 @@ impl GuestCall for RunCall {
                 .call_run(accessor, self.message)
                 .await
                 .map_err(|e| anyhow::anyhow!("runner.run trapped: {e:#}"));
+            let refused = reply.is_err().then_some("trap");
             let _ = self.reply.send(reply);
-            Ok(())
+            Ok(refused)
         })
     }
 }
@@ -154,7 +159,7 @@ impl HostPlugin for TaskPusher {
     ) -> anyhow::Result<()> {
         // Resolving the target here, while the workload resolves, is what
         // reserves a service's ingress before it starts running.
-        let target = workload.dispatch_target(item_id).await?;
+        let target = workload.dispatch_target(item_id, "acme-tasks").await?;
         self.targets
             .lock()
             .await
@@ -193,6 +198,16 @@ fn component_workload(
     pool_size: i32,
     max_concurrency: i32,
 ) -> WorkloadStartRequest {
+    component_workload_with(workload_id, pool_size, max_concurrency, 0)
+}
+
+/// As [`component_workload`], with an invocation budget per instance.
+fn component_workload_with(
+    workload_id: &str,
+    pool_size: i32,
+    max_concurrency: i32,
+    max_invocations: i32,
+) -> WorkloadStartRequest {
     WorkloadStartRequest {
         workload_id: workload_id.to_string(),
         workload: Workload {
@@ -206,7 +221,7 @@ fn component_workload(
                 bytes: bytes::Bytes::from_static(DISPATCH_TARGET_WASM),
                 local_resources: LocalResources::default(),
                 pool_size,
-                max_invocations: 0,
+                max_invocations,
                 max_concurrency,
                 ..Default::default()
             }],
@@ -273,6 +288,31 @@ async fn test_dispatch_runs_on_a_warm_component_instance() -> Result<()> {
     assert_eq!(plugin.run("warm", "c").await?, "c:3");
 
     stop(&host, "warm").await;
+    Ok(())
+}
+
+/// An instance stops taking dispatched calls once it has served
+/// `maxInvocations` of them, and the one that replaces it starts over.
+///
+/// Read through the replacement rather than the retired instance: a retired
+/// instance is drained and dropped, so nothing can ask it what it served. The
+/// third call answering `1` is the whole proof — the budget was spent, and the
+/// component the plugin drives is not one long-lived instance forever.
+#[tokio::test]
+async fn test_a_dispatched_call_spends_the_instances_invocation_budget() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload_with("budget", 1, 1, 2))
+        .await?;
+
+    assert_eq!(plugin.run("budget", "a").await?, "a:1");
+    assert_eq!(plugin.run("budget", "b").await?, "b:2");
+    assert_eq!(
+        plugin.run("budget", "c").await?,
+        "c:1",
+        "the third call must land on a fresh instance, not the one whose budget is spent"
+    );
+
+    stop(&host, "budget").await;
     Ok(())
 }
 
@@ -430,7 +470,7 @@ async fn test_an_unknown_item_is_refused() -> Result<()> {
     drop(target);
 
     let err = workload
-        .dispatch_target("no-such-item")
+        .dispatch_target("no-such-item", "acme-tasks")
         .await
         .expect_err("a missing item must not resolve as a dispatch target");
     assert!(

--- a/crates/wash-runtime/tests/integration_plugin_dispatch.rs
+++ b/crates/wash-runtime/tests/integration_plugin_dispatch.rs
@@ -1,0 +1,443 @@
+//! Integration tests for plugin-initiated dispatch: a host-native plugin that
+//! *imports* `acme:tasks/runner` and calls into whichever workload item exports
+//! it, the way a plugin consuming an external event stream pushes work into a
+//! workload.
+//!
+//! Every reply the fixture sends counts the calls its own instance has served,
+//! so the assertions here are about WHERE the host ran each call:
+//!
+//! - a component with a warm pool serves them all on one instance (`1, 2, 3`),
+//!   which is what `poolSize`/`maxConcurrency` are for;
+//! - a component that keeps no instances gets a fresh one per call (`1, 1, 1`);
+//! - a service serves them on the single instance it already is, concurrently.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use tokio::sync::{Mutex, oneshot};
+use wasmtime::component::{Accessor, Instance};
+
+use wash_runtime::engine::Engine;
+use wash_runtime::engine::ctx::SharedCtx;
+use wash_runtime::engine::dispatch::{DispatchTarget, GuestCall, GuestCallFuture};
+use wash_runtime::engine::workload::ResolvedWorkload;
+use wash_runtime::host::http::{DevRouter, Ingress};
+use wash_runtime::host::{HostApi, HostBuilder};
+use wash_runtime::plugin::{HostPlugin, WitInterfaces};
+use wash_runtime::types::{
+    Component, LocalResources, Service, Workload, WorkloadStartRequest, WorkloadStopRequest,
+};
+use wash_runtime::wit::{WitInterface, WitWorld};
+
+const DISPATCH_TARGET_WASM: &[u8] = include_bytes!("wasm/dispatch_target.wasm");
+
+/// A typed view over the fixture's `acme:tasks/runner` export, built against
+/// whichever instance the host picks for a call. The plugin owns the call; the
+/// host only owns the instance it runs on.
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "runner-view",
+        inline: "
+            package wasmcloud:dispatchtest@0.1.0;
+
+            world runner-view {
+                export acme:tasks/runner@0.1.0;
+            }
+
+            package acme:tasks@0.1.0 {
+                interface runner {
+                    run: async func(message: string) -> string;
+                }
+            }
+        ",
+        imports: { default: async | trappable },
+        exports: { default: async },
+    });
+}
+
+/// The interface the plugin drives and the fixture exports. One manifest entry
+/// covers it, because interface matching looks at an item's exports as well as
+/// its imports.
+fn acme_tasks_interface() -> WitInterface {
+    WitInterface {
+        namespace: "acme".to_string(),
+        package: "tasks".to_string(),
+        interfaces: ["runner".to_string()].into_iter().collect(),
+        version: Some(semver::Version::parse("0.1.0").unwrap()),
+        config: HashMap::new(),
+        name: None,
+    }
+}
+
+/// One `runner.run` call, as the plugin hands it to the host: the message to
+/// send and the channel its reply comes back on.
+struct RunCall {
+    message: String,
+    reply: oneshot::Sender<Result<String>>,
+}
+
+impl GuestCall for RunCall {
+    fn call<'a>(
+        self: Box<Self>,
+        accessor: &'a Accessor<SharedCtx>,
+        instance: Instance,
+    ) -> GuestCallFuture<'a> {
+        Box::pin(async move {
+            let view = accessor
+                .with(|mut access| bindings::RunnerView::new(&mut access, &instance))
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "dispatch target is missing its acme:tasks/runner export: {e:#}"
+                    )
+                })?;
+            let reply = view
+                .acme_tasks_runner()
+                .call_run(accessor, self.message)
+                .await
+                .map_err(|e| anyhow::anyhow!("runner.run trapped: {e:#}"));
+            let _ = self.reply.send(reply);
+            Ok(())
+        })
+    }
+}
+
+/// A host-native plugin in the push direction: it serves nothing a workload
+/// imports, and exists to call `acme:tasks/runner` on whatever bound it.
+#[derive(Default)]
+struct TaskPusher {
+    /// One dispatch target per workload, resolved while the workload resolved
+    /// and held for as long as it runs.
+    targets: Mutex<HashMap<String, DispatchTarget>>,
+}
+
+impl TaskPusher {
+    /// Push one unit of work into `workload_id` and wait for the reply.
+    async fn run(&self, workload_id: &str, message: &str) -> Result<String> {
+        let target = self
+            .targets
+            .lock()
+            .await
+            .get(workload_id)
+            .cloned()
+            .with_context(|| format!("no dispatch target for workload '{workload_id}'"))?;
+        let (reply, reply_rx) = oneshot::channel();
+        target
+            .dispatch(RunCall {
+                message: message.to_string(),
+                reply,
+            })
+            .await?;
+        reply_rx.await.context("dispatched call sent no reply")?
+    }
+}
+
+#[async_trait::async_trait]
+impl HostPlugin for TaskPusher {
+    fn id(&self) -> &'static str {
+        "acme-tasks"
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from("acme:tasks/runner@0.1.0")]),
+            ..Default::default()
+        }
+    }
+
+    async fn on_workload_resolved(
+        &self,
+        workload: &ResolvedWorkload,
+        item_id: &str,
+    ) -> anyhow::Result<()> {
+        // Resolving the target here, while the workload resolves, is what
+        // reserves a service's ingress before it starts running.
+        let target = workload.dispatch_target(item_id).await?;
+        self.targets
+            .lock()
+            .await
+            .insert(workload.id().to_string(), target);
+        Ok(())
+    }
+
+    async fn on_workload_unbind(
+        &self,
+        workload_id: &str,
+        _interfaces: WitInterfaces<'_>,
+    ) -> anyhow::Result<()> {
+        self.targets.lock().await.remove(workload_id);
+        Ok(())
+    }
+}
+
+/// A host running nothing but the plugin under test: the fixture imports only
+/// WASI, so no other plugin is involved in reaching it.
+async fn start_host() -> Result<(Arc<TaskPusher>, impl HostApi)> {
+    let plugin = Arc::new(TaskPusher::default());
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let host = HostBuilder::new()
+        .with_engine(Engine::builder().build()?)
+        .with_http_handler(Arc::new(ingress))
+        .with_plugin(Arc::clone(&plugin) as Arc<dyn HostPlugin>)?
+        .build()?;
+    let host = host.start().await.context("failed to start host")?;
+    Ok((plugin, host))
+}
+
+/// The fixture deployed as an ordinary component, with the instance limits the
+/// caller wants to observe.
+fn component_workload(
+    workload_id: &str,
+    pool_size: i32,
+    max_concurrency: i32,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: workload_id.to_string(),
+            annotations: HashMap::new(),
+            service: None,
+            components: vec![Component {
+                name: "dispatch-target".to_string(),
+                digest: None,
+                bytes: bytes::Bytes::from_static(DISPATCH_TARGET_WASM),
+                local_resources: LocalResources::default(),
+                pool_size,
+                max_invocations: 0,
+                max_concurrency,
+                ..Default::default()
+            }],
+            host_interfaces: vec![acme_tasks_interface()],
+            volumes: vec![],
+        },
+    }
+}
+
+/// The same fixture deployed as the workload's long-lived service, with nothing
+/// in its environment and no restarts.
+fn service_workload(workload_id: &str) -> WorkloadStartRequest {
+    service_workload_with(workload_id, HashMap::new(), 0)
+}
+
+/// The same fixture deployed as the workload's long-lived service, with the
+/// environment and restart budget the caller wants.
+fn service_workload_with(
+    workload_id: &str,
+    environment: HashMap<String, String>,
+    max_restarts: u64,
+) -> WorkloadStartRequest {
+    WorkloadStartRequest {
+        workload_id: workload_id.to_string(),
+        workload: Workload {
+            namespace: "test".to_string(),
+            name: workload_id.to_string(),
+            annotations: HashMap::new(),
+            service: Some(Service {
+                digest: None,
+                bytes: bytes::Bytes::from_static(DISPATCH_TARGET_WASM),
+                local_resources: LocalResources {
+                    environment,
+                    ..LocalResources::default()
+                },
+                max_restarts,
+            }),
+            components: vec![],
+            host_interfaces: vec![acme_tasks_interface()],
+            volumes: vec![],
+        },
+    }
+}
+
+async fn stop(host: &impl HostApi, workload_id: &str) {
+    let _ = host
+        .workload_stop(WorkloadStopRequest {
+            workload_id: workload_id.to_string(),
+        })
+        .await;
+}
+
+/// A component that keeps instances warm serves every dispatched call on one of
+/// them: the counts climb, which they only can if the instance outlived the
+/// call before it. This is what `poolSize` buys a push-mode plugin.
+#[tokio::test]
+async fn test_dispatch_runs_on_a_warm_component_instance() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload("warm", 1, 4))
+        .await?;
+
+    assert_eq!(plugin.run("warm", "a").await?, "a:1");
+    assert_eq!(plugin.run("warm", "b").await?, "b:2");
+    assert_eq!(plugin.run("warm", "c").await?, "c:3");
+
+    stop(&host, "warm").await;
+    Ok(())
+}
+
+/// A component that asked for no warm instances still gets its calls, each on
+/// an instance built and dropped for it — the count restarts every time.
+#[tokio::test]
+async fn test_dispatch_to_an_unpooled_component_builds_an_instance_per_call() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload("cold", 0, 0))
+        .await?;
+
+    assert_eq!(plugin.run("cold", "a").await?, "a:1");
+    assert_eq!(plugin.run("cold", "b").await?, "b:1");
+
+    stop(&host, "cold").await;
+    Ok(())
+}
+
+/// A workload whose SERVICE exports the interface is dispatched to on the
+/// instance already running — not silently skipped, and not instantiated a
+/// second time. The climbing counts are the proof: a service has no per-call
+/// instantiation to fall back on, so a fresh instance would answer `1` forever.
+#[tokio::test]
+async fn test_dispatch_reaches_a_service() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(service_workload("svc")).await?;
+
+    assert_eq!(plugin.run("svc", "a").await?, "a:1");
+    assert_eq!(plugin.run("svc", "b").await?, "b:2");
+    assert_eq!(plugin.run("svc", "c").await?, "c:3");
+
+    stop(&host, "svc").await;
+    Ok(())
+}
+
+/// Calls dispatched at once to a service are served concurrently on its one
+/// instance, so the counts they report are exactly `1..=n` — one instance, n
+/// calls, no duplicates.
+#[tokio::test]
+async fn test_concurrent_dispatches_share_the_service_instance() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(service_workload("svc-concurrent"))
+        .await?;
+
+    let messages: Vec<String> = (0..4).map(|i| format!("m{i}")).collect();
+    let replies =
+        futures::future::join_all(messages.iter().map(|m| plugin.run("svc-concurrent", m))).await;
+
+    let mut counts = replies
+        .into_iter()
+        .map(|reply| {
+            let reply = reply?;
+            let (_, count) = reply
+                .rsplit_once(':')
+                .context("reply is not `{message}:{count}`")?;
+            count.parse::<u32>().context("reply count is not a number")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    counts.sort_unstable();
+    assert_eq!(counts, vec![1, 2, 3, 4]);
+
+    stop(&host, "svc-concurrent").await;
+    Ok(())
+}
+
+/// A service reached only by dispatched calls is still supervised as the plain
+/// p3 service it would otherwise be: its `cli/run` failing spends the workload's
+/// restart budget and, at zero, ends the service. Binding a plugin that pushes
+/// into it must not quietly turn `maxRestarts` into "run forever with dead
+/// `cli/run` work".
+#[tokio::test]
+async fn test_a_dispatch_only_service_still_spends_its_restart_budget() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(service_workload_with(
+        "svc-run-fails",
+        HashMap::from([("RUN_EXIT".to_string(), "error".to_string())]),
+        0,
+    ))
+    .await?;
+
+    // The first dispatch may still land — `cli/run` and the ingress start
+    // together — so wait for the incarnation to end rather than asserting on a
+    // single call.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match plugin.run("svc-run-fails", "x").await {
+            Err(_) => break,
+            Ok(_) if std::time::Instant::now() >= deadline => {
+                panic!(
+                    "service kept serving dispatched calls after cli/run failed with no restarts left"
+                )
+            }
+            Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+        }
+    }
+
+    stop(&host, "svc-run-fails").await;
+    Ok(())
+}
+
+/// A target outlives the workload it names — a plugin holds one until it is
+/// unbound, which happens after teardown starts — so a dispatch that arrives
+/// once the workload has stopped is refused. Otherwise it would build (and, for
+/// a pooled component, park) a fresh instance in a workload the host has already
+/// torn down.
+#[tokio::test]
+async fn test_dispatch_after_the_workload_stops_is_refused() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload("stopped", 1, 1))
+        .await?;
+    assert_eq!(plugin.run("stopped", "a").await?, "a:1");
+
+    // Reach past the plugin's own unbind bookkeeping to the target it held
+    // while the workload ran: the host must refuse the call on its own, not
+    // rely on a plugin having tidied up first.
+    let target = plugin
+        .targets
+        .lock()
+        .await
+        .get("stopped")
+        .cloned()
+        .expect("plugin bound the workload");
+    stop(&host, "stopped").await;
+
+    let (reply, _reply_rx) = oneshot::channel();
+    let err = target
+        .dispatch(RunCall {
+            message: "after".to_string(),
+            reply,
+        })
+        .await
+        .expect_err("a stopped workload must take no more dispatched calls");
+    assert!(
+        err.to_string().contains("has stopped"),
+        "unexpected error: {err:#}"
+    );
+
+    Ok(())
+}
+
+/// An item the workload does not have is refused when the target is resolved,
+/// rather than accepted and dispatched into nothing.
+#[tokio::test]
+async fn test_an_unknown_item_is_refused() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload("unknown-item", 1, 1))
+        .await?;
+
+    let target = plugin.targets.lock().await;
+    let workload = target
+        .get("unknown-item")
+        .expect("plugin bound the workload")
+        .workload()
+        .clone();
+    drop(target);
+
+    let err = workload
+        .dispatch_target("no-such-item")
+        .await
+        .expect_err("a missing item must not resolve as a dispatch target");
+    assert!(
+        err.to_string().contains("no item 'no-such-item'"),
+        "unexpected error: {err:#}"
+    );
+
+    stop(&host, "unknown-item").await;
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_plugin_dispatch.rs
+++ b/crates/wash-runtime/tests/integration_plugin_dispatch.rs
@@ -13,7 +13,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
@@ -97,14 +97,17 @@ impl GuestCall for RunCall {
                         "dispatch target is missing its acme:tasks/runner export: {e:#}"
                     )
                 })?;
-            let reply = view
+            // A trap is a call that did not complete, so it is the host's
+            // `Err` — which is what retires the instance it ran on. Only an
+            // answer the guest actually gave goes back on the plugin's own
+            // channel.
+            let answer = view
                 .acme_tasks_runner()
                 .call_run(accessor, self.message)
                 .await
-                .map_err(|e| anyhow::anyhow!("runner.run trapped: {e:#}"));
-            let refused = reply.is_err().then_some("trap");
-            let _ = self.reply.send(reply);
-            Ok(refused)
+                .map_err(|e| anyhow::anyhow!("runner.run trapped: {e:#}"))?;
+            let _ = self.reply.send(Ok(answer));
+            Ok(None)
         })
     }
 }
@@ -115,7 +118,7 @@ impl GuestCall for RunCall {
 struct TaskPusher {
     /// One dispatch target per workload, resolved while the workload resolved
     /// and held for as long as it runs.
-    targets: Mutex<HashMap<String, DispatchTarget>>,
+    targets: Mutex<BTreeMap<String, DispatchTarget>>,
 }
 
 impl TaskPusher {
@@ -316,6 +319,34 @@ async fn test_a_dispatched_call_spends_the_instances_invocation_budget() -> Resu
     Ok(())
 }
 
+/// A dispatched call that traps takes the warm instance it ran on with it: the
+/// next call is served by a fresh one, counting from zero again.
+///
+/// The trap faults the whole store, so the driver ends and the pool reaps its
+/// handle — a `GuestCall` returning `Err` retires the instance for the failures
+/// that do *not* fault it, and reporting the trap that way is what keeps the two
+/// consistent.
+#[tokio::test]
+async fn test_a_trapping_dispatch_takes_its_warm_instance_with_it() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(component_workload("trapped", 1, 1))
+        .await?;
+
+    assert_eq!(plugin.run("trapped", "a").await?, "a:1");
+    assert!(
+        plugin.run("trapped", "trap").await.is_err(),
+        "a trapped call must be reported to the dispatcher, not answered"
+    );
+    assert_eq!(
+        plugin.run("trapped", "b").await?,
+        "b:1",
+        "the next call must land on a fresh instance, not the one that trapped"
+    );
+
+    stop(&host, "trapped").await;
+    Ok(())
+}
+
 /// A component that asked for no warm instances still gets its calls, each on
 /// an instance built and dropped for it — the count restarts every time.
 #[tokio::test]
@@ -410,6 +441,37 @@ async fn test_a_dispatch_only_service_still_spends_its_restart_budget() -> Resul
     }
 
     stop(&host, "svc-run-fails").await;
+    Ok(())
+}
+
+/// The same, for a `cli/run` that *traps* rather than answering with an error.
+/// A plain p3 service spends a restart on either, so a dispatch-only one — which
+/// reaches the trigger driver only because a plugin claimed it — has to as well.
+#[tokio::test]
+async fn test_a_dispatch_only_service_spends_its_budget_on_a_cli_run_trap() -> Result<()> {
+    let (plugin, host) = start_host().await?;
+    host.workload_start(service_workload_with(
+        "svc-run-traps",
+        HashMap::from([("RUN_EXIT".to_string(), "trap".to_string())]),
+        0,
+    ))
+    .await?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match plugin.run("svc-run-traps", "x").await {
+            Err(_) => break,
+            Ok(_) if std::time::Instant::now() >= deadline => {
+                panic!(
+                    "service kept serving dispatched calls after cli/run trapped with no \
+                     restarts left"
+                )
+            }
+            Ok(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+        }
+    }
+
+    stop(&host, "svc-run-traps").await;
     Ok(())
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -154,6 +154,8 @@ const P3_FIXTURES: &[&str] = &[
     "http-egress-plugin-caller",
     "events-plugin",
     "events-caller",
+    "events-service",
+    "dispatch-target",
 ];
 
 fn build_fixtures(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
This allows a host plugin to dispatch calls into a workload's Service.

1. The instance pool was `pub(crate)` but `PluginJob`, `InstanceJob`, `instance_pool_for_component` and `warm_instance_policy` were all crate-private. Found while building an out-of-tree native plugin.
2. `instantiate_pre` never looked at `self.service`. A `Service`-kind item exporting an interface a plugin calls had no instance to dispatch to. Imports were unaffected, they go through the linker like everything else, so only the export direction wasn't wired up.

A plugin resolves one `DispatchTarget` per item from `on_workload_resolved` and dispatches `GuestCall`s through it for as long as the workload runs. The host decides *where* each call runs, either on a warm instance, a store built for the call, or the running service. The plugin keeps making the call with its own generated bindings.

```rust
// once, from HostPlugin::on_workload_resolved
let target = workload.dispatch_target(item_id, self.id()).await?;

// per unit of work, for as long as the workload is up
target.dispatch(Deliver { records, reply }).await?;
```

A service is reached by a new `Ingress::Guest` on its trigger-service driver, claimed when the workload resolves. Calls land on the instance, sharing the state it has built up.

`InstanceJob` carried two variants meaning "a plugin's call": `Plugin`, the crate-private one the NATS subscriber used, and `Guest`, the public one. Now this removes `PluginJob` and replaces it with `GuestCall` so that there is one contract that the host owns, once, for every dispatched call:

- `rearm_for_call`, so the epoch deadline measures just the call.
- `watch_until_abandoned`, so a slow guest on a shared store is not condemned by another call's abandonment.

The NATS core and KV delivery jobs shed their copies of all of the above and became `GuestCall`s. This is a net deletion with no behavior changes.
