### PR TITLE
fix(gateway): stop trusting client X-Forwarded-For for X-Real-IP

### DIFF
--- a/runtime-gateway/proxy.go
+++ b/runtime-gateway/proxy.go
@@ -79,13 +79,16 @@ func (h *HTTPGateway) Start(ctx context.Context) error {
 }
 
 func (h *HTTPGateway) rewrite(req *httputil.ProxyRequest) {
-	// X-Forwarded-For handling
-	clientIP := req.In.RemoteAddr
+	// Derive X-Real-IP from the TCP peer, not client-controlled headers.
+	if clientIP, _, err := net.SplitHostPort(req.In.RemoteAddr); err == nil {
+		req.Out.Header.Set("X-Real-IP", clientIP)
+	} else {
+		req.Out.Header.Del("X-Real-IP")
+	}
+
 	if xff := req.In.Header.Get("X-Forwarded-For"); xff != "" {
-		clientIP = xff
 		req.Out.Header.Set("X-Forwarded-For", xff)
 	}
-	req.Out.Header.Set("X-Real-IP", clientIP)
 	req.SetXForwarded()
 
 	// Preserve Connection header from the original request

--- a/runtime-gateway/proxy_test.go
+++ b/runtime-gateway/proxy_test.go
@@ -132,6 +132,44 @@ func TestStartWaitsForInFlightRequests(t *testing.T) {
 	}
 }
 
+type fakeResolver struct{ result LookupResult }
+
+func (f fakeResolver) Resolve(context.Context, *http.Request) LookupResult { return f.result }
+
+func newProxyRequest(remoteAddr string, xForwardedFor string) *httputil.ProxyRequest {
+	in := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	in.RemoteAddr = remoteAddr
+	if xForwardedFor != "" {
+		in.Header.Set("X-Forwarded-For", xForwardedFor)
+	}
+	return &httputil.ProxyRequest{In: in, Out: in.Clone(context.Background())}
+}
+
+func TestRewriteRealIPIgnoresClientSuppliedForwardedFor(t *testing.T) {
+	gw := &HTTPGateway{Resolver: fakeResolver{result: LookupResult{Hostname: "backend:8080", Scheme: "http"}}}
+
+	pr := newProxyRequest("203.0.113.7:54321", "10.0.0.1, 192.168.1.1")
+	gw.rewrite(pr)
+
+	if got, want := pr.Out.Header.Get("X-Real-IP"), "203.0.113.7"; got != want {
+		t.Errorf("X-Real-IP = %q, want the actual peer %q, not the spoofable X-Forwarded-For", got, want)
+	}
+	if got, want := pr.Out.Header.Get("X-Forwarded-For"), "10.0.0.1, 192.168.1.1, 203.0.113.7"; got != want {
+		t.Errorf("X-Forwarded-For = %q, want %q", got, want)
+	}
+}
+
+func TestRewriteRealIPHasNoPort(t *testing.T) {
+	gw := &HTTPGateway{Resolver: fakeResolver{result: LookupResult{Hostname: "backend:8080", Scheme: "http"}}}
+
+	pr := newProxyRequest("203.0.113.7:54321", "")
+	gw.rewrite(pr)
+
+	if got, want := pr.Out.Header.Get("X-Real-IP"), "203.0.113.7"; got != want {
+		t.Errorf("X-Real-IP = %q, want %q", got, want)
+	}
+}
+
 func waitForListener(t *testing.T, addr string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)


### PR DESCRIPTION
`rewrite()` sets `X-Real-IP` from the client's own `X-Forwarded-For` header. 
that's client controlled, so any request can spoof it, even though the README calls `X-Real-Ip` "the canonical IP address of the client". 
with no `X-Forwarded-For` it falls back to `req.In.RemoteAddr`, which includes the port, so it's wrong on plain requests too

repro:
```
curl -H "X-Forwarded-For: 10.0.0.1" http://gateway:8000/   # X-Real-IP: 10.0.0.1, attacker chosen
curl http://gateway:8000/                                  # X-Real-IP: 1.2.3.4:54321, port included
```

fix: derive `X-Real-IP` from the actual tcp peer via `net.SplitHostPort(req.In.RemoteAddr)`, same as stdlib's `SetXForwarded()` does for `X-Forwarded-For`. 
`X-Forwarded-For` handling itself is untouched

added tests for both cases, checked they fail on old code and pass now. 
`go build`, `go vet`, `gofmt`, `go test ./...` all clean
