### PR TITLE
fix(wash-runtime): release a host's ingress when the host is dropped

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -415,7 +415,8 @@ impl wasmtime_wasi_http::p3::WasiHttpView for SharedCtx {
 
 /// HTTP hooks implementation that delegates to a [`HostHandler`](crate::host::http::HostHandler).
 struct CtxHttpHooks {
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    /// See [`crate::host::http::live_handler`] for why this is weak.
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     workload_id: Arc<str>,
     allowed_hosts: Arc<[AllowedHost]>,
 }
@@ -427,13 +428,25 @@ impl WasiHttpHooks for CtxHttpHooks {
         config: wasmtime_wasi_http::p2::types::OutgoingRequestConfig,
     ) -> wasmtime_wasi_http::p2::HttpResult<wasmtime_wasi_http::p2::types::HostFutureIncomingResponse>
     {
+        // A store with no handler at all and a store whose host has gone away
+        // under it are different failures, and the guest is told which: the
+        // first is how this host was configured, the second is a store
+        // outliving the host that built it.
         match &self.http_handler {
-            Some(handler) => {
-                handler.outgoing_request(&self.workload_id, request, config, &self.allowed_hosts)
-            }
             None => Err(wasmtime_wasi_http::p2::HttpError::trap(
                 wasmtime::format_err!("http client not available"),
             )),
+            Some(handler) => match crate::host::http::live_handler(handler) {
+                Ok(handler) => handler.outgoing_request(
+                    &self.workload_id,
+                    request,
+                    config,
+                    &self.allowed_hosts,
+                ),
+                Err(e) => Err(wasmtime_wasi_http::p2::HttpError::trap(
+                    wasmtime::format_err!("{e:#}"),
+                )),
+            },
         }
     }
 }
