### PR TITLE
fix(wash): correct --max-concurrent-starts help on parallel compilation

### DIFF
--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -389,10 +389,12 @@ pub struct HostCommand {
 
     /// How many workloads this host pulls and compiles at once.
     ///
-    /// Each start it admits ends in a single-threaded compile, so this is how
-    /// many cores a burst of starts can take from the ones serving HTTP and
-    /// NATS. Defaults to one fewer than the host can see, at most 4; lower it
-    /// on a host that must stay responsive while it starts things.
+    /// Each start it admits ends in a compile that spreads over every core the
+    /// host can see, so this is a floor on what a burst of starts takes from
+    /// the cores serving HTTP and NATS, not a ceiling. Cap the compiles
+    /// themselves with `RAYON_NUM_THREADS` or `WASMTIME_PARALLEL_COMPILATION=false`.
+    /// Defaults to one fewer than the host can see, at most 4; lower it on a
+    /// host that must stay responsive while it starts things.
     #[arg(long = "max-concurrent-starts", env = "WASH_MAX_CONCURRENT_STARTS")]
     pub max_concurrent_starts: Option<usize>,
 


### PR DESCRIPTION
Follow-up to issue #5549.

The clap help for `wash host --help` still says each admitted start "ends in a single-threaded compile". That stopped being true in #5527: parallel compilation is wasmtimes default and one compile fans out across rayons pool. The same wording already got fixed in `values.yaml` and in `default_max_concurrent_starts`, the CLI help just got missed.

So the help undersells the cost. Folks read it and size `--max-concurrent-starts` like 1 start == 1 core, when a single compile can grab every core the host can see.

The fix rewords the doc comment to match the other two spots, and points at `RAYON_NUM_THREADS` / `WASMTIME_PARALLEL_COMPILATION=false` for capping the compiles themselves. Docs only, no code paths touched.

## Reproduce

```
cargo run --bin wash -- host --help
```

before:

```
Each start it admits ends in a single-threaded compile, so this is how many
cores a burst of starts can take from the ones serving HTTP and NATS.
```

after:

```
Each start it admits ends in a compile that spreads over every core the host
can see, so this is a floor on what a burst of starts takes from the cores
serving HTTP and NATS, not a ceiling.
```
