### PR TITLE
fix(runtime-operator): make 7 host status fields optional

### DIFF
--- a/runtime-operator/api/runtime/v1alpha1/host_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/host_types.go
@@ -13,13 +13,13 @@ const (
 type HostStatus struct {
 	condition.ConditionedStatus `json:",inline"`
 
-	Version           string `json:"version"`
-	OSName            string `json:"osName"`
-	OSArch            string `json:"osArch"`
-	OSKernel          string `json:"osKernel"`
-	SystemCPUUsage    string `json:"systemCPUUsage"`
-	SystemMemoryTotal int64  `json:"systemMemoryTotal"`
-	SystemMemoryFree  int64  `json:"systemMemoryFree"`
+	Version           string `json:"version,omitempty"`
+	OSName            string `json:"osName,omitempty"`
+	OSArch            string `json:"osArch,omitempty"`
+	OSKernel          string `json:"osKernel,omitempty"`
+	SystemCPUUsage    string `json:"systemCPUUsage,omitempty"`
+	SystemMemoryTotal int64  `json:"systemMemoryTotal,omitempty"`
+	SystemMemoryFree  int64  `json:"systemMemoryFree,omitempty"`
 	ComponentCount    int    `json:"componentCount,omitempty"`
 	WorkloadCount     int    `json:"workloadCount,omitempty"`
 

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_hosts.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_hosts.yaml
@@ -135,14 +135,6 @@ spec:
                 type: string
               workloadCount:
                 type: integer
-            required:
-            - osArch
-            - osKernel
-            - osName
-            - systemCPUUsage
-            - systemMemoryFree
-            - systemMemoryTotal
-            - version
             type: object
         required:
         - hostId

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -35,7 +35,6 @@ const (
 	// the host finalizer can fan out to assigned workloads without
 	// scanning every Workload in the cluster.
 	workloadByHostIDIndex = "status.hostId"
-	statusUnknown         = "unknown"
 )
 
 // HostReconciler reconciles a Host object

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -390,26 +390,6 @@ func hostSpecChanged(existing, next *runtimev1alpha1.Host) bool {
 // that always refreshes LastSeen.
 func hostStatusPatch(status *runtimev1alpha1.HostStatus) ([]byte, error) {
 	s := map[string]any{"lastSeen": metav1.Now()}
-	if status.Version == "" {
-		s["version"] = statusUnknown
-	}
-	if status.OSName == "" {
-		s["osName"] = statusUnknown
-	}
-	if status.OSArch == "" {
-		s["osArch"] = statusUnknown
-	}
-	if status.OSKernel == "" {
-		s["osKernel"] = statusUnknown
-	}
-	if status.SystemCPUUsage == "" {
-		s["systemCPUUsage"] = "0"
-	}
-	if status.SystemMemoryTotal == 0 {
-		s["systemMemoryTotal"] = 0
-	}
-	if status.SystemMemoryFree == 0 {
-		s["systemMemoryFree"] = 0
-	}
+
 	return json.Marshal(map[string]any{"status": s})
 }

--- a/runtime-operator/internal/controller/runtime/host_controller_test.go
+++ b/runtime-operator/internal/controller/runtime/host_controller_test.go
@@ -41,10 +41,9 @@ const (
 	testHeartbeatHostID = "host-id-1"
 )
 
-// requiredHostStatusKeys are the status fields the Host CRD marks as required.
-// The heartbeat handler's status write is rejected unless every one of these
-// keys is present in the patched object.
-var requiredHostStatusKeys = []string{
+// hostStatusMeasuredKeys are the status fields reconcileReporting writes
+// from measured data. hostStatusPatch must never set them.
+var hostStatusMeasuredKeys = []string{
 	"version", "osName", "osArch", "osKernel",
 	"systemCPUUsage", "systemMemoryTotal", "systemMemoryFree",
 }
@@ -64,18 +63,17 @@ func patchStatusKeys(t *testing.T, status *runtimev1alpha1.HostStatus) map[strin
 	return p.Status
 }
 
-// TestHostStatusPatch_EmptyStatusInjectsRequiredKeys ensures that lastSeen is always
-// populated in the patch, even for an empty status. Other keys required are also tested
-// to ensure the patch is valid for the CRD.
+// TestHostStatusPatch_EmptyStatusInjectsRequiredKeys ensures an empty status
+// produces a patch with only lastSeen, no placeholder values.
 func TestHostStatusPatch_EmptyStatusInjectsRequiredKeys(t *testing.T) {
 	keys := patchStatusKeys(t, &runtimev1alpha1.HostStatus{})
 
 	if _, ok := keys["lastSeen"]; !ok {
 		t.Errorf("lastSeen must always be present in the patch")
 	}
-	for _, k := range requiredHostStatusKeys {
-		if _, ok := keys[k]; !ok {
-			t.Errorf("required key %q missing from patch for empty status", k)
+	for _, k := range hostStatusMeasuredKeys {
+		if _, ok := keys[k]; ok {
+			t.Errorf("field %q must not be set on an empty status", k)
 		}
 	}
 	// Conditions and the optional counts must never be in this patch — they are
@@ -104,7 +102,7 @@ func TestHostStatusPatch_ReportedFieldsPreserved(t *testing.T) {
 	if _, ok := keys["lastSeen"]; !ok {
 		t.Errorf("lastSeen must always be present in the patch")
 	}
-	for _, k := range requiredHostStatusKeys {
+	for _, k := range hostStatusMeasuredKeys {
 		if _, ok := keys[k]; ok {
 			t.Errorf("reported field %q must be omitted to avoid clobbering its real value", k)
 		}
@@ -170,13 +168,15 @@ func TestHostStatusPatch_SatisfiesCRDRequired(t *testing.T) {
 	}
 
 	// host.Status is empty here, exactly as it is the first time the heartbeat
-	// handler patches a host that reconcileReporting has not polled yet.
+	// handler patches a host that reconcileReporting has not polled yet. The
+	// seven measured fields are optional now, so the API server must accept
+	// this patch leaving them unset.
 	patch, err := hostStatusPatch(&host.Status)
 	if err != nil {
 		t.Fatalf("hostStatusPatch: %v", err)
 	}
 	if err := c.Status().Patch(ctx, host, client.RawPatch(types.MergePatchType, patch)); err != nil {
-		t.Fatalf("status patch rejected by API server (required-field regression?): %v", err)
+		t.Fatalf("status patch rejected by API server (optional-field regression?): %v", err)
 	}
 
 	got := &runtimev1alpha1.Host{}
@@ -186,8 +186,8 @@ func TestHostStatusPatch_SatisfiesCRDRequired(t *testing.T) {
 	if got.Status.LastSeen.IsZero() {
 		t.Errorf("expected lastSeen to be set after patch")
 	}
-	if got.Status.OSArch == "" || got.Status.Version == "" {
-		t.Errorf("expected required string fields to be defaulted, got %+v", got.Status)
+	if got.Status.OSArch != "" || got.Status.Version != "" {
+		t.Errorf("expected unmeasured fields to stay empty rather than be defaulted, got %+v", got.Status)
 	}
 
 	// A second patch after the host has reported real values must preserve them
@@ -874,8 +874,8 @@ func TestHeartbeatHandler_SkipsRedundantApply(t *testing.T) {
 }
 
 // TestHeartbeatHandler_PreservesReportedStatus is the call-site counterpart to
-// TestHostStatusPatch_ReportedFieldsPreserved: the placeholders must come from
-// the stored status, so a heartbeat leaves what reconcileReporting measured.
+// TestHostStatusPatch_ReportedFieldsPreserved: a heartbeat must leave what
+// reconcileReporting measured untouched.
 func TestHeartbeatHandler_PreservesReportedStatus(t *testing.T) {
 	c, ctx := startHostEnvtest(t)
 	ns := createTestNamespace(t, ctx, c, "host-heartbeat-status")


### PR DESCRIPTION
Earlier code force these fields (osArch, osName, osKernel, version, systemCPUUsage, systemMemoryTotal, systemMemoryFree) to be required in the CRD. Because of that, heartbeat handler had to fill fake values like "unknown" or 0 whenever cache was not updated yet, and it was overwriting real values by mistake.

Now made them optional (omitempty), so heartbeat handler only updates lastSeen and does not touch these fields anymore. Real values are only written by reconcileReporting, so no more overwrite issue.

Fixes #5504

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in:
https://github.com/wasmCloud/wasmCloud/blob/main/CONTRIBUTING.md

Please ensure all communication follows the code of conduct:
https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-->