@@ -443,7 +456,8 @@ impl WasiHttpHooks for CtxHttpHooks {
 /// (allowed-hosts policy, alternate transports, etc.) applies uniformly to
 /// both P2 and P3 components.
 struct CtxHttpHooksP3 {
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    /// See [`crate::host::http::live_handler`] for why this is weak.
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     workload_id: Arc<str>,
     allowed_hosts: Arc<[AllowedHost]>,
 }
@@ -490,17 +504,23 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for CtxHttpHooksP3 {
     > {
         use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode as P3ErrorCode;
 
-        match &self.http_handler {
-            Some(handler) => handler.outgoing_request_p3(
+        // As in [`CtxHttpHooks::send_request`], an unconfigured handler and a
+        // host that has gone away are reported apart.
+        let handler = match &self.http_handler {
+            None => Err("http client not available".to_string()),
+            Some(handler) => crate::host::http::live_handler(handler).map_err(|e| format!("{e:#}")),
+        };
+        match handler {
+            Ok(handler) => handler.outgoing_request_p3(
                 &self.workload_id,
                 request,
                 options,
                 fut,
                 &self.allowed_hosts,
             ),
-            None => Box::new(async move {
+            Err(message) => Box::new(async move {
                 Err(wasmtime_wasi::TrappableError::from(
-                    P3ErrorCode::InternalError(Some("http client not available".to_string())),
+                    P3ErrorCode::InternalError(Some(message)),
                 ))
             }),
         }
@@ -516,7 +536,7 @@ pub struct CtxBuilder {
     ctx: Option<WasiCtx>,
     sockets: Option<crate::sockets::WasiSocketsCtx>,
     plugins: HashMap<&'static str, Arc<dyn HostPlugin + Send + Sync>>,
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     allowed_hosts: Arc<[AllowedHost]>,
     /// TLS provider override for `wasi:tls` client connections.
     #[cfg(feature = "wasi-tls")]
@@ -562,11 +582,18 @@ impl CtxBuilder {
         self
     }
 
+    /// Point this store's outgoing HTTP at `http_handler`.
+    ///
+    /// Borrowed, not owned, because the store keeps only a
+    /// [`Weak`](std::sync::Weak) — see [`crate::host::http::live_handler`]. The
+    /// caller therefore has to keep the handler alive itself; taking it by
+    /// reference is what says so, rather than accepting an `Arc` whose last
+    /// strong count this call would quietly drop.
     pub fn with_http_handler(
         mut self,
-        http_handler: Arc<dyn crate::host::http::HostHandler>,
+        http_handler: &Arc<dyn crate::host::http::HostHandler>,
     ) -> Self {
-        self.http_handler = Some(http_handler);
+        self.http_handler = Some(Arc::downgrade(http_handler));
         self
     }
 

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -159,7 +159,8 @@ pub(crate) struct EphemeralLinkedCall {
     /// this call ends up running in.
     pub(crate) pre: InstancePre<SharedCtx>,
     pub(crate) engine: wasmtime::Engine,
-    pub(crate) http_handler: Arc<dyn crate::host::http::HostHandler>,
+    /// See [`crate::host::http::live_handler`] for why this is weak.
+    pub(crate) http_handler: std::sync::Weak<dyn crate::host::http::HostHandler>,
     /// The meter of the host this call runs on; see
     /// [`crate::engine::abandon::StoreMetering`].
     pub(crate) invocation: crate::observability::InvocationMeter,
@@ -312,7 +313,7 @@ async fn build_ctx_from_template(
     }
 
     let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
-        .with_http_handler(http_handler)
+        .with_http_handler(&http_handler)
         .with_wasi_ctx(wasi_ctx_builder.build())
         .with_sockets(sockets_ctx)
         .with_allowed_hosts(template.local_resources.allowed_hosts.clone());
@@ -491,7 +492,7 @@ async fn new_ephemeral_store(
 
     let store = new_store_from_templates(
         &call.engine,
-        call.http_handler.clone(),
+        crate::host::http::live_handler(&call.http_handler)?,
         &active,
         &linked,
         &linked_instances,

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -604,8 +604,10 @@ pub struct ResolvedWorkload {
     /// All components in the workload. This is behind a `RwLock` to support mutable
     /// access to the component linkers.
     components: Arc<RwLock<BTreeMap<Arc<str>, WorkloadComponent>>>,
-    /// The HTTP handler for outgoing HTTP requests
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    /// The HTTP handler for outgoing HTTP requests. See
+    /// [`crate::host::http::live_handler`] for why this is weak and how the
+    /// two kinds of caller differ.
+    http_handler: std::sync::Weak<dyn crate::host::http::HostHandler>,
     /// The meter of the host running this workload, stamped onto every store
     /// built for it. Reaches the engine the same way `http_handler` does,
     /// because a store has no other way back to the host that owns it.
@@ -657,7 +659,9 @@ impl std::fmt::Debug for ResolvedWorkload {
 /// leave every restarted incarnation permanently broken.
 struct ServiceStoreRecipe {
     engine: wasmtime::Engine,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    /// Weak, like the workload's own; the supervisor holds this recipe for as
+    /// long as the service runs.
+    http_handler: std::sync::Weak<dyn crate::host::http::HostHandler>,
     active_template: ComponentCtxTemplate,
     linked_templates: Vec<ComponentCtxTemplate>,
     linked_instances: Vec<(Arc<str>, wasmtime::component::InstancePre<SharedCtx>)>,
@@ -670,12 +674,13 @@ struct ServiceStoreRecipe {
 }
 
 impl ServiceStoreRecipe {
-    /// Build a fresh service store (`is_service = true` so `cli/run` may bind
-    /// its loopback socket).
+    /// Build a fresh service store. Always a service store: the flag it passes
+    /// is what lets `cli/run` bind its loopback socket, and every store built
+    /// from this recipe is an incarnation of a service that may want one.
     async fn build(&self) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
         let store = new_store_from_templates(
             &self.engine,
-            self.http_handler.clone(),
+            crate::host::http::live_handler(&self.http_handler)?,
             &self.active_template,
             &self.linked_templates,
             &self.linked_instances,
@@ -771,9 +776,7 @@ impl ResolvedWorkload {
         let Some(service) = self.service.as_ref() else {
             bail!("service unexpectedly missing during execution");
         };
-        let mut store = self
-            .new_store_from_metadata(&service.metadata, true)
-            .await?;
+        let mut store = self.new_store_from_metadata(&service.metadata).await?;
         let instance = pre.instantiate_async(&mut store).await?;
         let handle = tokio::spawn(async move {
             loop {
@@ -904,6 +907,10 @@ impl ResolvedWorkload {
         let mut store = recipe.build().await?;
         let http_handler = self.http_handler.clone();
         let workload_id: Arc<str> = Arc::from(self.id());
+        // Carried for the supervisor's own logs: the id alone does not say
+        // which workload's service a restart decision is about.
+        let workload_name: Arc<str> = self.name.clone();
+        let workload_namespace: Arc<str> = self.namespace.clone();
         // The hostnames this service serves HTTP on, derived once from the
         // workload's declared interfaces. Passed to every HTTP registration
         // (the first below and each restart re-registration in the supervisor)
@@ -931,13 +938,13 @@ impl ResolvedWorkload {
         let (ingresses, http_tx, messaging_tx) =
             build_trigger_ingresses(serves_http, serves_messaging, &service_calls);
         if let Some(http_tx) = http_tx {
-            self.http_handler
+            self.http_handler()?
                 .on_service_http_resolved(self.id(), &ingress_hostnames, http_tx)
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to register service HTTP handler: {e:#}"))?;
         }
         if let Some(messaging_tx) = messaging_tx {
-            self.http_handler
+            self.http_handler()?
                 .on_trigger_service_messaging_resolved(self.id(), messaging_tx)
                 .await
                 .map_err(|e| {
@@ -956,6 +963,20 @@ impl ResolvedWorkload {
                 let ingresses = match first.take() {
                     Some(ingresses) => ingresses,
                     None => {
+                        // The handler is held weakly, so a host that went away
+                        // while this service was faulting ends the supervisor:
+                        // there is nothing left to re-register the restarted
+                        // incarnation's ingresses with.
+                        let Some(http_handler) = http_handler.upgrade() else {
+                            error!(
+                                workload.id = %workload_id,
+                                workload.namespace = %workload_namespace,
+                                workload.name = %workload_name,
+                                "host HTTP handler is no longer available; \
+                                 not restarting this workload's service"
+                            );
+                            break;
+                        };
                         let (ingresses, http_tx, messaging_tx) =
                             build_trigger_ingresses(serves_http, serves_messaging, &service_calls);
                         if let Some(http_tx) = http_tx
@@ -963,14 +984,26 @@ impl ResolvedWorkload {
                                 .on_service_http_resolved(&workload_id, &ingress_hostnames, http_tx)
                                 .await
                         {
-                            error!(err = %e, "failed to re-register service HTTP handler on restart");
+                            error!(
+                                workload.id = %workload_id,
+                                workload.namespace = %workload_namespace,
+                                workload.name = %workload_name,
+                                err = %e,
+                                "failed to re-register service HTTP handler on restart"
+                            );
                         }
                         if let Some(messaging_tx) = messaging_tx
                             && let Err(e) = http_handler
                                 .on_trigger_service_messaging_resolved(&workload_id, messaging_tx)
                                 .await
                         {
-                            error!(err = %e, "failed to re-register trigger service messaging handler on restart");
+                            error!(
+                                workload.id = %workload_id,
+                                workload.namespace = %workload_namespace,
+                                workload.name = %workload_name,
+                                err = %e,
+                                "failed to re-register trigger service messaging handler on restart"
+                            );
                         }
                         ingresses
                     }
@@ -1559,8 +1592,12 @@ impl ResolvedWorkload {
     /// the messaging subscriber) deliver an inbound message to a long-lived
     /// trigger-service instance instead of instantiating a component per
     /// message.
-    pub fn http_handler(&self) -> &Arc<dyn crate::host::http::HostHandler> {
-        &self.http_handler
+    ///
+    /// Held weakly, so this fails once the host that owns the handler is gone
+    /// — which is the answer every caller wants: there is nothing left to
+    /// register with, deliver to, or send an outbound request through.
+    pub fn http_handler(&self) -> anyhow::Result<Arc<dyn crate::host::http::HostHandler>> {
+        crate::host::http::live_handler(&self.http_handler)
     }
 
     /// Gets the name of the workload
@@ -1633,7 +1670,7 @@ impl ResolvedWorkload {
         };
         let store = new_store_from_templates(
             &engine,
-            self.http_handler.clone(),
+            self.http_handler()?,
             &active_template,
             &linked_templates,
             &linked_instances,
@@ -1868,33 +1905,17 @@ impl ResolvedWorkload {
     }
 
     /// Creates a new wasmtime Store for multiple components from the given workload metadata.
+    ///
+    /// The recipe carries the metering stamp a service's store needs — it
+    /// serves every ingress the workload has, concurrently, for the life of the
+    /// workload, so no call on it can attribute a delta to itself and
+    /// `guest.execution.total` is all there is. See
+    /// [`crate::engine::abandon::GuestExecution`].
     async fn new_store_from_metadata(
         &self,
         metadata: &WorkloadMetadata,
-        is_service: bool,
     ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        let recipe = self.service_store_recipe(metadata).await?;
-        let store = new_store_from_templates(
-            &recipe.engine,
-            recipe.http_handler.clone(),
-            &recipe.active_template,
-            &recipe.linked_templates,
-            &recipe.linked_instances,
-            is_service,
-        )
-        .await?;
-        // A service's store is the one that most needs this: it serves every
-        // ingress the workload has, concurrently, for the life of the workload,
-        // so no call on it can attribute a delta to itself and
-        // `guest.execution.total` is all there is. See
-        // [`crate::engine::abandon::GuestExecution`].
-        if self.invocation.is_enabled() {
-            store
-                .data()
-                .executed
-                .set_identity(self.service_identity(metadata), self.invocation.clone());
-        }
-        Ok(store)
+        self.service_store_recipe(metadata).await?.build().await
     }
 
     /// The identity a service's store runs under.
@@ -2287,9 +2308,13 @@ impl ResolvedWorkload {
                 }
             }
 
-            if component.exports_wasi_http() {
+            // A handler that is already gone has nothing left to unbind from,
+            // so teardown treats that as done rather than as a failure.
+            if component.exports_wasi_http()
+                && let Some(http_handler) = self.http_handler.upgrade()
+            {
                 anyhow::Context::context(
-                    self.http_handler.on_workload_unbind(self.id()).await,
+                    http_handler.on_workload_unbind(self.id()).await,
                     "failed to notify HTTP handler of workload",
                 )?;
             }
@@ -2329,12 +2354,13 @@ impl ResolvedWorkload {
         // A trigger service registered its HTTP/messaging handlers at start
         // (`execute_trigger_service`); drop those registrations on stop so it no
         // longer receives host-invoked deliveries on a torn-down instance.
-        if self.service.is_some() {
-            if let Err(e) = self.http_handler.on_service_http_unbind(self.id()).await {
+        if self.service.is_some()
+            && let Some(http_handler) = self.http_handler.upgrade()
+        {
+            if let Err(e) = http_handler.on_service_http_unbind(self.id()).await {
                 tracing::error!(workload.id = %self.id(), err = %e, "failed to unbind service HTTP handler, continuing");
             }
-            if let Err(e) = self
-                .http_handler
+            if let Err(e) = http_handler
                 .on_trigger_service_messaging_unbind(self.id())
                 .await
             {
@@ -2974,7 +3000,7 @@ impl UnresolvedWorkload {
             service_calls: Arc::default(),
             released: Arc::default(),
             host_interfaces: self.host_interfaces,
-            http_handler: http_handler.clone(),
+            http_handler: Arc::downgrade(&http_handler),
             invocation: meters.invocation.clone(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -745,6 +745,27 @@ impl Router for DevRouter {
     }
 }
 
+/// Take a live handle on a handler that something the handler owns holds
+/// weakly, and the one error they all report when it is gone.
+///
+/// An ingress keeps every routable workload so an inbound request can find one,
+/// so anything reachable from a workload holds the handler back weakly or the
+/// two pin each other: the workload itself, an ephemeral linked call (which
+/// lives in a linker closure, hence in the `InstancePre` the ingress keeps), a
+/// service's store recipe, a store's egress hooks, and a bound host component
+/// plugin. Strong handles exist for the length of one call and are taken here.
+///
+/// Callers split two ways, deliberately. A path that cannot proceed without a
+/// handler propagates this error; a teardown path asks the `Weak` directly and
+/// skips, because a handler that is already gone has nothing left to unbind.
+pub(crate) fn live_handler(
+    handler: &std::sync::Weak<dyn HostHandler>,
+) -> anyhow::Result<Arc<dyn HostHandler>> {
+    handler
+        .upgrade()
+        .ok_or_else(|| anyhow::anyhow!("host HTTP handler is no longer available"))
+}
+
 /// Trait defining the behavior of a Host HTTP Extension
 /// Allows for custom handling of incoming and outgoing HTTP requests
 /// Use this trait to implement custom HTTP server transport
@@ -1420,6 +1441,15 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         if let Some(tx) = shutdown_guard.take() {
             let _ = tx.send(()).await;
         }
+        // Let go of what the routing tables hold. A stopped ingress serves
+        // nothing, so keeping them would pin every routed workload's
+        // `InstancePre` — its compiled components, and the engine behind them —
+        // for as long as anything still holds the ingress itself. A workload
+        // stopped after this finds nothing to unbind, which is the right
+        // answer.
+        self.workload_handles.write().await.clear();
+        self.service_handlers.write().await.clear();
+        self.messaging_handlers.write().await.clear();
         Ok(())
     }
 

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -287,7 +287,10 @@ pub struct ComponentHostPlugin {
     /// handler a workload's outgoing calls use. `None` traps every call with
     /// "http client not available", matching today's behavior for a plugin
     /// that imports `wasi:http/outgoing-handler` with no handler configured.
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    ///
+    /// Weak — a bound plugin is reached from every workload that binds it, and
+    /// the ingress holds those. See [`crate::host::http::live_handler`].
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     max_restarts: u32,
     /// Ports this plugin declared, as the operator wrote them.
     /// The subset of `ports` this plugin binds for real itself, precomputed for
@@ -343,7 +346,7 @@ impl ComponentHostPlugin {
         #[builder(default)] allowed_ip_name_lookups: Arc<
             [crate::host::allowed_ip_name::AllowedIpName],
         >,
-        http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+        http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
         #[builder(default)] ports: Arc<[crate::host::declared_port::DeclaredPort]>,
         socket_policy: Option<Arc<crate::sockets::policy::SocketPolicy>>,
     ) -> anyhow::Result<Self> {
@@ -698,7 +701,7 @@ pub async fn load_component_plugin(
     engine: &Engine,
     oci_config: OciConfig,
     native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     socket_policy: Option<Arc<crate::sockets::policy::SocketPolicy>>,
 ) -> anyhow::Result<Arc<ComponentHostPlugin>> {
     let loaded = spec
@@ -1774,7 +1777,7 @@ async fn run_supervisor(
     mut rx: tokio::sync::mpsc::Receiver<CapabilityJob>,
     allowed_hosts: Arc<[crate::host::allowed_hosts::AllowedHost]>,
     allowed_ip_name_lookups: Arc<[crate::host::allowed_ip_name::AllowedIpName]>,
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     network: crate::host::ports::NetworkHandle,
     direct_binds: Arc<[crate::sockets::policy::DirectBind]>,
     socket_policy: Arc<crate::sockets::policy::SocketPolicy>,
@@ -1964,7 +1967,7 @@ fn build_plugin_store(
     native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
     allowed_hosts: &Arc<[crate::host::allowed_hosts::AllowedHost]>,
     allowed_ip_name_lookups: &Arc<[crate::host::allowed_ip_name::AllowedIpName]>,
-    http_handler: Option<Arc<dyn crate::host::http::HostHandler>>,
+    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
     network: &crate::host::ports::NetworkHandle,
     direct_binds: &Arc<[crate::sockets::policy::DirectBind]>,
     socket_policy: &Arc<crate::sockets::policy::SocketPolicy>,
@@ -2009,8 +2012,10 @@ fn build_plugin_store(
         )
         .with_sockets(sockets_ctx)
         .with_allowed_hosts(Arc::clone(allowed_hosts));
-    if let Some(http_handler) = http_handler {
-        ctx_builder = ctx_builder.with_http_handler(http_handler);
+    // A store built after the host went away gets no handler, which its egress
+    // already reports; there is nothing left to send through.
+    if let Some(http_handler) = http_handler.as_ref().and_then(std::sync::Weak::upgrade) {
+        ctx_builder = ctx_builder.with_http_handler(&http_handler);
     }
     let ctx = ctx_builder.build();
     // The registry marks this as the plugin (real) side of the resource bridge

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -678,11 +678,31 @@ impl HostPlugin for InMemoryMessaging {
 
                         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Processing message");
 
+                        // The workload holds the handler weakly, so losing it
+                        // means the host this drains into is gone: nothing
+                        // queued now or later can be served, so the task ends
+                        // rather than the drain pass. This message is already
+                        // popped, so a requester waiting on it is failed here
+                        // for the same reason the shed path below does it.
+                        let http_handler = match workload.http_handler() {
+                            Ok(handler) => handler,
+                            Err(e) => {
+                                warn!(error = %e, "ending in-memory receive loop");
+                                if sole_subscriber
+                                    && let (Some(reply_to), Some(pending)) =
+                                        (&msg.reply_to, &pending_requests)
+                                    && let Some(sender) = pending.write().await.remove(reply_to)
+                                {
+                                    let _ = sender.send(Err(super::shed_error()));
+                                }
+                                break 'task;
+                            }
+                        };
+
                         // If this workload runs a long-lived trigger service for
                         // messaging, deliver to it (preserving its in-memory
                         // state) rather than instantiating a component per message.
-                        if workload
-                            .http_handler()
+                        if http_handler
                             .has_trigger_service_messaging(workload.id())
                             .await
                         {
@@ -691,8 +711,7 @@ impl HostPlugin for InMemoryMessaging {
                                 body: msg.body.clone(),
                                 reply_to: msg.reply_to.clone(),
                             };
-                            match workload
-                                .http_handler()
+                            match http_handler
                                 .deliver_trigger_service_message(
                                     workload.id(),
                                     broker,

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -607,11 +607,21 @@ impl HostPlugin for NatsMessaging {
                         let reply_to = msg.reply.as_ref().map(|r| r.to_string());
                         let body: Vec<u8> = msg.payload.into();
 
+                        // The workload holds the handler weakly, so losing it
+                        // means the host this subscriber delivers into is gone
+                        // and no later message can be served either.
+                        let http_handler = match workload.http_handler() {
+                            Ok(handler) => handler,
+                            Err(e) => {
+                                warn!(parent: &span, error = %e, "stopping NATS subscriber loop");
+                                break;
+                            }
+                        };
+
                         // If this workload runs a long-lived trigger service for
                         // messaging, deliver to it (preserving its in-memory
                         // state) rather than instantiating a component per message.
-                        if workload
-                            .http_handler()
+                        if http_handler
                             .has_trigger_service_messaging(workload.id())
                             .await
                         {
@@ -620,8 +630,7 @@ impl HostPlugin for NatsMessaging {
                                 body,
                                 reply_to,
                             };
-                            match workload
-                                .http_handler()
+                            match http_handler
                                 .deliver_trigger_service_message(
                                     workload.id(),
                                     broker,

--- a/crates/wash-runtime/tests/common/mod.rs
+++ b/crates/wash-runtime/tests/common/mod.rs
@@ -480,7 +480,7 @@ async fn start_host_with_component_plugin_router(
         .wasm(plugin_wasm)
         .engine(engine.clone())
         .native_plugins(native_plugins)
-        .maybe_http_handler(http_handler)
+        .maybe_http_handler(http_handler.as_ref().map(Arc::downgrade))
         .build()
         .await
         .context("failed to build host component plugin")?;

--- a/crates/wash-runtime/tests/integration_ingress_release.rs
+++ b/crates/wash-runtime/tests/integration_ingress_release.rs
@@ -1,0 +1,299 @@
+//! A host that is stopped and dropped releases its ingress.
+//!
+//! The ingress keeps every routable workload in its handle map so an inbound
+//! request can find one, and everything reachable from a workload can reach the
+//! ingress back. Held strongly, those make a loop nothing can break: stopping
+//! the host would free neither, and the ingress would go on holding each
+//! workload's `InstancePre`, its compiled components and the engine behind them
+//! for the life of the process.
+//!
+//! There are three ways back, and each test here pins one that the others do
+//! not reach: a workload's own handle and its stores' egress hooks, an
+//! ephemeral linked call (which lives in a linker closure, hence in the
+//! caller's `InstancePre`), and a bound host component plugin.
+//!
+//! Its own binary, so the assertions are about these hosts and not about
+//! whatever another test in the same process left running.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use anyhow::{Context, Result};
+
+use wash_runtime::engine::Engine;
+use wash_runtime::host::http::{DevRouter, HostHandler, Ingress};
+use wash_runtime::host::{Host, HostApi};
+use wash_runtime::types::{Component, LocalResources, Workload, WorkloadStartRequest};
+
+mod common;
+use common::{component_workload_request, http_only_host_interfaces};
+
+const HTTP_HANDLER_P3_WASM: &[u8] = include_bytes!("wasm/http_handler_p3.wasm");
+const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
+const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
+
+/// Build an ingress and a host around it, handing back the address, the started
+/// host, and a `Weak` on the ingress. The only strong handle left is the host's
+/// own, so what the `Weak` measures afterwards is the host's reachability.
+async fn host_with_weak_ingress() -> Result<(std::net::SocketAddr, Arc<Host>, Weak<dyn HostHandler>)>
+{
+    let engine = Engine::builder()
+        .with_pooling_allocator(false)
+        .build()
+        .context("failed to build the engine")?;
+    // `DevRouter`, so a plain GET reaches the workload without these tests also
+    // having to arrange hostname routing.
+    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?)
+        .await
+        .context("failed to bind an ingress")?;
+    let addr = ingress.addr();
+    let ingress: Arc<dyn HostHandler> = Arc::new(ingress);
+    let weak = Arc::downgrade(&ingress);
+
+    let host = Host::builder()
+        .with_engine(engine)
+        .with_http_handler(Arc::clone(&ingress))
+        .build()
+        .context("failed to build the host")?;
+    let host = host.start().await.context("failed to start the host")?;
+    drop(ingress);
+
+    Ok((addr, host, weak))
+}
+
+/// Serve one GET and drain the body, so the store the call ran on is dropped
+/// before the host is — a request still in flight legitimately holds the
+/// ingress.
+async fn serve_one(addr: &std::net::SocketAddr) -> Result<()> {
+    let response = reqwest::get(format!("http://{addr}/"))
+        .await
+        .context("the workload must serve a request")?;
+    assert!(
+        response.status().is_success(),
+        "the workload must serve a request, got {}",
+        response.status()
+    );
+    response.bytes().await.context("failed to read the body")?;
+    Ok(())
+}
+
+/// The workload is deliberately left running in each of these: a host torn down
+/// without each of its workloads stopped first is exactly the case a strong
+/// back-reference strands, and it is the case an embedder building hosts
+/// repeatedly hits.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_stopped_host_releases_its_ingress() -> Result<()> {
+    let ingress = {
+        let (addr, host, weak) = host_with_weak_ingress().await?;
+
+        host.workload_start(component_workload_request(
+            "http-handler-p3.wasm",
+            "ingress-release",
+            HTTP_HANDLER_P3_WASM,
+            LocalResources {
+                memory_limit_mb: 128,
+                cpu_limit: 1,
+                ..Default::default()
+            },
+            http_only_host_interfaces("ingress-release"),
+        ))
+        .await
+        .context("failed to start the workload")?;
+
+        // The handle map is populated at bind, but routing a request is what
+        // builds the store whose egress hooks are the second way back.
+        serve_one(&addr).await?;
+
+        // Dropped, not stopped: `stop` clears the routing tables, which would
+        // break the loop by itself. The weak handles are what has to hold for a
+        // host that is simply let go.
+        drop(host);
+        weak
+    };
+
+    assert!(
+        ingress.upgrade().is_none(),
+        "the ingress outlived the host that owned it: a running workload still \
+         holds it, so nothing it routes is ever freed"
+    );
+    Ok(())
+}
+
+/// A component that calls another component in the same workload gets an
+/// `EphemeralLinkedCall`, which lives in a linker closure and so in the
+/// caller's `InstancePre` — which the ingress keeps. The single-component test
+/// above builds none, so only this one pins that edge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_workload_with_an_ephemeral_linked_call_releases_its_ingress() -> Result<()> {
+    let ingress = {
+        let (addr, host, weak) = host_with_weak_ingress().await?;
+
+        let request = WorkloadStartRequest {
+            workload_id: uuid::Uuid::new_v4().to_string(),
+            workload: Workload {
+                namespace: "test".to_string(),
+                name: "ingress-release-linked".to_string(),
+                annotations: HashMap::new(),
+                service: None,
+                components: vec![
+                    Component {
+                        name: "ephemeral-caller".to_string(),
+                        digest: None,
+                        bytes: bytes::Bytes::from_static(EPHEMERAL_CALLER_P3_WASM),
+                        local_resources: LocalResources::default(),
+                        pool_size: 1,
+                        max_invocations: 100,
+                        max_concurrency: 1,
+                        ..Default::default()
+                    },
+                    Component {
+                        name: "ephemeral-callee".to_string(),
+                        digest: None,
+                        bytes: bytes::Bytes::from_static(EPHEMERAL_CALLEE_P3_WASM),
+                        local_resources: LocalResources::default(),
+                        pool_size: 1,
+                        max_invocations: 100,
+                        max_concurrency: 1,
+                        ..Default::default()
+                    },
+                ],
+                host_interfaces: http_only_host_interfaces("ingress-release-linked"),
+                volumes: vec![],
+            },
+        };
+        host.workload_start(request)
+            .await
+            .context("failed to start the linked workload")?;
+
+        // Drives the linked call, so the ephemeral path has actually run.
+        serve_one(&addr).await?;
+
+        // Dropped, not stopped: `stop` clears the routing tables, which would
+        // break the loop by itself. The weak handles are what has to hold for a
+        // host that is simply let go.
+        drop(host);
+        weak
+    };
+
+    assert!(
+        ingress.upgrade().is_none(),
+        "the ingress outlived its host: a linked call in a component's linker \
+         still holds it"
+    );
+    Ok(())
+}
+
+/// A bound host component plugin is reached from every workload that binds it,
+/// and the ingress holds those, so the plugin's own handle on the ingress is a
+/// third way back. Neither test above loads a plugin, so only this one pins it.
+///
+/// `stop_first` decides which half is under test. `false` drops the host
+/// outright, which is what the weak handle has to survive. `true` stops it
+/// first, which is the other half of the teardown: an ingress that has stopped
+/// lets go of its routing tables, so the workloads it routed — and the plugin
+/// they bound — are released rather than held until the last handle on the
+/// ingress goes. Dropping alone cannot show that, because the detached accept
+/// loop still holds a handle on those tables.
+#[cfg(feature = "host-component-plugins")]
+async fn plugin_host_release(
+    stop_first: bool,
+) -> Result<(Weak<dyn HostHandler>, Weak<impl Sized>)> {
+    use wash_runtime::host::HostBuilder;
+    use wash_runtime::plugin::component_host::ComponentHostPlugin;
+    use wash_runtime::wit::WitInterface;
+
+    const EGRESS_PLUGIN_WASM: &[u8] = include_bytes!("wasm/http_egress_plugin.wasm");
+    const CALLER_WASM: &[u8] = include_bytes!("wasm/http_egress_plugin_caller.wasm");
+
+    let handles = {
+        let engine = Engine::builder().with_pooling_allocator(false).build()?;
+        let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+        let ingress: Arc<dyn HostHandler> = Arc::new(ingress);
+        let weak_ingress = Arc::downgrade(&ingress);
+
+        let builder = HostBuilder::new()
+            .with_engine(engine.clone())
+            .with_http_handler(Arc::clone(&ingress));
+        let native_plugins = builder.native_plugins();
+        let http_handler = builder.http_handler();
+
+        let plugin = ComponentHostPlugin::builder()
+            .id("http-egress-plugin")
+            .wasm(EGRESS_PLUGIN_WASM)
+            .engine(engine)
+            .native_plugins(native_plugins)
+            .allowed_hosts(vec!["example.com".parse()?].into())
+            .maybe_http_handler(http_handler.as_ref().map(Arc::downgrade))
+            .build()
+            .await
+            .context("the egress plugin should link cleanly")?;
+        let plugin = Arc::new(plugin);
+        let weak_plugin = Arc::downgrade(&plugin);
+
+        let host = builder.with_plugin(plugin)?.build()?;
+        let host = host.start().await.context("failed to start the host")?;
+        drop(ingress);
+
+        // Binding is what puts the plugin in the workload's component
+        // metadata, which is what closes the loop; the call itself is not
+        // needed and would reach the network.
+        host.workload_start(component_workload_request(
+            "http-egress-plugin-caller",
+            "caller",
+            CALLER_WASM,
+            LocalResources::default(),
+            vec![
+                common::http_incoming_handler_interface("caller", None),
+                WitInterface {
+                    namespace: "acme".to_string(),
+                    package: "httpegress".to_string(),
+                    interfaces: ["fetch".to_string()].into_iter().collect(),
+                    version: Some(semver::Version::parse("0.1.0")?),
+                    config: HashMap::new(),
+                    name: None,
+                },
+            ],
+        ))
+        .await
+        .context("the caller workload should bind the plugin")?;
+
+        match stop_first {
+            true => host.stop().await.context("failed to stop the host")?,
+            false => drop(host),
+        }
+        (weak_ingress, weak_plugin)
+    };
+
+    Ok(handles)
+}
+
+/// Dropped without being stopped, the host still releases its ingress: the
+/// plugin's handle on it is weak.
+#[cfg(feature = "host-component-plugins")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_dropped_host_with_a_component_plugin_releases_its_ingress() -> Result<()> {
+    let (ingress, _plugin) = plugin_host_release(false).await?;
+    assert!(
+        ingress.upgrade().is_none(),
+        "the ingress outlived its host: a bound component plugin still holds it"
+    );
+    Ok(())
+}
+
+/// Stopping the host first releases the workload graph too — the plugin the
+/// workload bound is freed, which freeing the ingress alone would not show.
+#[cfg(feature = "host-component-plugins")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_stopped_host_releases_the_workloads_it_routed() -> Result<()> {
+    let (ingress, plugin) = plugin_host_release(true).await?;
+    assert!(
+        plugin.upgrade().is_none(),
+        "a stopped host kept the plugin its workload bound, so the workload, \
+         its `InstancePre` and its compiled components are still alive too"
+    );
+    assert!(
+        ingress.upgrade().is_none(),
+        "the ingress outlived its stopped host"
+    );
+    Ok(())
+}

--- a/crates/wash-runtime/tests/integration_plugin_http_egress.rs
+++ b/crates/wash-runtime/tests/integration_plugin_http_egress.rs
@@ -134,7 +134,7 @@ async fn start_host_with_egress_plugin(
         .engine(engine)
         .native_plugins(native_plugins)
         .allowed_hosts(allowed_hosts.into())
-        .maybe_http_handler(http_handler)
+        .maybe_http_handler(http_handler.as_ref().map(Arc::downgrade))
         .build()
         .await
         .context("http-egress-plugin should link cleanly")?;

--- a/crates/wash-runtime/tests/integration_plugin_imports_native.rs
+++ b/crates/wash-runtime/tests/integration_plugin_imports_native.rs
@@ -111,7 +111,7 @@ async fn test_host_component_plugin_imports_native_secrets() -> Result<()> {
         .engine(engine)
         .native_plugins(native_plugins)
         .config(plugin_config)
-        .maybe_http_handler(http_handler)
+        .maybe_http_handler(http_handler.as_ref().map(Arc::downgrade))
         .build()
         .await
         .context("secrets-consumer-plugin should link against the native secrets plugin")?;
@@ -183,7 +183,7 @@ async fn test_missing_labeled_secret_fails_plugin_construction() -> Result<()> {
         .engine(engine)
         .native_plugins(native_plugins)
         .config(plugin_config)
-        .maybe_http_handler(http_handler)
+        .maybe_http_handler(http_handler.as_ref().map(Arc::downgrade))
         .build()
         .await;
     let Err(err) = result else {

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -384,7 +384,7 @@ impl CliCommand for DevCommand {
                     &engine,
                     oci_config.clone(),
                     &native_plugins,
-                    http_handler.clone(),
+                    http_handler.as_ref().map(Arc::downgrade),
                     None,
                 )
                 .await

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -979,7 +979,7 @@ impl CliCommand for HostCommand {
                     &engine,
                     plugin_oci_config.clone(),
                     &native_plugins,
-                    http_handler.clone(),
+                    http_handler.as_ref().map(Arc::downgrade),
                     Some(Arc::clone(&socket_policy)),
                 )
                 .await


### PR DESCRIPTION
An ingress keeps every routable workload in `workload_handles` so an inbound request can find one, and each workload reached the ingress back for its outbound HTTP, for its service registrations, etc. Held strongly in both directions so stopping a host did not free. This isn't an issue for `wash dev` or `wash host` but is an issue for host embedders.

Every handle a workload keeps for the length of its life is now `Weak`, and a strong one is taken for the length of a single call through `host::http::live_handler`, which owns the error they all report. The teardown path treats a handler that is already gone as nothing left to unbind rather than as a failure. A path that cannot proceed without one like building a store, a service re-registering its ingresses on restart, a message delivery, reports it and stops.
