### PR TITLE
fix(wash-runtime): stop the host when a command task panics

### DIFF
--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -263,13 +263,15 @@ impl ClusterHostBuilder {
     }
 }
 
-/// Why the command loop stopped turning. Both run the same shutdown; they
+/// Why the command loop stopped turning. All run the same shutdown; they
 /// differ only in what the host reports afterwards.
 enum Ended {
     /// The cleanup future was awaited.
     Requested,
     /// The HTTP ingress' accept loop returned.
     IngressStopped,
+    /// A command task panicked or was cancelled.
+    CommandPanicked(tokio::task::JoinError),
 }
 
 pub struct ClusterHost {
@@ -403,9 +405,13 @@ impl ClusterHost {
                         // exists" for the life of the host. Taking the host
                         // down is what a panic here did before commands ran as
                         // their own tasks, and a restart is what clears it.
+                        //
+                        // Fatal by way of the shutdown below: skipping
+                        // `host.stop()` would leave the ingress accepting and
+                        // the plugins bound on a host that is already finished.
                         Some(finished) = commands.join_next() => {
                             if let Err(e) = finished {
-                                return Err(anyhow!("command task failed: {e}"));
+                                break Ended::CommandPanicked(e);
                             }
                         }
                         // OCI cache cleanup
@@ -568,6 +574,10 @@ impl ClusterHost {
                             "HTTP ingress stopped accepting connections; \
                              the host can no longer serve traffic"
                         ))
+                    }
+                    Ended::CommandPanicked(e) => {
+                        stopped?;
+                        Err(anyhow!("command task failed: {e}"))
                     }
                 }
             }


### PR DESCRIPTION
## Problem

A panicked command task returns straight out of the `ClusterHost` command loop:

```rust
Some(finished) = commands.join_next() => {
    if let Err(e) = finished {
        return Err(anyhow!("command task failed: {e}"));
    }
}
```

The loop's other two exits `break`, and everything that actually takes the host down sits after the loop. The `return` skips cleanup.

`host.stop()` is what calls `http_handler.stop()`, so on this path the accept loop is never stopped. The host keeps its HTTP listener open, holds every workload it was given, and goes on answering its control plane, with no plugin unbound and no reserved id released. The exit is also invisible to whoever embeds the host.

## Fix

`Ended` gains a `CommandPanicked(JoinError)` variant, and the branch breaks with it instead of returning. The panic stays fatal, a command may have died holding a workload id it claimed and never committed or released, and only a restart clears that.