### PR TITLE
test(runtime-operator): canary e2e flags

### DIFF
--- a/runtime-operator/test/e2e/e2e_suite_test.go
+++ b/runtime-operator/test/e2e/e2e_suite_test.go
@@ -487,15 +487,6 @@ func buildBaseHelmSets() []string {
 			fmt.Sprintf("runtime.image.tag=%s", runtimeImageTag),
 			"runtime.image.pull_policy=IfNotPresent",
 			"gateway.image.tag=canary",
-			// Chart features whose host flags are not in canary yet. This path
-			// runs whatever upstream last published, so it cannot enable a
-			// flag added on the branch: `wash host` exits on an argument it
-			// does not know, and the pod never starts. Drop an entry here once
-			// its flag has merged. `BUILD_RUNTIME_IMAGE=true` runs the
-			// branch's own host and exercises them.
-			"runtime.probes.endpoint.enabled=false",
-			"runtime.drainDelaySeconds=0",
-			"runtime.natsConnectTimeoutSeconds=0",
 		)
 	}
 	return sets


### PR DESCRIPTION
The three overrides existed because the published canary host predated `--probe-addr`, `--drain-delay` and `--nats-connect-timeout`. All three merged with #5536 and canary has since republished, so that leg can take the chart defaults and exercise them like the branch-built leg does.
