### PR TITLE
fix(wash-runtime): build a store without a live HTTP handler

### DIFF
--- a/crates/wash-runtime/src/engine/ctx.rs
+++ b/crates/wash-runtime/src/engine/ctx.rs
@@ -584,16 +584,16 @@ impl CtxBuilder {
 
     /// Point this store's outgoing HTTP at `http_handler`.
     ///
-    /// Borrowed, not owned, because the store keeps only a
-    /// [`Weak`](std::sync::Weak) — see [`crate::host::http::live_handler`]. The
-    /// caller therefore has to keep the handler alive itself; taking it by
-    /// reference is what says so, rather than accepting an `Arc` whose last
-    /// strong count this call would quietly drop.
+    /// Weak, and taken weak: building a store must not depend on the host
+    /// still being there, because a store is built on paths — a message
+    /// delivery, a service restart — that have nothing to do with egress. Only
+    /// an actual outbound call needs a live handler, and the hooks report it
+    /// per call. See [`crate::host::http::live_handler`].
     pub fn with_http_handler(
         mut self,
-        http_handler: &Arc<dyn crate::host::http::HostHandler>,
+        http_handler: &std::sync::Weak<dyn crate::host::http::HostHandler>,
     ) -> Self {
-        self.http_handler = Some(Arc::downgrade(http_handler));
+        self.http_handler = Some(http_handler.clone());
         self
     }
 

--- a/crates/wash-runtime/src/engine/linked_call.rs
+++ b/crates/wash-runtime/src/engine/linked_call.rs
@@ -260,7 +260,7 @@ pub(crate) fn func_is_bridge_safe(func_ty: &ComponentFunc) -> bool {
 
 async fn build_ctx_from_template(
     template: &ComponentCtxTemplate,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    http_handler: &std::sync::Weak<dyn crate::host::http::HostHandler>,
     all_volume_mounts: &[ResolvedVolumeMount],
     store_id: &str,
     is_service: bool,
@@ -313,7 +313,7 @@ async fn build_ctx_from_template(
     }
 
     let mut ctx_builder = Ctx::builder(template.workload_id.clone(), template.component_id.clone())
-        .with_http_handler(&http_handler)
+        .with_http_handler(http_handler)
         .with_wasi_ctx(wasi_ctx_builder.build())
         .with_sockets(sockets_ctx)
         .with_allowed_hosts(template.local_resources.allowed_hosts.clone());
@@ -334,7 +334,7 @@ async fn build_ctx_from_template(
 
 pub(crate) async fn new_store_from_templates(
     engine: &wasmtime::Engine,
-    http_handler: Arc<dyn crate::host::http::HostHandler>,
+    http_handler: &std::sync::Weak<dyn crate::host::http::HostHandler>,
     active: &ComponentCtxTemplate,
     linked: &[ComponentCtxTemplate],
     linked_instances: &[(Arc<str>, InstancePre<SharedCtx>)],
@@ -347,7 +347,7 @@ pub(crate) async fn new_store_from_templates(
         .collect::<Vec<_>>();
     let active_ctx = build_ctx_from_template(
         active,
-        http_handler.clone(),
+        http_handler,
         &all_volume_mounts,
         &store_id,
         is_service,
@@ -356,14 +356,9 @@ pub(crate) async fn new_store_from_templates(
     let mut shared_ctx = SharedCtx::new(active_ctx).with_guest_memory(&active.guest_memory);
 
     for linked in linked {
-        let linked_ctx = build_ctx_from_template(
-            linked,
-            http_handler.clone(),
-            &all_volume_mounts,
-            &store_id,
-            false,
-        )
-        .await?;
+        let linked_ctx =
+            build_ctx_from_template(linked, http_handler, &all_volume_mounts, &store_id, false)
+                .await?;
         shared_ctx
             .contexts
             .insert(linked.component_id.clone(), linked_ctx);
@@ -492,7 +487,7 @@ async fn new_ephemeral_store(
 
     let store = new_store_from_templates(
         &call.engine,
-        crate::host::http::live_handler(&call.http_handler)?,
+        &call.http_handler,
         &active,
         &linked,
         &linked_instances,

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -680,7 +680,7 @@ impl ServiceStoreRecipe {
     async fn build(&self) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
         let store = new_store_from_templates(
             &self.engine,
-            crate::host::http::live_handler(&self.http_handler)?,
+            &self.http_handler,
             &self.active_template,
             &self.linked_templates,
             &self.linked_instances,
@@ -776,7 +776,11 @@ impl ResolvedWorkload {
         let Some(service) = self.service.as_ref() else {
             bail!("service unexpectedly missing during execution");
         };
-        let mut store = self.new_store_from_metadata(&service.metadata).await?;
+        let mut store = self
+            .service_store_recipe(&service.metadata)
+            .await?
+            .build()
+            .await?;
         let instance = pre.instantiate_async(&mut store).await?;
         let handle = tokio::spawn(async move {
             loop {
@@ -956,6 +960,8 @@ impl ResolvedWorkload {
         // handler), re-instantiate into the same store, rebuild the ingresses, and
         // re-register their handlers (swapping the stale senders) until the restart
         // budget is exhausted. A clean exit (every channel closed) stops it.
+        // A property of what the component exports, not of an incarnation.
+        let needs_handler = serves_http || serves_messaging;
         let handle = tokio::spawn(async move {
             let mut first = Some(ingresses);
             let mut restarts = max_restarts;
@@ -963,47 +969,55 @@ impl ResolvedWorkload {
                 let ingresses = match first.take() {
                     Some(ingresses) => ingresses,
                     None => {
-                        // The handler is held weakly, so a host that went away
-                        // while this service was faulting ends the supervisor:
-                        // there is nothing left to re-register the restarted
-                        // incarnation's ingresses with.
-                        let Some(http_handler) = http_handler.upgrade() else {
-                            error!(
-                                workload.id = %workload_id,
-                                workload.namespace = %workload_namespace,
-                                workload.name = %workload_name,
-                                "host HTTP handler is no longer available; \
-                                 not restarting this workload's service"
-                            );
-                            break;
-                        };
                         let (ingresses, http_tx, messaging_tx) =
                             build_trigger_ingresses(serves_http, serves_messaging, &service_calls);
-                        if let Some(http_tx) = http_tx
-                            && let Err(e) = http_handler
-                                .on_service_http_resolved(&workload_id, &ingress_hostnames, http_tx)
-                                .await
-                        {
-                            error!(
-                                workload.id = %workload_id,
-                                workload.namespace = %workload_namespace,
-                                workload.name = %workload_name,
-                                err = %e,
-                                "failed to re-register service HTTP handler on restart"
-                            );
-                        }
-                        if let Some(messaging_tx) = messaging_tx
-                            && let Err(e) = http_handler
-                                .on_trigger_service_messaging_resolved(&workload_id, messaging_tx)
-                                .await
-                        {
-                            error!(
-                                workload.id = %workload_id,
-                                workload.namespace = %workload_namespace,
-                                workload.name = %workload_name,
-                                err = %e,
-                                "failed to re-register trigger service messaging handler on restart"
-                            );
+                        // A service with ingresses cannot come back without a
+                        // handler to re-register them with. One the host merely
+                        // dispatches to has none, and restarts either way.
+                        if needs_handler {
+                            let Some(http_handler) = http_handler.upgrade() else {
+                                error!(
+                                    workload.id = %workload_id,
+                                    workload.namespace = %workload_namespace,
+                                    workload.name = %workload_name,
+                                    "host HTTP handler is no longer available; \
+                                     not restarting this workload's service"
+                                );
+                                break;
+                            };
+                            if let Some(http_tx) = http_tx
+                                && let Err(e) = http_handler
+                                    .on_service_http_resolved(
+                                        &workload_id,
+                                        &ingress_hostnames,
+                                        http_tx,
+                                    )
+                                    .await
+                            {
+                                error!(
+                                    workload.id = %workload_id,
+                                    workload.namespace = %workload_namespace,
+                                    workload.name = %workload_name,
+                                    err = %e,
+                                    "failed to re-register service HTTP handler on restart"
+                                );
+                            }
+                            if let Some(messaging_tx) = messaging_tx
+                                && let Err(e) = http_handler
+                                    .on_trigger_service_messaging_resolved(
+                                        &workload_id,
+                                        messaging_tx,
+                                    )
+                                    .await
+                            {
+                                error!(
+                                    workload.id = %workload_id,
+                                    workload.namespace = %workload_namespace,
+                                    workload.name = %workload_name,
+                                    err = %e,
+                                    "failed to re-register trigger service messaging handler on restart"
+                                );
+                            }
                         }
                         ingresses
                     }
@@ -1593,11 +1607,19 @@ impl ResolvedWorkload {
     /// trigger-service instance instead of instantiating a component per
     /// message.
     ///
-    /// Held weakly, so this fails once the host that owns the handler is gone
-    /// — which is the answer every caller wants: there is nothing left to
-    /// register with, deliver to, or send an outbound request through.
+    /// Held weakly, so this fails once the host that owns the handler is gone.
+    /// For a caller that would rather skip than fail, see
+    /// [`Self::try_http_handler`].
     pub fn http_handler(&self) -> anyhow::Result<Arc<dyn crate::host::http::HostHandler>> {
-        crate::host::http::live_handler(&self.http_handler)
+        self.try_http_handler()
+            .ok_or_else(|| anyhow::anyhow!("host HTTP handler is no longer available"))
+    }
+
+    /// [`Self::http_handler`] for a path that has something else to do when the
+    /// host is gone — a message still deliverable to a component of its own,
+    /// say. No error is built for an answer the caller only branches on.
+    pub fn try_http_handler(&self) -> Option<Arc<dyn crate::host::http::HostHandler>> {
+        self.http_handler.upgrade()
     }
 
     /// Gets the name of the workload
@@ -1670,7 +1692,7 @@ impl ResolvedWorkload {
         };
         let store = new_store_from_templates(
             &engine,
-            self.http_handler()?,
+            &self.http_handler,
             &active_template,
             &linked_templates,
             &linked_instances,
@@ -1902,20 +1924,6 @@ impl ResolvedWorkload {
             Some(pool) => pool.policy(),
             None => InstancePolicy::Ephemeral,
         }
-    }
-
-    /// Creates a new wasmtime Store for multiple components from the given workload metadata.
-    ///
-    /// The recipe carries the metering stamp a service's store needs — it
-    /// serves every ingress the workload has, concurrently, for the life of the
-    /// workload, so no call on it can attribute a delta to itself and
-    /// `guest.execution.total` is all there is. See
-    /// [`crate::engine::abandon::GuestExecution`].
-    async fn new_store_from_metadata(
-        &self,
-        metadata: &WorkloadMetadata,
-    ) -> anyhow::Result<wasmtime::Store<SharedCtx>> {
-        self.service_store_recipe(metadata).await?.build().await
     }
 
     /// The identity a service's store runs under.
@@ -2964,7 +2972,7 @@ impl UnresolvedWorkload {
         mut self,
         plugins: Option<&HashMap<&'static str, Arc<dyn HostPlugin + 'static>>>,
         plugin_bindings: &crate::plugin::PluginBindings,
-        http_handler: Arc<dyn crate::host::http::HostHandler>,
+        http_handler: &Arc<dyn crate::host::http::HostHandler>,
         meters: &crate::observability::Meters,
     ) -> anyhow::Result<ResolvedWorkload> {
         // Bind to plugins
@@ -3000,7 +3008,7 @@ impl UnresolvedWorkload {
             service_calls: Arc::default(),
             released: Arc::default(),
             host_interfaces: self.host_interfaces,
-            http_handler: Arc::downgrade(&http_handler),
+            http_handler: Arc::downgrade(http_handler),
             invocation: meters.invocation.clone(),
             #[cfg(feature = "wasi-tls")]
             tls_provider: self.tls_provider,
@@ -4193,12 +4201,15 @@ mod tests {
 
         let plugin = Arc::new(RollbackPlugin::new(None));
         let workload = marker_workload(vec![importer]);
+        // Bound, not a temporary: the resolved workload keeps only a `Weak`.
+        let http_handler: Arc<dyn crate::host::http::HostHandler> =
+            Arc::new(crate::host::http::NullServer::default());
 
         workload
             .resolve(
                 Some(&plugin.registered()),
                 &crate::plugin::PluginBindings::new(),
-                Arc::new(crate::host::http::NullServer::default()),
+                &http_handler,
                 &crate::observability::Meters::new(crate::observability::MeterKind::Off),
             )
             .await

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -1345,6 +1345,50 @@ impl<T: Router> Ingress<T, DefaultOutgoingHandler> {
 }
 
 impl<T: Router, O: OutgoingHandler> Ingress<T, O> {
+    /// Empty the routing tables once this ingress has drained, so a host that
+    /// is stopped but still held lets go of the workloads it routed. Detached
+    /// because a drain outlasts this call, bounded by
+    /// [`crate::timeouts::ingress_drain`] because it may never finish, and
+    /// holding the tables rather than the ingress so it pins neither.
+    fn release_when_drained(&self) {
+        let connections = self.connections.clone();
+        let workload_handles = Arc::clone(&self.workload_handles);
+        let service_handlers = Arc::clone(&self.service_handlers);
+        let messaging_handlers = Arc::clone(&self.messaging_handlers);
+        let addr = self.addr;
+        tokio::spawn(async move {
+            let budget = crate::timeouts::ingress_drain();
+            if tokio::time::timeout(budget, connections.drained())
+                .await
+                .is_err()
+            {
+                warn!(
+                    addr = ?addr,
+                    budget_secs = budget.as_secs(),
+                    "ingress still had connections at the end of its drain; \
+                     releasing its routes anyway"
+                );
+            }
+            workload_handles.write().await.clear();
+            service_handlers.write().await.clear();
+            messaging_handlers.write().await.clear();
+        });
+    }
+
+    /// How many workloads this ingress can currently route an inbound message
+    /// or request to. Zero once [`HostHandler::stop`] has drained, and what an
+    /// embedder without a probe listener can report about routing state.
+    ///
+    /// All three tables, because a workload reaches routing by more than one
+    /// door: a service-only workload registers through
+    /// [`HostHandler::on_service_http_resolved`] and never appears among the
+    /// component handles.
+    pub async fn routed_workloads(&self) -> usize {
+        self.workload_handles.read().await.len()
+            + self.service_handlers.read().await.len()
+            + self.messaging_handlers.read().await.len()
+    }
+
     /// Returns the actual bound address (useful when binding to port 0).
     pub fn addr(&self) -> SocketAddr {
         self.addr
@@ -1435,21 +1479,30 @@ impl<T: Router, O: OutgoingHandler> HostHandler for Ingress<T, O> {
         Ok(())
     }
 
+    /// Ends the accept loop, and lets go of the routing tables once the drain
+    /// it starts has finished — not before, because connections already
+    /// established are served from their own handles on those tables, and
+    /// emptying them here would 404 every request still arriving over one.
     async fn stop(&self) -> anyhow::Result<()> {
         info!(addr = ?self.addr, "HTTP server stopping");
-        let mut shutdown_guard = self.shutdown_tx.write().await;
-        if let Some(tx) = shutdown_guard.take() {
-            let _ = tx.send(()).await;
+        // Scoped, so the release below is arranged without this guard held
+        // across the locks it takes.
+        let was_accepting = {
+            let mut shutdown_guard = self.shutdown_tx.write().await;
+            match shutdown_guard.take() {
+                Some(tx) => {
+                    let _ = tx.send(()).await;
+                    true
+                }
+                None => false,
+            }
+        };
+        // An ingress that never started has no drain to wait on, and waiting
+        // would be forever: nothing will mark an accept loop stopped that never
+        // ran.
+        if was_accepting {
+            self.release_when_drained();
         }
-        // Let go of what the routing tables hold. A stopped ingress serves
-        // nothing, so keeping them would pin every routed workload's
-        // `InstancePre` — its compiled components, and the engine behind them —
-        // for as long as anything still holds the ingress itself. A workload
-        // stopped after this finds nothing to unbind, which is the right
-        // answer.
-        self.workload_handles.write().await.clear();
-        self.service_handlers.write().await.clear();
-        self.messaging_handlers.write().await.clear();
         Ok(())
     }
 
@@ -1792,6 +1845,20 @@ impl ConnectionLimit {
         // `Err` is the sender dropped, which cannot happen through a `&self`
         // holding it — and would mean the same thing if it could.
         let _ = stopped.wait_for(|stopped| *stopped).await;
+    }
+
+    /// Resolves once the accept loop has stopped *and* every connection it
+    /// accepted has finished — the end of a drain, not the start of one.
+    ///
+    /// [`Self::stopped`] is weaker: connections are served by tasks outliving
+    /// the loop, each holding the permit [`Self::take`] gave it, so holding
+    /// every permit at once is what says none of them is still serving.
+    pub async fn drained(&self) {
+        self.stopped().await;
+        let all = u32::try_from(self.max).unwrap_or(u32::MAX);
+        // `Err` is a closed semaphore, which this never closes; either way
+        // there is nothing left to wait for.
+        let _ = self.permits.acquire_many(all).await;
     }
 
     /// Take a slot for an accepted connection, or `None` at the ceiling.

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -311,6 +311,13 @@ pub struct Host {
     /// owns. Monotonic for the life of the host, so a reservation identifies one
     /// occupant of a workload id and never a later one.
     reservations: std::sync::atomic::AtomicU64,
+    /// Set by [`Self::stop`], and read by [`Self::workload_reserve`] under the
+    /// `workloads` write lock that both take — so a start either reserves
+    /// before the stop or is refused by it, never lands between the two. A
+    /// stopped host is on its way out: its ingress has stopped accepting and
+    /// its plugins are stopping, so a workload started onto one would be
+    /// unroutable and, once the ingress drain ends, silently unregistered.
+    stopped: std::sync::atomic::AtomicBool,
     /// Plugins in a map from their ID to the plugin itself
     plugins: HashMap<&'static str, Arc<dyn HostPlugin>>,
     /// What the operator declared about each plugin's bindings — the host layer
@@ -575,6 +582,14 @@ impl Host {
     /// # Returns
     /// Ok if the shutdown process completes (even with plugin errors).
     pub async fn stop(self: Arc<Self>) -> anyhow::Result<()> {
+        // Before anything else stops, and under the lock `workload_reserve`
+        // takes, so no start can be admitted from here on.
+        {
+            let _workloads = self.workloads.write().await;
+            self.stopped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+
         self.http_handler
             .stop()
             .await
@@ -811,7 +826,7 @@ impl Host {
             .resolve(
                 Some(&self.plugins),
                 &self.plugin_bindings,
-                self.http_handler.clone(),
+                &self.http_handler,
                 &self.meters,
             )
             .await?;
@@ -1093,6 +1108,11 @@ impl WorkloadReservation for Host {
         // start claimed.
         let reservation = self.reserve();
         let mut workloads = self.workloads.write().await;
+        if self.stopped.load(std::sync::atomic::Ordering::SeqCst) {
+            let message = format!("Host [{}] is stopped and accepts no new workloads", self.id);
+            tracing::warn!(workload_id, reason = message, "refused to start workload");
+            return Err(message);
+        }
         if workloads.contains_key(workload_id) {
             let message = format!(
                 "Workload ID [{workload_id}] already exists (the exising workload must be stopped to reuse the ID)"
@@ -1590,6 +1610,7 @@ impl HostBuilder {
             engine,
             workloads: Arc::default(),
             reservations: std::sync::atomic::AtomicU64::default(),
+            stopped: std::sync::atomic::AtomicBool::new(false),
             plugins: self.plugins,
             plugin_bindings: Arc::new(self.plugin_bindings),
             id: self.id,
@@ -2198,6 +2219,39 @@ mod tests {
         assert!(
             host.workloads.read().await.is_empty(),
             "stopping should drop the id"
+        );
+    }
+
+    /// A stopped host takes no new workloads. Its ingress has stopped
+    /// accepting and its plugins are stopping, so one started onto it would be
+    /// unroutable — and would be unregistered without a word when the ingress
+    /// finishes draining.
+    #[tokio::test]
+    async fn test_a_stopped_host_refuses_to_start_a_workload() {
+        let host = Arc::new(host_with(Arc::new(BindRecordingPlugin::default())));
+        Arc::clone(&host)
+            .stop()
+            .await
+            .expect("stopping the host should succeed");
+
+        let refused = host
+            .workload_start(marker_request("after-stop"))
+            .await
+            .expect("a refusal is a response, not a transport failure");
+        assert_eq!(
+            refused.workload_status.workload_state,
+            WorkloadState::Error,
+            "a stopped host must refuse a start, got {:?}",
+            refused.workload_status
+        );
+        assert!(
+            refused.workload_status.message.contains("stopped"),
+            "the refusal must say why, got {:?}",
+            refused.workload_status.message
+        );
+        assert!(
+            !host.workloads.read().await.contains_key("after-stop"),
+            "a refused start must leave no reservation behind"
         );
     }
 

--- a/crates/wash-runtime/src/plugin/component_host/mod.rs
+++ b/crates/wash-runtime/src/plugin/component_host/mod.rs
@@ -1792,7 +1792,7 @@ async fn run_supervisor(
             &state.native_plugins,
             &allowed_hosts,
             &allowed_ip_name_lookups,
-            http_handler.clone(),
+            http_handler.as_ref(),
             &network,
             &direct_binds,
             &socket_policy,
@@ -1967,7 +1967,7 @@ fn build_plugin_store(
     native_plugins: &HashMap<&'static str, Arc<dyn HostPlugin>>,
     allowed_hosts: &Arc<[crate::host::allowed_hosts::AllowedHost]>,
     allowed_ip_name_lookups: &Arc<[crate::host::allowed_ip_name::AllowedIpName]>,
-    http_handler: Option<std::sync::Weak<dyn crate::host::http::HostHandler>>,
+    http_handler: Option<&std::sync::Weak<dyn crate::host::http::HostHandler>>,
     network: &crate::host::ports::NetworkHandle,
     direct_binds: &Arc<[crate::sockets::policy::DirectBind]>,
     socket_policy: &Arc<crate::sockets::policy::SocketPolicy>,
@@ -2012,10 +2012,8 @@ fn build_plugin_store(
         )
         .with_sockets(sockets_ctx)
         .with_allowed_hosts(Arc::clone(allowed_hosts));
-    // A store built after the host went away gets no handler, which its egress
-    // already reports; there is nothing left to send through.
-    if let Some(http_handler) = http_handler.as_ref().and_then(std::sync::Weak::upgrade) {
-        ctx_builder = ctx_builder.with_http_handler(&http_handler);
+    if let Some(http_handler) = http_handler {
+        ctx_builder = ctx_builder.with_http_handler(http_handler);
     }
     let ctx = ctx_builder.build();
     // The registry marks this as the plugin (real) side of the resource bridge

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/in_memory.rs
@@ -678,33 +678,38 @@ impl HostPlugin for InMemoryMessaging {
 
                         debug!(subject = %msg.subject, reply_to = %msg.reply_to.as_deref().unwrap_or("<none>"), "Processing message");
 
-                        // The workload holds the handler weakly, so losing it
-                        // means the host this drains into is gone: nothing
-                        // queued now or later can be served, so the task ends
-                        // rather than the drain pass. This message is already
-                        // popped, so a requester waiting on it is failed here
-                        // for the same reason the shed path below does it.
-                        let http_handler = match workload.http_handler() {
-                            Ok(handler) => handler,
-                            Err(e) => {
-                                warn!(error = %e, "ending in-memory receive loop");
-                                if sole_subscriber
-                                    && let (Some(reply_to), Some(pending)) =
-                                        (&msg.reply_to, &pending_requests)
-                                    && let Some(sender) = pending.write().await.remove(reply_to)
-                                {
-                                    let _ = sender.send(Err(super::shed_error()));
-                                }
-                                break 'task;
+                        // Only the trigger-service branch below needs the
+                        // handler; a per-message component is delivered to
+                        // without it. So a gone handler skips that branch
+                        // rather than ending the drain — unless nothing else
+                        // can serve the message either, in which case the task
+                        // ends rather than waking per message forever. A
+                        // requester waiting on this one is failed on the way
+                        // out, as the shed path below does.
+                        let http_handler = workload.try_http_handler();
+                        if http_handler.is_none() && pre.is_none() {
+                            warn!(
+                                component_id = %component_id,
+                                "host is gone and this component has no per-message \
+                                 instance; ending the in-memory receive loop"
+                            );
+                            if sole_subscriber
+                                && let (Some(reply_to), Some(pending)) =
+                                    (&msg.reply_to, &pending_requests)
+                                && let Some(sender) = pending.write().await.remove(reply_to)
+                            {
+                                let _ = sender.send(Err(super::shed_error()));
                             }
-                        };
+                            break 'task;
+                        }
 
                         // If this workload runs a long-lived trigger service for
                         // messaging, deliver to it (preserving its in-memory
                         // state) rather than instantiating a component per message.
-                        if http_handler
-                            .has_trigger_service_messaging(workload.id())
-                            .await
+                        if let Some(http_handler) = &http_handler
+                            && http_handler
+                                .has_trigger_service_messaging(workload.id())
+                                .await
                         {
                             let broker = crate::host::trigger_service::BrokerMessage {
                                 subject: msg.subject.clone(),

--- a/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_messaging/nats.rs
@@ -607,23 +607,36 @@ impl HostPlugin for NatsMessaging {
                         let reply_to = msg.reply.as_ref().map(|r| r.to_string());
                         let body: Vec<u8> = msg.payload.into();
 
-                        // The workload holds the handler weakly, so losing it
-                        // means the host this subscriber delivers into is gone
-                        // and no later message can be served either.
-                        let http_handler = match workload.http_handler() {
-                            Ok(handler) => handler,
-                            Err(e) => {
-                                warn!(parent: &span, error = %e, "stopping NATS subscriber loop");
-                                break;
-                            }
-                        };
+                        // Only the trigger-service branch below needs the
+                        // handler; a per-message component is delivered to
+                        // without it. A gone handler therefore skips that
+                        // branch rather than ending the loop — the message is
+                        // already consumed, and tearing the subscriptions down
+                        // here would drop it with nothing able to redeliver.
+                        let http_handler = workload.try_http_handler();
+
+                        // Unless nothing else can serve it either. A workload
+                        // whose handler is its trigger service has no
+                        // per-message instance to fall back to, so going on
+                        // would win this component's share of a queue group
+                        // forever and drop every message in it.
+                        if http_handler.is_none() && pre.is_none() {
+                            warn!(
+                                parent: &span,
+                                component_id = %component_id,
+                                "host is gone and this component has no per-message \
+                                 instance; ending the NATS subscriber loop"
+                            );
+                            break;
+                        }
 
                         // If this workload runs a long-lived trigger service for
                         // messaging, deliver to it (preserving its in-memory
                         // state) rather than instantiating a component per message.
-                        if http_handler
-                            .has_trigger_service_messaging(workload.id())
-                            .await
+                        if let Some(http_handler) = &http_handler
+                            && http_handler
+                                .has_trigger_service_messaging(workload.id())
+                                .await
                         {
                             let broker = crate::host::trigger_service::BrokerMessage {
                                 subject: subject.clone(),

--- a/crates/wash-runtime/src/timeouts.rs
+++ b/crates/wash-runtime/src/timeouts.rs
@@ -85,6 +85,15 @@ declare_timeouts! {
     http_response = ("WASH_HTTP_RESPONSE_TIMEOUT_SECS", 600);
     /// Max wall-clock for a trigger service to acknowledge a delivered message.
     messaging_deliver = ("WASH_MESSAGING_DELIVER_TIMEOUT_SECS", 600);
+    /// How long a stopped ingress waits for its connections to finish before
+    /// letting go of the workloads it routed anyway.
+    ///
+    /// A bound rather than a wait, because a connection need never close: h2
+    /// keep-alive pings hold an idle one open indefinitely, and a stream has no
+    /// deadline of its own. Past this the routes serve nobody worth keeping
+    /// them for, and holding them pins every routed workload's `InstancePre`,
+    /// its components and the engine behind them for the life of the process.
+    ingress_drain = ("WASH_INGRESS_DRAIN_TIMEOUT_SECS", 60);
     /// How long an abandoned call may keep running before its store acts on the
     /// abandonment (see [`crate::engine::abandon`]). This is what makes
     /// abandonment safe to signal on every disconnect: a healthy guest finishes

--- a/crates/wash-runtime/tests/integration_ingress_release.rs
+++ b/crates/wash-runtime/tests/integration_ingress_release.rs
@@ -1,19 +1,11 @@
-//! A host that is stopped and dropped releases its ingress.
+//! An ingress holds every routable workload, and everything reachable from a
+//! workload can reach the ingress back. Held strongly both ways, nothing frees
+//! either — so each way back is weak, and each gets a test here, because no one
+//! of them reaches the others: a workload's own handle and its stores' egress
+//! hooks, an ephemeral linked call, and a bound host component plugin.
 //!
-//! The ingress keeps every routable workload in its handle map so an inbound
-//! request can find one, and everything reachable from a workload can reach the
-//! ingress back. Held strongly, those make a loop nothing can break: stopping
-//! the host would free neither, and the ingress would go on holding each
-//! workload's `InstancePre`, its compiled components and the engine behind them
-//! for the life of the process.
-//!
-//! There are three ways back, and each test here pins one that the others do
-//! not reach: a workload's own handle and its stores' egress hooks, an
-//! ephemeral linked call (which lives in a linker closure, hence in the
-//! caller's `InstancePre`), and a bound host component plugin.
-//!
-//! Its own binary, so the assertions are about these hosts and not about
-//! whatever another test in the same process left running.
+//! The rest cover teardown: a stop must serve its drain out, and must let go of
+//! what it routed once that drain ends.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Weak};
@@ -32,32 +24,37 @@ const HTTP_HANDLER_P3_WASM: &[u8] = include_bytes!("wasm/http_handler_p3.wasm");
 const EPHEMERAL_CALLER_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_caller_p3.wasm");
 const EPHEMERAL_CALLEE_P3_WASM: &[u8] = include_bytes!("wasm/ephemeral_callee_p3.wasm");
 
-/// Build an ingress and a host around it, handing back the address, the started
-/// host, and a `Weak` on the ingress. The only strong handle left is the host's
-/// own, so what the `Weak` measures afterwards is the host's reachability.
-async fn host_with_weak_ingress() -> Result<(std::net::SocketAddr, Arc<Host>, Weak<dyn HostHandler>)>
-{
+/// Build an ingress and a started host around it.
+///
+/// `DevRouter`, so a plain GET reaches the workload without these tests also
+/// having to arrange hostname routing.
+async fn host_with_ingress() -> Result<(std::net::SocketAddr, Arc<Host>, Arc<Ingress<DevRouter>>)> {
     let engine = Engine::builder()
         .with_pooling_allocator(false)
         .build()
         .context("failed to build the engine")?;
-    // `DevRouter`, so a plain GET reaches the workload without these tests also
-    // having to arrange hostname routing.
-    let ingress = Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?)
-        .await
-        .context("failed to bind an ingress")?;
+    let ingress = Arc::new(
+        Ingress::new(DevRouter::default(), "127.0.0.1:0".parse()?)
+            .await
+            .context("failed to bind an ingress")?,
+    );
     let addr = ingress.addr();
-    let ingress: Arc<dyn HostHandler> = Arc::new(ingress);
-    let weak = Arc::downgrade(&ingress);
-
     let host = Host::builder()
         .with_engine(engine)
-        .with_http_handler(Arc::clone(&ingress))
+        .with_http_handler(Arc::clone(&ingress) as Arc<dyn HostHandler>)
         .build()
         .context("failed to build the host")?;
     let host = host.start().await.context("failed to start the host")?;
-    drop(ingress);
+    Ok((addr, host, ingress))
+}
 
+/// [`host_with_ingress`], with the ingress handed back only weakly and no
+/// strong one left but the host's — so what the `Weak` measures afterwards is
+/// the host's own reachability.
+async fn host_with_weak_ingress() -> Result<(std::net::SocketAddr, Arc<Host>, Weak<dyn HostHandler>)>
+{
+    let (addr, host, ingress) = host_with_ingress().await?;
+    let weak = Arc::downgrade(&(ingress as Arc<dyn HostHandler>));
     Ok((addr, host, weak))
 }
 
@@ -82,7 +79,7 @@ async fn serve_one(addr: &std::net::SocketAddr) -> Result<()> {
 /// back-reference strands, and it is the case an embedder building hosts
 /// repeatedly hits.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_stopped_host_releases_its_ingress() -> Result<()> {
+async fn a_dropped_host_releases_its_ingress() -> Result<()> {
     let ingress = {
         let (addr, host, weak) = host_with_weak_ingress().await?;
 
@@ -104,9 +101,8 @@ async fn a_stopped_host_releases_its_ingress() -> Result<()> {
         // builds the store whose egress hooks are the second way back.
         serve_one(&addr).await?;
 
-        // Dropped, not stopped: `stop` clears the routing tables, which would
-        // break the loop by itself. The weak handles are what has to hold for a
-        // host that is simply let go.
+        // Dropped rather than stopped: letting a host go without stopping it
+        // is the case a strong back-reference strands.
         drop(host);
         weak
     };
@@ -168,9 +164,8 @@ async fn a_workload_with_an_ephemeral_linked_call_releases_its_ingress() -> Resu
         // Drives the linked call, so the ephemeral path has actually run.
         serve_one(&addr).await?;
 
-        // Dropped, not stopped: `stop` clears the routing tables, which would
-        // break the loop by itself. The weak handles are what has to hold for a
-        // host that is simply let go.
+        // Dropped rather than stopped: letting a host go without stopping it
+        // is the case a strong back-reference strands.
         drop(host);
         weak
     };
@@ -186,14 +181,6 @@ async fn a_workload_with_an_ephemeral_linked_call_releases_its_ingress() -> Resu
 /// A bound host component plugin is reached from every workload that binds it,
 /// and the ingress holds those, so the plugin's own handle on the ingress is a
 /// third way back. Neither test above loads a plugin, so only this one pins it.
-///
-/// `stop_first` decides which half is under test. `false` drops the host
-/// outright, which is what the weak handle has to survive. `true` stops it
-/// first, which is the other half of the teardown: an ingress that has stopped
-/// lets go of its routing tables, so the workloads it routed — and the plugin
-/// they bound — are released rather than held until the last handle on the
-/// ingress goes. Dropping alone cannot show that, because the detached accept
-/// loop still holds a handle on those tables.
 #[cfg(feature = "host-component-plugins")]
 async fn plugin_host_release(
     stop_first: bool,
@@ -228,8 +215,8 @@ async fn plugin_host_release(
             .await
             .context("the egress plugin should link cleanly")?;
         let plugin = Arc::new(plugin);
-        let weak_plugin = Arc::downgrade(&plugin);
 
+        let weak_plugin = Arc::downgrade(&plugin);
         let host = builder.with_plugin(plugin)?.build()?;
         let host = host.start().await.context("failed to start the host")?;
         drop(ingress);
@@ -257,10 +244,13 @@ async fn plugin_host_release(
         .await
         .context("the caller workload should bind the plugin")?;
 
-        match stop_first {
-            true => host.stop().await.context("failed to stop the host")?,
-            false => drop(host),
+        if stop_first {
+            Arc::clone(&host)
+                .stop()
+                .await
+                .context("failed to stop the host")?;
         }
+        drop(host);
         (weak_ingress, weak_plugin)
     };
 
@@ -280,20 +270,129 @@ async fn a_dropped_host_with_a_component_plugin_releases_its_ingress() -> Result
     Ok(())
 }
 
-/// Stopping the host first releases the workload graph too — the plugin the
-/// workload bound is freed, which freeing the ingress alone would not show.
+/// Stopping before dropping must release just as thoroughly, and this measures
+/// the workload graph rather than the table that held it: the plugin is
+/// reachable only through the workload that bound it, so a live plugin means a
+/// live `InstancePre` and the components it compiled.
 #[cfg(feature = "host-component-plugins")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_stopped_host_releases_the_workloads_it_routed() -> Result<()> {
+async fn a_stopped_then_dropped_host_releases_the_plugin_its_workload_bound() -> Result<()> {
     let (ingress, plugin) = plugin_host_release(true).await?;
     assert!(
         plugin.upgrade().is_none(),
-        "a stopped host kept the plugin its workload bound, so the workload, \
-         its `InstancePre` and its compiled components are still alive too"
+        "the host component plugin outlived its host, so the workload that \
+         bound it and everything that workload compiled are still alive too"
     );
+    assert!(ingress.upgrade().is_none(), "the ingress outlived its host");
+    Ok(())
+}
+
+/// The far end of the drain: once it finishes, a host that is stopped but still
+/// held lets go of the workloads it routed. Asserted while the host and its
+/// ingress are both deliberately still alive — freeing them would prove nothing
+/// about what they held.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_drained_host_releases_the_workloads_it_routed() -> Result<()> {
+    let (addr, host, ingress) = host_with_ingress().await?;
+
+    host.workload_start(component_workload_request(
+        "http-handler-p3.wasm",
+        "ingress-drained",
+        HTTP_HANDLER_P3_WASM,
+        LocalResources {
+            memory_limit_mb: 128,
+            cpu_limit: 1,
+            ..Default::default()
+        },
+        http_only_host_interfaces("ingress-drained"),
+    ))
+    .await
+    .context("failed to start the workload")?;
+    serve_one(&addr).await?;
+    assert_eq!(
+        ingress.routed_workloads().await,
+        1,
+        "the workload must be routable before the drain"
+    );
+
+    Arc::clone(&host)
+        .stop()
+        .await
+        .context("failed to stop the host")?;
+
+    // The release is detached, because a drain outlasts the call that starts
+    // it; `reqwest` holds its pooled connection until the client is dropped.
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        while ingress.routed_workloads().await != 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .context("the routing tables were still populated long after the drain")?;
+
+    // The host and its ingress are both still bound here, so what the wait
+    // above measured was release and not teardown.
+    Ok(())
+}
+
+/// Stopping a host ends its accept loop but must not withdraw the routes under
+/// connections it already has: a client holding a keep-alive connection goes on
+/// sending, and answering those 404 hands an upstream proxy a response to
+/// forward rather than a reason to try another replica. That drain window is
+/// what clearing the routing tables in `stop()` closed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_stopped_host_still_serves_an_established_connection() -> Result<()> {
+    let (addr, host, ingress) = host_with_ingress().await?;
+
+    host.workload_start(component_workload_request(
+        "http-handler-p3.wasm",
+        "ingress-drain",
+        HTTP_HANDLER_P3_WASM,
+        LocalResources {
+            memory_limit_mb: 128,
+            cpu_limit: 1,
+            ..Default::default()
+        },
+        http_only_host_interfaces("ingress-drain"),
+    ))
+    .await
+    .context("failed to start the workload")?;
+
+    // One client, reused, so the second request rides the connection the first
+    // opened rather than dialing a listener that has stopped accepting.
+    let client = reqwest::Client::builder()
+        .pool_idle_timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let first = client.get(format!("http://{addr}/")).send().await?;
     assert!(
-        ingress.upgrade().is_none(),
-        "the ingress outlived its stopped host"
+        first.status().is_success(),
+        "the workload must serve before the drain"
+    );
+    first.bytes().await?;
+
+    Arc::clone(&host)
+        .stop()
+        .await
+        .context("failed to stop the host")?;
+    // Separates the two ways the request below can fail: a withdrawn route, or
+    // a connection the client did not reuse.
+    assert_eq!(
+        ingress.routed_workloads().await,
+        1,
+        "stop must leave the route in place for the drain"
+    );
+
+    let during_drain = client
+        .get(format!("http://{addr}/"))
+        .send()
+        .await
+        .context("a request on an established connection must still be answered")?;
+    assert!(
+        during_drain.status().is_success(),
+        "a draining host withdrew the route under an established connection and \
+         answered {} — an upstream proxy forwards that to the client rather than \
+         retrying another replica",
+        during_drain.status()
     );
     Ok(())
 }


### PR DESCRIPTION
Follow-ups to #5548. This removes the requirement we had where building a store required upgrading the host's HTTP handler.

A handler is an egress dependency. It has nothing to do with the paths that build stores.

`new_store`, `ServiceStoreRecipe::build` and `new_ephemeral_store` all took a strong handle with `?`, so once the host was gone a workload that never makes an outbound request could not run at all.

The weak handle is now threaded through `new_store_from_templates` and `build_ctx_from_template` to the builder, and the store's own egress hooks stay the only place that needs the host alive.

`Ingress::stop` no longer clears the routing tables. `Host::stop` calls it first, and connections already established are served by tasks holding their own handles on those tables.  Emptying them mid-drain turned every request on an open keep-alive connection into a 404 or 503, which anupstream proxy forwards to the client rather than retrying elsewhere. Now the release happens once the drain finishes.
